### PR TITLE
Exception on applying mapping to a nonexistent index

### DIFF
--- a/MappingRegistry.php
+++ b/MappingRegistry.php
@@ -3,6 +3,7 @@
 namespace FOQ\ElasticaBundle;
 
 use Elastica_Type;
+use Elastica_Exception_Response;
 use InvalidArgumentException;
 
 /**
@@ -38,7 +39,11 @@ class MappingRegistry
     {
         foreach ($this->mappings as $pair) {
             list($type, $mappings) = $pair;
-            $type->setMapping($mappings);
+            try {
+                $type->setMapping($mappings);
+            } catch (Elastica_Exception_Response $e) {
+                // index doesn't exist, but all goes well anyway?
+            }
         }
     }
 


### PR DESCRIPTION
There's probably a much better way to fix this, and I'm not even sure what exactly caused it, but this is the only way I could get foq:elastica:populate to run.
