### PR TITLE
Throw RuntimeException when all Elastica objects cannot be found via Doctrine

### DIFF
--- a/Doctrine/AbstractElasticaToModelTransformer.php
+++ b/Doctrine/AbstractElasticaToModelTransformer.php
@@ -5,7 +5,6 @@ namespace FOQ\ElasticaBundle\Doctrine;
 use FOQ\ElasticaBundle\HybridResult;
 use FOQ\ElasticaBundle\Transformer\ElasticaToModelTransformerInterface;
 use Elastica_Document;
-use RuntimeException;
 
 /**
  * Maps Elastica documents with Doctrine objects
@@ -74,6 +73,9 @@ abstract class AbstractElasticaToModelTransformer implements ElasticaToModelTran
         }, $elasticaObjects);
 
         $objects = $this->findByIdentifiers($this->objectClass, $this->options['identifier'], $ids, $this->options['hydrate']);
+        if (count($objects) < count($elasticaObjects)) {
+            throw new \RuntimeException('Cannot find corresponding Doctrine objects for all Elastica results.');
+        };
 
         $identifierGetter = 'get'.ucfirst($this->options['identifier']);
 
@@ -90,9 +92,6 @@ abstract class AbstractElasticaToModelTransformer implements ElasticaToModelTran
     public function hybridTransform(array $elasticaObjects)
     {
         $objects = $this->transform($elasticaObjects);
-        if (count($objects) < count($elasticaObjects)) {
-            throw new RuntimeException('Cannot transform all Elastica results into objects.');
-        };
 
         $result = array();
         for ($i = 0; $i < count($elasticaObjects); $i++) {


### PR DESCRIPTION
Throw a more meaningful error when the number of items retrieved by Doctrine is less than the number of items from ElasticSearch.
