### PR TITLE
Collector: print query data as json instead of yaml

### DIFF
--- a/Resources/views/Collector/elastica.html.twig
+++ b/Resources/views/Collector/elastica.html.twig
@@ -46,7 +46,7 @@
                     <strong>Path</strong>: {{ query.path }}<br />
                     <strong>Method</strong>: {{ query.method }}
                     <div>
-                        <code>{{ query.data|yaml_encode }}</code>
+                        <code>{{ query.data|json_encode }}</code>
                     </div>
                     <small>
                         <strong>Time</strong>: {{ '%0.2f'|format(query.executionMS * 1000) }} ms


### PR DESCRIPTION
It is more convenient to print the queries in json format so you can copy & paste them directly into [eshead](https://github.com/mobz/elasticsearch-head) (or another tool to query the server).
