### PR TITLE
fix search command when no index option is passed

### DIFF
--- a/Command/SearchCommand.php
+++ b/Command/SearchCommand.php
@@ -40,7 +40,8 @@ class SearchCommand extends ContainerAwareCommand
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $index = $this->getContainer()->get('foq_elastica.index_manager')->getIndex($input->getOption('index'));
+        $indexName = $input->getOption('index');
+        $index = $this->getContainer()->get('foq_elastica.index_manager')->getIndex($indexName ? $indexName : null);
         $type  = $index->getType($input->getArgument('type'));
         $query = Elastica_Query::create($input->getArgument('query'));
         $query->setLimit($input->getOption('limit'));

--- a/IndexManager.php
+++ b/IndexManager.php
@@ -13,10 +13,10 @@ class IndexManager
      * @param array  $indexesByName
      * @param string $defaultIndexName
      */
-    public function __construct(array $indexesByName, $defaultIndexName)
+    public function __construct(array $indexesByName, $defaultIndex)
     {
         $this->indexesByName = $indexesByName;
-        $this->defaultIndexName = $defaultIndexName;
+        $this->defaultIndexName = $defaultIndex->getName();
     }
 
     /**


### PR DESCRIPTION
when searching from command line and providing no index, FOQElasticaBundle throws an exception (The index "" does not exist - () at /project/vendor/exercise/elastica-bundle/FOQ/ElasticaBundle/IndexManager.php:46). 

First, if no --index option is given, $input->getOption('index') returns false, while IndexManager's getIndex only uses the defaultIndexName if the index name is null. 

Second, the dependency passed to IndexManager's constructor as the second argument is the default index, not its name.
