### PR TITLE
[WIP] Using aliases to allow reindexing with atomic alias switching

### DIFF
--- a/Command/PopulateCommand.php
+++ b/Command/PopulateCommand.php
@@ -77,7 +77,7 @@ class PopulateCommand extends ContainerAwareCommand
                 $this->populateIndex($output, $index, $reset);
             }
         } else {
-            $indexes = array_keys($this->indexManager->getAllIndexes());
+            $indexes = $this->indexManager->getAllIndexes();
 
             foreach ($indexes as $index) {
                 $this->populateIndex($output, $index, $reset);
@@ -111,6 +111,7 @@ class PopulateCommand extends ContainerAwareCommand
         }
 
         $output->writeln(sprintf('<info>Refreshing</info> <comment>%s</comment>', $index));
+        $this->resetter->postPopulate($index);
         $this->indexManager->getIndex($index)->refresh();
     }
 

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -120,6 +120,7 @@ class Configuration implements ConfigurationInterface
                         ->performNoDeepMerging()
                         ->children()
                             ->scalarNode('index_name')->end()
+                            ->booleanNode('use_alias')->defaultValue(false)->end()
                             ->scalarNode('client')->end()
                             ->scalarNode('finder')
                                 ->treatNullLike(true)

--- a/ElasticaDynamicIndex.php
+++ b/ElasticaDynamicIndex.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace FOS\ElasticaBundle;
+
+/**
+ * Elastica index capable of reassigning name dynamically
+ *
+ * @author Konstantin Tjuterev <kostik.lv@gmail.com>
+ */
+class ElasticaDynamicIndex extends \Elastica_Index
+{
+
+    /**
+     * Reassign index name
+     *
+     * While it's technically a regular setter for name property, it's specifically named overrideName, but not setName
+     * since it's used for a very specific case and normally should not be used
+     *
+     * @param string $name Index name
+     *
+     * @return void
+     */
+    public function overrideName($name)
+    {
+        $this->_name = $name;
+    }
+
+}

