### PR TITLE
Added name option to index definition.

### DIFF
--- a/DependencyInjection/FOQElasticaExtension.php
+++ b/DependencyInjection/FOQElasticaExtension.php
@@ -89,6 +89,10 @@ class FOQElasticaExtension extends Extension
     {
         $indexIds = array();
         foreach ($indexes as $name => $index) {
+            if (isset($index['name'])) {
+                $name = $index['name'];
+            }
+
             if (isset($index['client'])) {
                 $clientName = $index['client'];
                 if (!isset($clientIdsByName[$clientName])) {


### PR DESCRIPTION
Allows for a parameter to be used as an index name, useful for environmental index names.

See https://github.com/Exercise/FOQElasticaBundle/issues/185
