### PR TITLE
[Propel] Added new method to return a query to use in findByIdentifiers().

### DIFF
--- a/Propel/ElasticaToModelTransformer.php
+++ b/Propel/ElasticaToModelTransformer.php
@@ -114,17 +114,31 @@ class ElasticaToModelTransformer implements ElasticaToModelTransformerInterface
             return array();
         }
 
-        $queryClass   = $class.'Query';
-        $filterMethod = 'filterBy'.$this->camelize($identifierField);
-        $query = $queryClass::create()
-            ->$filterMethod($identifierValues)
-            ;
+        $query = $this->createQuery($class, $identifierField, $identifierValues);
 
         if (!$hydrate) {
             return $query->toArray();
         }
 
         return $query->find();
+    }
+
+    /**
+     * Create a query to use in the findByIdentifiers() method.
+     *
+     * @param string $class the model class
+     * @param string $identifierField like 'id'
+     * @param array $identifierValues ids values
+     * @return \ModelCriteria
+     */
+    protected function createQuery($class, $identifierField, array $identifierValues)
+    {
+        $queryClass   = $class.'Query';
+        $filterMethod = 'filterBy'.$this->camelize($identifierField);
+
+        return $queryClass::create()
+            ->$filterMethod($identifierValues)
+            ;
     }
 
     /**


### PR DESCRIPTION
It's easy to create its own ElasticaToModelTransformer class by extending the existing one.
The main use case is to tweak the query to retrieve your model objects (to add join by default in order to reduce the number of queries for instance). So, most of the time you will override the `findByIdentifiers()` method, which seems fine but it's not!

The main issue is that you will have to copy/paste this method to override it because it contains more logic than a simple query. The aim of this PR is to add a new protected method to the default implementation (`createQuery()`) designed to be overrided.

``` php
<?php

namespace My\Bundle\Elastica;

use FOQ\ElasticaBundle\Propel\ElasticaToModelTransformer;
use My\Bundle\Model\PostQuery;

class ElasticaToPostTransformer extends ElasticaToModelTransformer
{
    public function __construct()
    {   
        parent::__construct('My\Bundle\Model\Post', array('identifier' => 'id', 'hydrate' => true));
    }   

    /** 
     * {@inheritdoc}
     */
    protected function createQuery($class, $identifierField, array $identifierValues)
    {   
        return PostQuery::create()
            ->joinWithTags()
            ->filterById($identifierValues)
            ;   
    }   
}
```

As you can see, it's much better.

By the way, is there a reason to have `$class`, and `$identifierField` as arguments of the `findByIdentifiers()` method? I mean, these parameters are attributes, so we could avoid to pass them as arguments.
