### PR TITLE
Adding manager that returns Doctrine style repositories

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -138,6 +138,7 @@ class Configuration
                         ->children()
                             ->scalarNode('driver')->end()
                             ->scalarNode('model')->end()
+                            ->scalarNode('repository')->end()
                             ->scalarNode('identifier')->defaultValue('id')->end()
                             ->arrayNode('provider')
                                 ->children()

--- a/DependencyInjection/FOQElasticaExtension.php
+++ b/DependencyInjection/FOQElasticaExtension.php
@@ -305,6 +305,15 @@ class FOQElasticaExtension extends Extension
         $finderDef->replaceArgument(1, new Reference($elasticaToModelId));
         $container->setDefinition($finderId, $finderDef);
 
+        $managerDef = $container->getDefinition('foq_elastica.manager');
+        $arguments = array( $typeConfig['model'], new Reference($finderId));
+        if (isset($typeConfig['repository'])) {
+            $arguments[] = $typeConfig['repository'];
+        }
+
+        $managerDef->addMethodCall('addEntity', $arguments);
+        $container->setDefinition('foq_elastica.manager', $managerDef);
+
         return $finderId;
     }
 

--- a/Manager.php
+++ b/Manager.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace FOQ\ElasticaBundle;
+
+use RuntimeException;
+
+/**
+ * @author Richard Miller <info@limethinking.co.uk>
+ *
+ * Allows retrieval of basic or custom repository for mapped Doctrine
+ * entities/documents.
+ */
+class Manager
+{
+    protected $entities;
+    protected $repositories;
+
+    public function addEntity($entityName, $finder, $repositoryName = null)
+    {
+        $this->entities[$entityName]= array();
+        $this->entities[$entityName]['finder'] = $finder;
+        $this->entities[$entityName]['repositoryName'] = $repositoryName;
+    }
+
+    /**
+     * Return repository for entity
+     *
+     * Returns custom repository if one specified otherwise
+     * returns a basic respository.
+     */
+    public function getRepository($entityName)
+    {
+        if (isset($this->repositories[$entityName])) {
+            return $this->repositories[$entityName];
+        }
+
+        if (!isset($this->entities[$entityName])) {
+            throw new RuntimeException(sprintf('No search finder configured for %s', $entityName));
+        }
+
+        if (isset($this->entities[$entityName]['repositoryName'])) {
+
+            $repositoryName = $this->entities[$entityName]['repositoryName'];
+            if (!class_exists($repositoryName)) {
+                throw new RuntimeException(sprintf('%s repository for %s does not exist', $repositoryName, $entityName));
+            }
+            $repository = new $repositoryName($this->entities[$entityName]['finder']);
+            $this->repositories[$entityName] = $repository;
+            return $repository;
+        }
+
+        $repository = new Repository($this->entities[$entityName]['finder']);
+        $this->repositories[$entityName] = $repository;
+        return $repository;
+    }
+
+}

--- a/Repository.php
+++ b/Repository.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace FOQ\ElasticaBundle;
+
+/**
+ * @author Richard Miller <info@limethinking.co.uk>
+ *
+ * Basic respoitory to be extended to hold custom queries to be run
+ * in the finder.
+ */
+class Repository
+{
+    protected $finder;
+
+    public function __construct($finder)
+    {
+        $this->finder = $finder;
+    }
+
+
+    public function find($query)
+    {
+        return $this->finder->find($query);
+    }
+
+    public function findPaginated($query)
+    {
+        return $this->finder->findPaginated($query);
+    }
+
+}

--- a/Resources/config/config.xml
+++ b/Resources/config/config.xml
@@ -10,6 +10,7 @@
         <parameter key="foq_elastica.type.class">Elastica_Type</parameter>
         <parameter key="foq_elastica.logger.class">FOQ\ElasticaBundle\Logger\ElasticaLogger</parameter>
         <parameter key="foq_elastica.data_collector.class">FOQ\ElasticaBundle\DataCollector\ElasticaDataCollector</parameter>
+        <parameter key="foq_elastica.manager.class">FOQ\ElasticaBundle\Manager</parameter>
     </parameters>
 
 
@@ -61,6 +62,8 @@
         <service id="foq_elastica.model_to_elastica_transformer.prototype.auto" class="FOQ\ElasticaBundle\Transformer\ModelToElasticaAutoTransformer" public="false" abstract="true">
             <argument /> <!-- options -->
         </service>
+
+        <service id="foq_elastica.manager" class="%foq_elastica.manager.class%" />
 
     </services>
 

