### PR TITLE
use iso date format when normalizing a date value for es

### DIFF
--- a/Transformer/ModelToElasticaAutoTransformer.php
+++ b/Transformer/ModelToElasticaAutoTransformer.php
@@ -98,7 +98,7 @@ class ModelToElasticaAutoTransformer implements ModelToElasticaTransformerInterf
         $normalizeValue = function(&$v)
         {
             if ($v instanceof \DateTime) {
-                $v = (int)$v->format('U');
+                $v = $v->format('c');
             } elseif (!is_scalar($v) && !is_null($v)) {
                 $v = (string)$v;
             }


### PR DESCRIPTION
Formatting date with `U` is wrong as when date field is passed an integer elastic search expects it in microseconds. We could use `u` but then we should not cast the return value  to integer because it will immediately overflow on 32bit php.
So the only acceptable format that the elastic search will accept and conversion back to php shouldn't be a problematic one is the iso
