### PR TITLE
Adding configuring index name separately from service name

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -102,6 +102,7 @@ class Configuration
                     ->prototype('array')
                         ->performNoDeepMerging()
                         ->children()
+                            ->scalarNode('index_name')->end()
                             ->scalarNode('client')->end()
                             ->scalarNode('finder')
                                 ->treatNullLike(true)

--- a/DependencyInjection/FOQElasticaExtension.php
+++ b/DependencyInjection/FOQElasticaExtension.php
@@ -100,7 +100,8 @@ class FOQElasticaExtension extends Extension
 
             $clientId = $clientIdsByName[$clientName];
             $indexId = sprintf('foq_elastica.index.%s', $name);
-            $indexDefArgs = array($name);
+            $indexName = isset($index['index_name']) ? $index['index_name'] : $name;
+            $indexDefArgs = array($indexName);
             $indexDef = new Definition('%foq_elastica.index.class%', $indexDefArgs);
             $indexDef->setFactoryService($clientId);
             $indexDef->setFactoryMethod('getIndex');


### PR DESCRIPTION
This allows the index name to be set separately from the alias used in the service names, so that the index name can vary across environments whilst keeping the service name consistent.

As per GH-187

This seems very straightforward and appears to be working fine for me. @jmikola can you see anything I have missed?

I have used index_name as name is already used as the key is it is present. 
