### PR TITLE
Moved `identifier` to `persistence` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,8 +208,7 @@ You can change this value in the provider configuration.
                         persistence:
                             driver: orm
                             model: Application\UserBundle\Entity\User
-                            provider:
-                                identifier: id
+                            identifier: id
 
 #### Manual provider
 


### PR DESCRIPTION
`identifier` config var is child of `persistence` root, and not `provider`
