### PR TITLE
Added term_vector configuration node

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -202,6 +202,7 @@ class Configuration
                     ->scalarNode('store')->end()
                     ->scalarNode('index')->end()
                     ->scalarNode('analyzer')->end()
+                    ->scalarNode('term_vector')->end()
                 ->end()
             ->end()
         ;


### PR DESCRIPTION
Allows setting the `term_vector` to allow the usage of the [fast highlighter](http://www.elasticsearch.org/guide/reference/api/search/highlighting.html)
