### PR TITLE
Replaced form component with property access

### DIFF
--- a/Tests/Transformer/ModelToElasticaAutoTransformerTest.php
+++ b/Tests/Transformer/ModelToElasticaAutoTransformerTest.php
@@ -201,7 +201,7 @@ class ModelToElasticaAutoTransformerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException \Symfony\Component\Form\Exception\PropertyAccessDeniedException
+     * @expectedException \Symfony\Component\PropertyAccess\Exception\PropertyAccessDeniedException
      */
     public function testThatCannotTransformObjectWhenGetterDoesNotExistForPrivateMethod()
     {

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         "php": ">=5.3.2",
         "symfony/framework-bundle": ">=2.1.0,<2.3-dev",
         "symfony/console": ">=2.1.0,<2.3-dev",
-        "symfony/form": ">=2.1.0,<2.3-dev",
+        "symfony/property-access": ">=2.1.0,<2.3-dev",
         "ruflin/elastica": "0.19.8"
     },
     "require-dev":{


### PR DESCRIPTION
Because \Symfony\Component\Form\Util\PropertyPath is deprecated since version 2.2 and will be removed in 2.3.
