### PR TITLE
Method name changed

### DIFF
--- a/Doctrine/AbstractProvider.php
+++ b/Doctrine/AbstractProvider.php
@@ -70,7 +70,7 @@ abstract class AbstractProvider implements ProviderInterface
             $this->objectPersister->insertMany($objects);
 
             if ($this->options['clear_object_manager']) {
-                $this->registry->getManagerForClass($this->objectClass)->clear();
+                $this->registry->getEntityManagerForClass($this->objectClass)->clear();
             }
 
             $stepNbObjects = count($objects);

--- a/Doctrine/MongoDB/ElasticaToModelTransformer.php
+++ b/Doctrine/MongoDB/ElasticaToModelTransformer.php
@@ -24,7 +24,7 @@ class ElasticaToModelTransformer extends AbstractElasticaToModelTransformer
     protected function findByIdentifiers($class, $identifierField, array $identifierValues, $hydrate)
     {
         return $this->registry
-            ->getManagerForClass($class)
+            ->getEntityManagerForClass($class)
             ->createQueryBuilder($class)
             ->field($identifierField)->in($identifierValues)
             ->hydrate($hydrate)

--- a/Doctrine/MongoDB/Provider.php
+++ b/Doctrine/MongoDB/Provider.php
@@ -38,7 +38,7 @@ class Provider extends AbstractProvider
     protected function createQueryBuilder()
     {
         return $this->registry
-            ->getManagerForClass($this->objectClass)
+            ->getEntityManagerForClass($this->objectClass)
             ->getRepository($this->objectClass)
             ->{$this->options['query_builder_method']}();
     }

--- a/Doctrine/ORM/ElasticaToModelTransformer.php
+++ b/Doctrine/ORM/ElasticaToModelTransformer.php
@@ -29,7 +29,7 @@ class ElasticaToModelTransformer extends AbstractElasticaToModelTransformer
         }
         $hydrationMode = $hydrate ? Query::HYDRATE_OBJECT : Query::HYDRATE_ARRAY;
         $qb = $this->registry
-            ->getManagerForClass($class)
+            ->getEntityManagerForClass($class)
             ->getRepository($class)
             ->createQueryBuilder('o');
         /* @var $qb \Doctrine\ORM\QueryBuilder */

--- a/Doctrine/ORM/Provider.php
+++ b/Doctrine/ORM/Provider.php
@@ -45,7 +45,7 @@ class Provider extends AbstractProvider
     protected function createQueryBuilder()
     {
         return $this->registry
-            ->getManagerForClass($this->objectClass)
+            ->getEntityManagerForClass($this->objectClass)
             ->getRepository($this->objectClass)
             ->{$this->options['query_builder_method']}('a');
     }


### PR DESCRIPTION
`php app/console foq:elastica:populate`

PHP Fatal error:  Call to undefined method Symfony\Bundle\DoctrineBundle\Registry::getManagerForClass() in vendor/bundles/FOQ/ElasticaBundle/Doctrine/AbstractProvider.php on line 73