--- a/Tests/ManagerTest.php
+++ b/Tests/ManagerTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace FOQ\ElasticaBundle\Tests;
+
+use FOQ\ElasticaBundle\Manager;
+
+class CustomRepository{}
+
+/**
+ * @author Richard Miller <info@limethinking.co.uk>
+ */
+class ManagerTest extends \PHPUnit_Framework_TestCase
+{
+
+    public function testThatGetRepositoryReturnsDefaultRepository()
+    {
+        $finderMock = $this->getMockBuilder('FOQ\ElasticaBundle\Finder\TransformedFinder')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $entityName = 'Test Entity';
+
+        $manager = new Manager($finderMock);
+        $manager->addEntity($entityName, $finderMock);
+        $repository = $manager->getRepository($entityName);
+        $this->assertInstanceOf('FOQ\ElasticaBundle\Repository', $repository);
+    }
+
+    public function testThatGetRepositoryReturnsCustomRepository()
+    {
+        $finderMock = $this->getMockBuilder('FOQ\ElasticaBundle\Finder\TransformedFinder')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $entityName = 'Test Entity';
+
+        $manager = new Manager($finderMock);
+        $manager->addEntity($entityName, $finderMock, 'FOQ\ElasticaBundle\Tests\CustomRepository');
+        $repository = $manager->getRepository($entityName);
+        $this->assertInstanceOf('FOQ\ElasticaBundle\Tests\CustomRepository', $repository);
+    }
+
+    /**
+     * @expectedException RuntimeException
+     */
+    public function testThatGetRepositoryThrowsExceptionIfEntityNotConfigured()
+    {
+        $finderMock = $this->getMockBuilder('FOQ\ElasticaBundle\Finder\TransformedFinder')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $entityName = 'Test Entity';
+
+        $manager = new Manager($finderMock);
+        $manager->addEntity($entityName, $finderMock);
+        $manager->getRepository('Missing Entity');
+    }
+
+    /**
+     * @expectedException RuntimeException
+     */
+    public function testThatGetRepositoryThrowsExceptionIfCustomRepositoryNotFound()
+    {
+        $finderMock = $this->getMockBuilder('FOQ\ElasticaBundle\Finder\TransformedFinder')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $entityName = 'Test Entity';
+
+        $manager = new Manager($finderMock);
+        $manager->addEntity($entityName, $finderMock, 'FOQ\ElasticaBundle\Tests\MissingRepository');
+        $manager->getRepository('Missing Entity');
+    }
+}

--- a/Tests/RepositoryTest.php
+++ b/Tests/RepositoryTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace FOQ\ElasticaBundle\Tests;
+
+use FOQ\ElasticaBundle\Repository;
+
+/**
+ * @author Richard Miller <info@limethinking.co.uk>
+ */
+class RepositoryTest extends \PHPUnit_Framework_TestCase
+{
+
+    public function testThatFindCallsFindOnFinder()
+    {
+        $testQuery = 'Test Query';
+
+        $finderMock = $this->getMockBuilder('FOQ\ElasticaBundle\Finder\TransformedFinder')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $finderMock->expects($this->once())
+            ->method('find')
+            ->with($this->equalTo($testQuery));
+
+        $repository = new Repository($finderMock);
+        $repository->find($testQuery);
+    }
+
+    public function testThatFindPaginatedCallsFindPaginatedOnFinder()
+    {
+        $testQuery = 'Test Query';
+
+        $finderMock = $this->getMockBuilder('FOQ\ElasticaBundle\Finder\TransformedFinder')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $finderMock->expects($this->once())
+            ->method('findPaginated')
+            ->with($this->equalTo($testQuery));
+
+        $repository = new Repository($finderMock);
+        $repository->findPaginated($testQuery);
+    }
+
+}


### PR DESCRIPTION
Added a manager class that returns Doctrine style repositories so that you can just inject the `foq_elastica.manager` service and then ask it for the repository for an entity rather than injecting a finder service for each entity type.

Main use is to allow encapsulating custom queries to avoid keeping them in controller and to allow easy reuse. E.g. :

```
<?php

namespace ExampleBundle\SearchRepository;

use FOQ\ElasticaBundle\Repository;

class ExampleRepository extends Repository
{

    public function findByNameOrUrl($searchTerm)
    {
        $boolQuery = new \Elastica_Query_Bool();
        $nameQuery = new \Elastica_Query_Text();
        $nameQuery->setFieldQuery('name', $searchTerm);
        $urlQuery = new \Elastica_Query_Text();
        $urlQuery->setFieldQuery('url', $searchTerm);
        $boolQuery->addShould($nameQuery);
        $boolQuery->addShould($urlQuery);

        return $this->find($boolQuery);
    }

}
```

```
$repository = $this->get('foq_elastica.manager')->getRespository('ExampleBundle\Entity\ExampleEntity');
$results = $repository->findByNameOrUrl($searchTerm);
```

Fully qualified entity/document name needs to be specified as doesn't yet support Doctrine style `Bundle:EntityName` syntax.
