### PR TITLE
Fixing identifier field not being set in TransformerCollection

### DIFF
--- a/Doctrine/AbstractElasticaToModelTransformer.php
+++ b/Doctrine/AbstractElasticaToModelTransformer.php
@@ -111,6 +111,14 @@ abstract class AbstractElasticaToModelTransformer implements ElasticaToModelTran
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function getIdentifierField()
+    {
+        return $this->options['identifier'];
+    }
+
+    /**
      * Fetches objects by theses identifier values
      *
      * @param array $identifierValues ids values

--- a/Propel/ElasticaToModelTransformer.php
+++ b/Propel/ElasticaToModelTransformer.php
@@ -100,6 +100,14 @@ class ElasticaToModelTransformer implements ElasticaToModelTransformerInterface
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function getIdentifierField()
+    {
+        return $this->options['identifier'];
+    }
+
+    /**
      * Fetch objects for theses identifier values
      *
      * @param string $class the model class

--- a/Resources/config/config.xml
+++ b/Resources/config/config.xml
@@ -64,7 +64,6 @@
 
         <service id="foq_elastica.elastica_to_model_transformer.collection.prototype" class="%foq_elastica.elastica_to_model_transformer.collection.class%" public="true" abstract="true">
             <argument type="collection" /> <!-- transformers -->
-            <argument type="collection" /> <!-- options -->
         </service>
 
     </services>

--- a/Tests/Transformer/ElasticaToModelTransformerCollectionTest.php
+++ b/Tests/Transformer/ElasticaToModelTransformerCollectionTest.php
@@ -19,10 +19,18 @@ class ElasticaToModelTransformerCollectionTest extends \PHPUnit_Framework_TestCa
             ->method('getObjectClass')
             ->will($this->returnValue('FOQ\ElasticaBundle\Tests\Transformer\POPO'));
 
+        $transformer1->expects($this->any())
+            ->method('getIdentifierField')
+            ->will($this->returnValue('id'));
+
         $transformer2 = $this->getMock('FOQ\ElasticaBundle\Transformer\ElasticaToModelTransformerInterface');
         $transformer2->expects($this->any())
             ->method('getObjectClass')
             ->will($this->returnValue('FOQ\ElasticaBundle\Tests\Transformer\POPO2'));
+
+        $transformer2->expects($this->any())
+            ->method('getIdentifierField')
+            ->will($this->returnValue('id'));
 
         $this->collection = new ElasticaToModelTransformerCollection($this->transformers = array(
             'type1' => $transformer1,

--- a/Transformer/ElasticaToModelTransformerInterface.php
+++ b/Transformer/ElasticaToModelTransformerInterface.php
@@ -24,4 +24,11 @@ interface ElasticaToModelTransformerInterface
      * @return string
      */
     function getObjectClass();
+
+    /**
+     * Returns the identifier field from the options
+     *
+     * @return string the identifier field
+     */
+    function getIdentifierField();
 }


### PR DESCRIPTION
As per #165

@jmikola can you just give this a once over when you get a chance. Should fix the issue - as it stood the identifier option was set to be set for the whole collection when it needs to be per transformer. Not sure that having to ad the method to get it from the transformers is ideal but seemed better than having to build a config mapping of class to identifier field for the collection transformer.
