### PR TITLE
Use PropertyPath in ModelToElasticaTransformer

### DIFF
--- a/Transformer/ModelToElasticaAutoTransformer.php
+++ b/Transformer/ModelToElasticaAutoTransformer.php
@@ -7,6 +7,8 @@ use Traversable;
 use ArrayAccess;
 use RuntimeException;
 
+use Symfony\Component\Form\Util\PropertyPath;
+
 /**
  * Maps Elastica documents with Doctrine objects
  * This mapper assumes an exact match between
@@ -44,14 +46,14 @@ class ModelToElasticaAutoTransformer implements ModelToElasticaTransformerInterf
     {
         $array = array();
         foreach ($fields as $key) {
-            $getter = 'get'.ucfirst($key);
-            if (!is_callable(array($object, $getter))) {
-                throw new RuntimeException(sprintf('The method %s::%s is not callable', get_class($object), $getter));
-            }
-            $array[$key] = $this->normalizeValue($object->$getter());
+            $propertyPath = new PropertyPath($key);
+            $value = $propertyPath->getValue($object);
+
+            $array[$key] = $this->normalizeValue($value);
         }
-        $identifierGetter = 'get'.ucfirst($this->options['identifier']);
-        $identifier = $object->$identifierGetter();
+
+        $propertyPath = new PropertyPath($this->options['identifier']);
+        $identifier = $propertyPath->getValue($object);
 
         return new Elastica_Document($identifier, $array);
     }


### PR DESCRIPTION
A cleaner way to access object properties. Moreover, we can now use the "parent.child" notation in the objects mappings.
