### PR TITLE
Add suggested Doctrine and Propel deps for test suite coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ php:
 
 before_script:
   - wget -nc http://getcomposer.org/composer.phar
-  - php composer.phar install
+  - php composer.phar install --install-suggests
 
 script: phpunit
 

--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,11 @@
         "symfony/console": "2.1.*",
         "ruflin/elastica": ">=0.19.0"
     },
+    "suggest": {
+        "doctrine/orm": "2.2.*",
+        "doctrine/mongodb-odm": "dev-master",
+        "propel/propel1": "1.6.*"
+    },
     "autoload": {
         "psr-0": { "FOQ\\ElasticaBundle": "" }
     },


### PR DESCRIPTION
MongoDB ODM and Propel don't have real versions here, and `2.2.*` seemed the best thing to use for Doctrine ORM.
