### PR TITLE
Updated README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ Declare that you want a Doctrine/Propel finder in your configuration:
 
 You can now use the `foq_elastica.finder.website.user` service:
 
-    /** var FOQ\ElasticaBundle\Finder\MappedFinder */
+    /** var FOQ\ElasticaBundle\Finder\TransformedFinder */
     $finder = $container->get('foq_elastica.finder.website.user');
 
     /** var array of Acme\UserBundle\Entity\User */


### PR DESCRIPTION
Class name on docblock was a little misleading. I can't seem to find a MappedFinder class. get_class on the code sample returns TransformedFinder.
