### PR TITLE
Updated documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -577,19 +577,19 @@ You can also choose to only listen for some of the events:
 If you use listeners to update your index, you may need to validate your
 entities before you index them (e.g. only index "public" entities). Typically,
 you'll want the listener to be consistent with the provider's query criteria.
-This may be achieved by using the `is_indexable_callback_class` config parameter:
+This may be achieved by using the `is_indexable_callback` config parameter:
 
                         persistence:
                             listener:
-                                is_indexable_callback_class: "isPublic"
+                                is_indexable_callback: "isPublic"
 
-If `is_indexable_callback_class` is a string and the entity has a method with the
+If `is_indexable_callback` is a string and the entity has a method with the
 specified name, the listener will only index entities for which the method
 returns `true`. Additionally, you may provide a service and method name pair:
 
                         persistence:
                             listener:
-                                is_indexable_callback_class: [ "%custom_service_id%", "isIndexable" ]
+                                is_indexable_callback: [ "%custom_service_id%", "isIndexable" ]
 
 In this case, the callback_class will be the `isIndexable()` method on the specified
 service and the object being considered for indexing will be passed as the only


### PR DESCRIPTION
Changed `is_indexable_callback_class` in the documentation back to `is_indexable_callback`. The `is_indexable_callback_class` config parameter doesn't exist and is probably the result of a replace-all.
