### PR TITLE
When mapping is not defined then clear cache fails

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -360,14 +360,16 @@ class Configuration
      * @param array $mappings The mappings for the current type
      * @return array The nested mappings defined for this type
      */
-    protected function getNestingsForType($mappings)
+    protected function getNestingsForType(array $mappings = null)
     {
         $nestings = array();
-        foreach ($mappings as $field) {
-            if (isset($field['fields'])) {
-                $this->addPropertyNesting($field, $nestings, 'fields');
-            } else if (isset($field['properties'])) {
-                $this->addPropertyNesting($field, $nestings, 'properties');
+        if ($mappings) {
+            foreach ($mappings as $field) {
+                if (isset($field['fields'])) {
+                    $this->addPropertyNesting($field, $nestings, 'fields');
+                } else if (isset($field['properties'])) {
+                    $this->addPropertyNesting($field, $nestings, 'properties');
+                }
             }
         }
 


### PR DESCRIPTION
This modification allowes to clear cache in symfony when no mapping is defined.

Error during clear-cache:

[ErrorException]  
  Warning: Invalid argument supplied for foreach() in //symfony-standard/vendor/exercise/elastica-bundle/FOQ/ElasticaBundle/DependencyInjection/Configuration.php line 375  

Script Sensio\Bundle\DistributionBundle\Composer\ScriptHandler::clearCache handling the post-update-cmd event terminated with an exception

  [RuntimeException]  
  An error occurred when executing the "'cache:clear --no-warmup'" command.  
