### PR TITLE
Switched to use a query parameter in the ORM implementation

### DIFF
--- a/Doctrine/ORM/ElasticaToModelTransformer.php
+++ b/Doctrine/ORM/ElasticaToModelTransformer.php
@@ -31,7 +31,9 @@ class ElasticaToModelTransformer extends AbstractElasticaToModelTransformer
         $qb = $this->objectManager
             ->getRepository($class)
             ->createQueryBuilder('o');
-        $qb->where($qb->expr()->in('o.'.$identifierField, $identifierValues));
+        /* @var $qb \Doctrine\ORM\QueryBuilder */
+        $qb->where($qb->expr()->in('o.'.$identifierField, ':values'))
+            ->setParameter('values', $identifierValues, 'array');
 
         return $qb->getQuery()->setHydrationMode($hydrationMode)->execute();
     }

--- a/Doctrine/ORM/Provider.php
+++ b/Doctrine/ORM/Provider.php
@@ -9,10 +9,6 @@ class Provider extends AbstractProvider
     /**
      * Counts the objects of a query builder
      *
-     * OMG this implementation is radical. Yes. There seems to be
-     * no easy way to do that with Doctrine ORM 2.0.
-     * Please tell me if you have a better idea.
-     *
      * @param queryBuilder
      * @return int
      **/


### PR DESCRIPTION
The ORM version has been bumped to use 2.1 in Symfony2 because 2.0.x does not support fully Common 3.0.x so it is now possible to write the query in a clean way using an array parameter (which is a 2.1 feature)
