### PR TITLE
Changed ObjectPersiter::transformToElasticaDocument from protected to public to allow usage as a converter service

### DIFF
--- a/Persister/ObjectPersister.php
+++ b/Persister/ObjectPersister.php
@@ -100,7 +100,7 @@ class ObjectPersister implements ObjectPersisterInterface
      * @param object $object
      * @return Elastica_Document the elastica document
      */
-    protected function transformToElasticaDocument($object)
+    public function transformToElasticaDocument($object)
     {
         return $this->transformer->transform($object, $this->fields);
     }


### PR DESCRIPTION
The goal of this commit is to allow to pass the object persister service and use it to convert known object types to indexable arrays.

The method having no side effects and this service being the only way (that I know of) to access fields mapping of another type, I see no harm in putting it public.
