### PR TITLE
adds to the config the index parameter

### DIFF
--- a/DependencyInjection/FOQElasticaExtension.php
+++ b/DependencyInjection/FOQElasticaExtension.php
@@ -187,6 +187,9 @@ class FOQElasticaExtension extends Extension
             if (isset($type['search_analyzer'])) {
                 $this->indexConfigs[$indexName]['config']['mappings'][$name]['search_analyzer'] = $type['search_analyzer'];
             }
+            if (isset($type['index'])) {
+                $this->indexConfigs[$indexName]['config']['mappings'][$name]['index'] = $type['index'];
+            }
         }
     }
 


### PR DESCRIPTION
The configuration allows setting the index property but it's not pushing it to elastica.

When indexing multi word tags and keywords sometimes it's better to disable the analyzer.
