### PR TITLE
Fix resultSet size when using a Repository for master

### DIFF
--- a/Repository.php
+++ b/Repository.php
@@ -20,9 +20,9 @@ class Repository
     }
 
 
-    public function find($query)
+    public function find($query, $limit=null)
     {
-        return $this->finder->find($query);
+        return $this->finder->find($query, $limit);
     }
 
     public function findPaginated($query)


### PR DESCRIPTION
When using a Repository, the $limit parameter was lost along the way.
This is why the limit was always set to 10 in that case.
