### PR TITLE
Fixes undefined index error when populating index

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -50,7 +50,7 @@ class Configuration
                             ->then(function($v) {
                                 return array(
                                     'servers' => array(
-                                        'default' => array(
+                                        array(
                                             'host' => $v['host'],
                                             'port' => $v['port'],
                                         )
@@ -63,7 +63,7 @@ class Configuration
                             ->then(function($v) {
                                 return array(
                                     'servers' => array(
-                                        'default' => array(
+                                        array(
                                             'url' => $v['url'],
                                         )
                                     )


### PR DESCRIPTION
Due to the support of multiple servers in Elastica before this fix the population command fails with an error: `Notice: Undefined offset: 0 in /opt/local/apache2/htdocs/fmdb/vendor/ruflin/Elastica/lib/Elastica/Request.php line 182`. This is due to the fact that the server-array is passed with an associated index. This fix changes this to an numeric index.
