### PR TITLE
Added support for index-time document boosting

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -214,6 +214,7 @@ class Configuration
                 ->end()
                 ->append($this->getMappingsNode())
                 ->append($this->getSourceNode())
+                ->append($this->getBoostNode())
             ->end()
         ;
 
@@ -290,6 +291,24 @@ class Configuration
                     ->useAttributeAsKey('name')
                     ->prototype('scalar')->end()
                 ->end()
+            ->end()
+        ;
+
+        return $node;
+    }
+
+    /**
+     * Returns the array node used for "_boost".
+     */
+    protected function getBoostNode()
+    {
+        $builder = new TreeBuilder();
+        $node = $builder->root('_boost');
+
+        $node
+            ->children()
+                ->scalarNode('name')->end()
+                ->scalarNode('null_value')->end()
             ->end()
         ;
 

--- a/DependencyInjection/FOQElasticaExtension.php
+++ b/DependencyInjection/FOQElasticaExtension.php
@@ -170,6 +170,9 @@ class FOQElasticaExtension extends Extension
             if (isset($type['_source'])) {
                 $this->indexConfigs[$indexName]['config']['mappings'][$name]['_source'] = $type['_source'];
             }
+            if (isset($type['_boost'])) {
+                $this->indexConfigs[$indexName]['config']['mappings'][$name]['_boost'] = $type['_boost'];
+            }
             if (isset($type['mappings'])) {
                 $this->indexConfigs[$indexName]['config']['mappings'][$name]['properties'] = $type['mappings'];
                 $typeName = sprintf('%s/%s', $indexName, $name);


### PR DESCRIPTION
In the course of my integration of FOQElasticaBundle, I've often come across the need to boost my documents by a field (using http://www.elasticsearch.org/guide/reference/mapping/boost-field.html).

Originally I simply updated the index mapping after each reset, but this became a maintenance nightmare, so I wanted to provide direct support to the bundle, modeled after #85
