### PR TITLE
fix search command

### DIFF
--- a/DependencyInjection/FOQElasticaExtension.php
+++ b/DependencyInjection/FOQElasticaExtension.php
@@ -112,7 +112,7 @@ class FOQElasticaExtension extends Extension
             $indexDef->setFactoryMethod('getIndex');
             $container->setDefinition($indexId, $indexDef);
             $typePrototypeConfig = isset($index['type_prototype']) ? $index['type_prototype'] : array();
-            $indexIds[$name] = $indexId;
+            $indexIds[$indexName] = $indexId;
             $this->indexConfigs[$name] = array(
                 'index' => new Reference($indexId),
                 'config' => array(


### PR DESCRIPTION
The bug:
The Search command throws an invalid argument exception when the index
alias and the index_name are different.
See pull request 207
(https://github.com/Exercise/FOQElasticaBundle/pull/207) for a background
on the issue.

Fix:
The first argument of the index manager should be an array of index
objects having index names as keys, and should only fall back to using index aliases
if the index_name config param is not set.
