### PR TITLE
Fixed SearchCommand's index option

### DIFF
--- a/Command/SearchCommand.php
+++ b/Command/SearchCommand.php
@@ -25,7 +25,7 @@ class SearchCommand extends ContainerAwareCommand
             ->setName('foq:elastica:search')
             ->addArgument('type', InputArgument::REQUIRED, 'The type to search in')
             ->addArgument('query', InputArgument::REQUIRED, 'The text to search')
-            ->addOption('index', null, InputOption::VALUE_NONE, 'The index to search in')
+            ->addOption('index', null, InputOption::VALUE_REQUIRED, 'The index to search in')
             ->addOption('limit', null, InputOption::VALUE_REQUIRED, 'The maximum number of documents to return', 20)
             ->addOption('show-field', null, InputOption::VALUE_REQUIRED, 'Field to show, null uses the first field')
             ->addOption('show-source', null, InputOption::VALUE_NONE, 'Show the documents sources')


### PR DESCRIPTION
The --index option on foq:elastica:search was not configured to accept a parameter, resulting in any attempt to use it to request index '1'.

This PR fixes that.

nb: the search command doesn't work _without_ the --index option either, pending the landing of #148
