### PR TITLE
Allow symfony >= 2.3

### DIFF
--- a/Tests/Transformer/ModelToElasticaAutoTransformerTest.php
+++ b/Tests/Transformer/ModelToElasticaAutoTransformerTest.php
@@ -203,7 +203,7 @@ class ModelToElasticaAutoTransformerTest extends \PHPUnit_Framework_TestCase
 
     public function testThatCannotTransformObjectWhenGetterDoesNotExistForPrivateMethod()
     {
-        $this->setExpectedException('Symfony\Component\PropertyAccess\Exception\PropertyAccessDeniedException');
+        $this->setExpectedException('Symfony\Component\PropertyAccess\Exception\ExceptionInterface');
 
         $transformer = $this->getTransformer();
         $transformer->transform(new POPO(), array('desc' => array()));

--- a/composer.json
+++ b/composer.json
@@ -12,10 +12,10 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "symfony/framework-bundle": ">=2.1.0,<2.3.0-dev",
-        "symfony/console": ">=2.1.0,<2.3.0-dev",
-        "symfony/form": ">=2.1.0,<2.3.0-dev",
-        "symfony/property-access": "2.2.*",
+        "symfony/framework-bundle": "~2.1",
+        "symfony/console": "~2.1",
+        "symfony/form": "~2.1",
+        "symfony/property-access": "~2.2",
         "ruflin/elastica": "0.20.5.*@dev"
     },
     "require-dev":{


### PR DESCRIPTION
This required a small tweak to the tests as
Symfony\Component\PropertyAccess\Exception\PropertyAccessDeniedException
 has been removed in 2.3
