### PR TITLE
Fixed missing argument concerning the foq:elastica:populate command

### DIFF
--- a/Command/PopulateCommand.php
+++ b/Command/PopulateCommand.php
@@ -76,7 +76,7 @@ class PopulateCommand extends ContainerAwareCommand
             $indexes = array_keys($this->indexManager->getAllIndexes());
 
             foreach ($indexes as $index) {
-                $this->populateIndex($output, $index);
+                $this->populateIndex($output, $index, $reset);
             }
         }
     }


### PR DESCRIPTION
Good afternoon,
Today I had a problem when launching the `foq:elastica:populate` command with no arguments.
I suppose it's coming from the changes you made yesterday on the command, so here is the fix :)
