### PR TITLE
use RuntimeException

### DIFF
--- a/Transformer/ModelToElasticaAutoTransformer.php
+++ b/Transformer/ModelToElasticaAutoTransformer.php
@@ -5,6 +5,7 @@ namespace FOQ\ElasticaBundle\Transformer;
 use Elastica_Document;
 use Traversable;
 use ArrayAccess;
+use RuntimeException;
 
 /**
  * Maps Elastica documents with Doctrine objects


### PR DESCRIPTION
I added "use RuntimeException;" because script cannot found it before.