--- a/IndexManager.php
+++ b/IndexManager.php
@@ -4,19 +4,21 @@ namespace FOS\ElasticaBundle;
 
 class IndexManager
 {
-    protected $indexesByName;
-    protected $defaultIndexName;
+    protected $indexConfigs;
+    protected $defaultIndexKey;
 
     /**
      * Constructor.
      *
-     * @param array $indexesByName
-     * @param \Elastica_Index $defaultIndex
+     * @param array  $indexConfigs    Indexes configuration
+     * @param string $defaultIndexKey Config key of default index
+     *
+     * @internal param string $defaultIndexName
      */
-    public function __construct(array $indexesByName, \Elastica_Index $defaultIndex)
+    public function __construct(array $indexConfigs, $defaultIndexKey)
     {
-        $this->indexesByName = $indexesByName;
-        $this->defaultIndexName = $defaultIndex->getName();
+        $this->indexConfigs = $indexConfigs;
+        $this->defaultIndexKey = $defaultIndexKey;
     }
 
     /**
@@ -26,27 +28,57 @@ class IndexManager
      */
     public function getAllIndexes()
     {
-        return $this->indexesByName;
+        return array_keys($this->indexConfigs);
     }
 
     /**
      * Gets an index by its name
      *
-     * @param string $name Index to return, or the default index if null
-     * @return \Elastica_Index
-     * @throws \InvalidArgumentException if no index exists for the given name
+     * @param string|null $key Index key
+     *
+     * @return \FOS\ElasticaBundle\ElasticaDynamicIndex
      */
-    public function getIndex($name = null)
+    public function getIndex($key = null)
     {
-        if (null === $name) {
-            $name = $this->defaultIndexName;
+        $config = $this->getIndexConfig($key);
+        return isset($config['index']) ? $config['index'] : $this->buildIndex($key);
+    }
+
+    /**
+     * Factory method for creating index instances
+     *
+     * @param string|null $key Index key
+     *
+     * @return \FOS\ElasticaBundle\ElasticaDynamicIndex
+     */
+    public function buildIndex($key = null)
+    {
+        $config = $this->getIndexConfig($key);
+        $esIndex = new ElasticaDynamicIndex($config['client'], $config['name_or_alias']);
+        $this->indexConfigs[$key ? : $this->defaultIndexKey]['index'] = $esIndex;
+
+        return $esIndex;
+    }
+
+    /**
+     * Returns index configuration by key
+     *
+     * @param string|null $key Index key
+     *
+     * @return array
+     * @throws \InvalidArgumentException
+     */
+    public function getIndexConfig($key)
+    {
+        if (null === $key) {
+            $key = $this->defaultIndexKey;
         }
 
-        if (!isset($this->indexesByName[$name])) {
-            throw new \InvalidArgumentException(sprintf('The index "%s" does not exist', $name));
+        if (!isset($this->indexConfigs[$key])) {
+            throw new \InvalidArgumentException(sprintf('The index "%s" does not exist', $key));
         }
 
-        return $this->indexesByName[$name];
+        return $this->indexConfigs[$key];
     }
 
     /**
@@ -56,6 +88,6 @@ class IndexManager
      */
     public function getDefaultIndex()
     {
-        return $this->getIndex($this->defaultIndexName);
+        return $this->getIndex($this->defaultIndexKey);
     }
 }

--- a/Resetter.php
+++ b/Resetter.php
@@ -7,16 +7,23 @@ namespace FOS\ElasticaBundle;
  */
 class Resetter
 {
-    protected $indexConfigsByName;
+    protected $indexConfigsByKey;
+
+    /**
+     * Index Manager
+     *
+     * @var \FOQ\ElasticaBundle\IndexManager
+     */
+    protected $indexManager;
 
     /**
      * Constructor.
      *
-     * @param array $indexConfigsByName
+     * @param array $indexConfigsByKey
      */
-    public function __construct(array $indexConfigsByName)
+    public function __construct(IndexManager $indexManager)
     {
-        $this->indexConfigsByName = $indexConfigsByName;
+        $this->indexManager = $indexManager;
     }
 
     /**
@@ -24,8 +31,8 @@ class Resetter
      */
     public function resetAllIndexes()
     {
-        foreach ($this->indexConfigsByName as $indexConfig) {
-            $indexConfig['index']->create($indexConfig['config'], true);
+        foreach ($this->indexManager->getAllIndexes() as $name) {
+            $this->resetIndex($name);
         }
     }
 
@@ -35,28 +42,159 @@ class Resetter
      * @param string $indexName
      * @throws \InvalidArgumentException if no index exists for the given name
      */
-    public function resetIndex($indexName)
+    public function resetIndex($indexKey)
     {
-        $indexConfig = $this->getIndexConfig($indexName);
-        $indexConfig['index']->create($indexConfig['config'], true);
+        $indexConfig = $this->indexManager->getIndexConfig($indexKey);
+        /** @var $esIndex \Elastica_Index */
+        $esIndex = $this->indexManager->getIndex($indexKey);
+        if (isset($indexConfig['use_alias']) && $indexConfig['use_alias']) {
+            $name = $indexConfig['name_or_alias'];
+            $name .= date('-Y-m-d-Gis');
+            $esIndex->overrideName($name);
+            $esIndex->create($indexConfig['config']);
+        } else {
+            $esIndex->create($indexConfig['config'], true);
+        }
+    }
+
+    public function postPopulate($indexKey)
+    {
+        $indexConfig = $this->indexManager->getIndexConfig($indexKey);
+        if (isset($indexConfig['use_alias']) && $indexConfig['use_alias']) {
+            $this->switchIndexAlias($indexKey);
+        }
+    }
+
+    /**
+     * Switches the alias for given index (by key) to the newly populated index
+     * and deletes the old index
+     *
+     * @param string $indexKey Index key
+     *
+     * @return void
+     *
+     * @throws \RuntimeException
+     */
+    private function switchIndexAlias($indexKey)
+    {
+        $indexConfig = $this->indexManager->getIndexConfig($indexKey);
+        $esIndex = $this->indexManager->getIndex($indexKey);
+        $aliasName = $indexConfig['name_or_alias'];
+        $oldIndexName = false;
+        $newIndexName = $esIndex->getName();
+
+        $aliasedIndexes = $this->getAliasedIndexes($esIndex, $aliasName);
+
+        if (count($aliasedIndexes) > 1) {
+            throw new \RuntimeException(
+                sprintf(
+                    'Alias %s is used for multiple indexes: [%s].
+                    Make sure it\'s either not used or is assigned to one index only',
+                    $aliasName,
+                    join(', ', $aliasedIndexes)
+                )
+            );
+        }
+
+        // Change the alias to point to the new index
+        // Elastica's addAlias can't be used directly, because in current (0.19.x) version it's not atomic
+        // In 0.20.x it's atomic, but it doesn't return the old index name
+        $aliasUpdateRequest = array('actions' => array());
+        if (count($aliasedIndexes) == 1) {
+            // if the alias is set - add an action to remove it
+            $oldIndexName = $aliasedIndexes[0];
+            $aliasUpdateRequest['actions'][] = array(
+                'remove' => array('index' => $oldIndexName, 'alias' => $aliasName)
+            );
+        }
+
+        // add an action to point the alias to the new index
+        $aliasUpdateRequest['actions'][] = array(
+            'add' => array('index' => $newIndexName, 'alias' => $aliasName)
+        );
+
+        try {
+            $esIndex->getClient()->request('_aliases', 'POST', $aliasUpdateRequest);
+        } catch (\Elastica_Exception_Abstract $renameAliasException) {
+            $additionalError   = '';
+            // if we failed to move the alias, delete the newly built index
+            try {
+                $esIndex->delete();
+            } catch (\Elastica_Exception_Abstract $deleteNewIndexException) {
+                $additionalError = sprintf(
+                    'Tried to delete newly built index %s, but also failed: %s',
+                    $newIndexName,
+                    $deleteNewIndexException->getError()
+                );
+            }
+
+            throw new \RuntimeException(
+                sprintf(
+                    'Failed to updated index alias: %s. %s',
+                    $renameAliasException->getMessage(),
+                    $additionalError ? : sprintf('Newly built index %s was deleted', $newIndexName)
+                )
+            );
+        }
+
+        // Delete the old index after the alias has been switched
+        if ($oldIndexName) {
+            $oldIndex = new \Elastica_Index($esIndex->getClient(), $oldIndexName);
+            try {
+                $oldIndex->delete();
+            } catch (\Elastica_Exception_Abstract $deleteOldIndexException) {
+                throw new \RuntimeException(
+                    sprintf(
+                        'Failed to delete old index %s with message: %s',
+                        $oldIndexName,
+                        $deleteOldIndexException->getMessage()
+                    )
+                );
+            }
+        }
+    }
+
+    /**
+     * Returns array of indexes which are mapped to given alias
+     *
+     * @param \Elastica_Index $esIndex   ES Index
+     * @param string          $aliasName Alias name
+     *
+     * @return array
+     */
+    private function getAliasedIndexes($esIndex, $aliasName)
+    {
+        $aliasedIndexes = array();
+        $aliasesInfo    = $esIndex->getClient()->request('_aliases', 'GET')->getData();
+        foreach ($aliasesInfo as $indexName => $indexInfo) {
+            $aliases = array_keys($indexInfo['aliases']);
+            if (in_array($aliasName, $aliases)) {
+                $aliasedIndexes[] = $indexName;
+            }
+        }
+
+        return $aliasedIndexes;
     }
 
     /**
      * Deletes and recreates a mapping type for the named index
      *
-     * @param string $indexName
+     * @param string $indexKey
      * @param string $typeName
      * @throws \InvalidArgumentException if no index or type mapping exists for the given names
      */
-    public function resetIndexType($indexName, $typeName)
+    public function resetIndexType($indexKey, $typeName)
     {
-        $indexConfig = $this->getIndexConfig($indexName);
+        $indexConfig = $this->indexManager->getIndexConfig($indexKey);
+        $esIndex = $this->indexManager->getIndex($indexKey);
 
         if (!isset($indexConfig['config']['mappings'][$typeName]['properties'])) {
-            throw new \InvalidArgumentException(sprintf('The mapping for index "%s" and type "%s" does not exist.', $indexName, $typeName));
+            throw new \InvalidArgumentException(sprintf('The mapping for index "%s" and type "%s" does not exist.', $indexKey, $typeName));
         }
 
-        $type = $indexConfig['index']->getType($typeName);
+        $type = $esIndex->getType($typeName);
+
+        // @TODO add type exists check, otherwise it fails when creating new types in existing index
         $type->delete();
         $mapping = $this->createMapping($indexConfig['config']['mappings'][$typeName]);
         $type->setMapping($mapping);
@@ -79,23 +217,5 @@ class Resetter
         }
 
         return $mapping;
-    }
-
-    /**
-     * Gets an index config by its name
-     *
-     * @param string $indexName Index name
-     *
-     * @param $indexName
-     * @return array
-     * @throws \InvalidArgumentException if no index config exists for the given name
-     */
-    protected function getIndexConfig($indexName)
-    {
-        if (!isset($this->indexConfigsByName[$indexName])) {
-            throw new \InvalidArgumentException(sprintf('The configuration for index "%s" does not exist.', $indexName));
-        }
-
-        return $this->indexConfigsByName[$indexName];
     }
 }

--- a/Resources/config/config.xml
+++ b/Resources/config/config.xml
@@ -35,12 +35,12 @@
         </service>
 
         <service id="fos_elastica.index_manager" class="FOS\ElasticaBundle\IndexManager">
-            <argument /> <!-- indexes -->
-            <argument /> <!-- default index -->
+            <argument /> <!-- index configs -->
+            <argument /> <!-- default index key -->
         </service>
 
         <service id="fos_elastica.resetter" class="FOS\ElasticaBundle\Resetter">
-            <argument /> <!-- index configs -->
+            <argument type="service" id="fos_elastica.index_manager"/>
         </service>
 
         <service id="fos_elastica.object_persister.prototype" class="FOS\ElasticaBundle\Persister\ObjectPersister" abstract="true">

--- a/Tests/IndexManagerTest.php
+++ b/Tests/IndexManagerTest.php
@@ -28,7 +28,7 @@ class IndexManagerTest extends \PHPUnit_Framework_TestCase
             ->method('getName')
             ->will($this->returnValue($this->defaultIndexName));
 
-        $this->indexManager = new IndexManager($this->indexesByName, $defaultIndex);
+        $this->indexManager = new IndexManager($tbd, $defaultIndex);
     }
 
     public function testGetAllIndexes()


### PR DESCRIPTION
Currently `populate` command resets the index, and so it's not available while being reindexed, meaning if you need to reindex in production (due to mapping changes or whatever else), you site (or at least search) will be down.

This PR makes use of ES aliases to fix the above problem. `populate` command now creates a new index, populates it and then updates the alias to point to the new index in an atomic way. The old index is automatically deleted after a successful alias update. 

To achieve this, I had to extend `Elastica_Index` class to add `overrideName` method (which is a setter for index name). Since this bundle used `Elastica_Client` as the factory service for creating index instances, and I needed to make it instantiate a different class (`ElasticaDynamicIndex`), I had to refactor the way the index instances are being created. I figured out that the `IndexManager` is the best candidate for the job of creating index instances. (I'm also going to submit PR to Elastica to update the original `Elastica_Index` class, but nevertheless, I think the refactoring of `IndexManager` to build the indexes makes sense). 

I have also removed injecting of index settings into `Resetter` and made it use `IndexManger` for everything related to index configuration.

Also, to avoid any confusion between index service name (as defined in YML as config's key), ES actual index name (defined in `index_name` attribute) and index alias (introduced in this PR), I had renamed the references of indexes (in variable names) to `key` instead of `name` where applicable.

The functionality is optional. To use it, add `use_alias: true` into index configuration (YML). Note, that to switch from using index_name directly to using an alias, you have to first manually delete the existing index (otherwise the alias can't be set because an index with such name already exists). Switching back from using alias to plain index is easy - `Resetter` will just delete the index by its alias and then recreate it as plain index.

Please review the code. If the concept is fine, I'll update the tests and documentation.
