### PR TITLE
Fix register custom finder for entity

### DIFF
--- a/DependencyInjection/FOQElasticaExtension.php
+++ b/DependencyInjection/FOQElasticaExtension.php
@@ -364,8 +364,7 @@ class FOQElasticaExtension extends Extension
     {
         if (isset($typeConfig['finder']['service'])) {
             $finderId = $typeConfig['finder']['service'];
-        }
-        else{
+        } else {
             $abstractFinderId = 'foq_elastica.finder.prototype';
             $finderId = sprintf('foq_elastica.finder.%s.%s', $indexName, $typeName);
             $finderDef = new DefinitionDecorator($abstractFinderId);


### PR DESCRIPTION
RepositoryManager::addEntity() wasn't executed for custom finder for type, so there isn't configured repository for Entity and configuration for custom repository for type is ommited.
