### PR TITLE
Remove exception when multi_field type is used

### DIFF
--- a/Transformer/ModelToElasticaAutoTransformer.php
+++ b/Transformer/ModelToElasticaAutoTransformer.php
@@ -53,8 +53,6 @@ class ModelToElasticaAutoTransformer implements ModelToElasticaTransformerInterf
                 $submapping     = $mapping['properties'];
                 $subcollection  = $property->getValue($object);
                 $document->add($key, $this->transformNested($subcollection, $submapping, $document));
-            } else if (isset($mapping['type']) && $mapping['type'] == 'multi_field') {
-                throw new \Exception('Please implement me !');
             } else if (isset($mapping['type']) && $mapping['type'] == 'attachment') {
                 $attachment = $property->getValue($object);
                 if ($attachment instanceof \SplFileInfo) {


### PR DESCRIPTION
Hello,

When the nested object functionality was recently merged, `Transformer/ModelToElasticaAutoTransformer.php`'s behaviour was changed to throw an exception if the field type is `multi_field`. 

Multi-field mapping seemed to be working for me, so I'm not sure why this was necessary? It's quite possible I'm missing something, but if the functionality is missing, surely it's better to not do anything at all? Based on that opinion, I've removed the Exception.

Cheers,
Craig
