### PR TITLE
Made persister services public to use them

### DIFF
--- a/Resources/config/config.xml
+++ b/Resources/config/config.xml
@@ -45,7 +45,7 @@
             <argument /> <!-- index configs -->
         </service>
 
-        <service id="foq_elastica.object_persister.prototype" class="FOQ\ElasticaBundle\Persister\ObjectPersister" public="false" abstract="true">
+        <service id="foq_elastica.object_persister.prototype" class="FOQ\ElasticaBundle\Persister\ObjectPersister" abstract="true">
             <argument /> <!-- type -->
             <argument /> <!-- model to elastica transformer -->
             <argument /> <!-- model -->


### PR DESCRIPTION
Heya,

`foq_elastica.object_persister.*.*` services are not public by default. So you can't use persister services except by injecting them at container build time. That means no way to use them in a controller for instance.

These services are useful for listeners. In Doctrine, listeners are services so it's ok, but with Propel, you don't have listeners as services. What I do is to set the `objectPersister` instance on my model object, and then hooks can use it.

For example, here is a `processForm()` method with an `Event` class (to deal with events in a calendar I mean):

``` php
<?php

public function processForm(Event $event)
{
    // ...
    $event->setObjectPersister($this->get('foq_elastica.object_persister.website.event'));

    if ($form->isValid()) {
        $event->save();
        // ...
    }
}
```

And then:

``` php
<?php

/**
 * This class is part of the Model layer, it's not an Event class for lifecycle stuffs.
 * It contains an id, a name, dates, a description, etc.
 */
class Event extends BaseEvent
{
   /** 
     * @var \FOQ\ElasticaBundle\Persister\ObjectPersisterInterface
     */
    protected $objectPersister;

    /** 
     * @param ObjectPersisterInterface $objectPersister
     */
    public function setObjectPersister(ObjectPersisterInterface $objectPersister)
    {   
        $this->objectPersister = $objectPersister;
    }   

    public function postSave(\PropelPDO $con = null)
    {   
        if (null !== $this->objectPersister) {
            $this->objectPersister->insertOne($this);
        }   
    }   

    public function postUpdate(\PropelPDO $con = null)
    {   
        if (null !== $this->objectPersister) {
            $this->objectPersister->replaceOne($this);
        }   
    }   

    public function postDelete(\PropelPDO $con = null)
    {   
        if (null !== $this->objectPersister) {
            $this->objectPersister->deleteById($this->getId());
        }   
    }   
}
```

Everything is explicit, testable, ... So far so good :)

This Pull Request just makes persisters services accessible everywhere.
