### PR TITLE
Updated the DoctrineMongoDBBundle service IDs

### DIFF
--- a/Resources/config/mongodb.xml
+++ b/Resources/config/mongodb.xml
@@ -10,7 +10,7 @@
             <argument /> <!-- object persister -->
             <argument /> <!-- model -->
             <argument type="collection" /> <!-- options -->
-            <argument type="service" id="doctrine.odm.mongodb" />
+            <argument type="service" id="doctrine_mongodb" />
         </service>
 
         <service id="foq_elastica.listener.prototype.mongodb" class="FOQ\ElasticaBundle\Doctrine\MongoDB\Listener" public="false" abstract="true">
@@ -21,13 +21,13 @@
         </service>
 
         <service id="foq_elastica.elastica_to_model_transformer.prototype.mongodb" class="FOQ\ElasticaBundle\Doctrine\MongoDB\ElasticaToModelTransformer" public="false">
-            <argument type="service" id="doctrine.odm.mongodb" />
+            <argument type="service" id="doctrine_mongodb" />
             <argument /> <!-- model -->
             <argument type="collection" /> <!-- options -->
         </service>
 
         <service id="foq_elastica.manager.mongodb" class="FOQ\ElasticaBundle\Doctrine\RepositoryManager">
-            <argument type="service" id="doctrine.odm.mongodb"/>
+            <argument type="service" id="doctrine_mongodb"/>
             <argument type="service" id="annotation_reader"/>
         </service>
 

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     },
     "suggest": {
         "doctrine/orm": "2.2.*",
-        "doctrine/mongodb-odm": "dev-master",
+        "doctrine/mongodb-odm": ">=3.0.0-beta2,<3.1-dev",
         "propel/propel1": "1.6.*"
     },
     "autoload": {


### PR DESCRIPTION
The service IDs for the DoctrineMongoDBBundle have changed for version 2.1.  This is an update to reflect that change.

https://github.com/doctrine/DoctrineMongoDBBundle/pull/134

Closes issue #154
