### PR TITLE
Optimized Entity update handler to support elasticsearch update

### DIFF
--- a/DependencyInjection/FOSElasticaExtension.php
+++ b/DependencyInjection/FOSElasticaExtension.php
@@ -385,7 +385,7 @@ class FOSElasticaExtension extends Extension
         $events = array();
         $eventMapping = array(
             'insert' => array('postPersist'),
-            'update' => array('postUpdate'),
+            'update' => array('preUpdate', 'postUpdate'),
             'delete' => array('postRemove', 'preRemove')
         );
 

--- a/Doctrine/ORM/Listener.php
+++ b/Doctrine/ORM/Listener.php
@@ -3,10 +3,14 @@
 namespace FOS\ElasticaBundle\Doctrine\ORM;
 
 use Doctrine\ORM\Event\LifecycleEventArgs;
+use Doctrine\ORM\Event\PreUpdateEventArgs;
 use FOS\ElasticaBundle\Doctrine\AbstractListener;
 
 class Listener extends AbstractListener
 {
+    /** @var array */
+    protected $changes = array();
+
     public function postPersist(LifecycleEventArgs $eventArgs)
     {
         $entity = $eventArgs->getEntity();
@@ -16,13 +20,24 @@ class Listener extends AbstractListener
         }
     }
 
+    public function preUpdate(PreUpdateEventArgs $eventArgs)
+    {
+        $entity = $eventArgs->getEntity();
+
+        if ($entity instanceof $this->objectClass) {
+            if ($this->isObjectIndexable($entity)) {
+                $this->changes[$this->changeKey($entity)] = $eventArgs->getEntityChangeSet();
+            }
+        }
+    }
+
     public function postUpdate(LifecycleEventArgs $eventArgs)
     {
         $entity = $eventArgs->getEntity();
 
         if ($entity instanceof $this->objectClass) {
             if ($this->isObjectIndexable($entity)) {
-                $this->objectPersister->replaceOne($entity);
+                $this->objectPersister->replaceOne($entity, $this->changes[$this->changeKey($entity)]);
             } else {
                 $this->scheduleForRemoval($entity, $eventArgs->getEntityManager());
                 $this->removeIfScheduled($entity);
@@ -46,5 +61,10 @@ class Listener extends AbstractListener
         if ($entity instanceof $this->objectClass) {
             $this->removeIfScheduled($entity);
         }
+    }
+
+    protected function changeKey($entity)
+    {
+        return get_class($entity) . '_' . $entity->getId();
     }
 }

--- a/Persister/ObjectPersister.php
+++ b/Persister/ObjectPersister.php
@@ -43,13 +43,17 @@ class ObjectPersister implements ObjectPersisterInterface
      * Replaces one object in the type
      *
      * @param object $object
+     * @param array  $fields
+     *
      * @return null
-     **/
-    public function replaceOne($object)
+     */
+    public function replaceOne($object, array $fields = array())
     {
-        $document = $this->transformToElasticaDocument($object);
-        $this->type->deleteById($document->getId());
-        $this->type->addDocument($document);
+        $document = $this->transformToElasticaDocument($object, $fields);
+
+        if ($document) {
+            $this->type->updateDocument($document);
+        }
     }
 
     /**
@@ -95,10 +99,17 @@ class ObjectPersister implements ObjectPersisterInterface
      * Transforms an object to an elastica document
      *
      * @param object $object
-     * @return Document the elastica document
+     * @param array  $fields
+     *
+     * @return Document|null the elastica document
      */
-    public function transformToElasticaDocument($object)
+    public function transformToElasticaDocument($object, array $fields = array())
     {
-        return $this->transformer->transform($object, $this->fields);
+        $fields = !empty($fields) ? array_intersect_key($this->fields, $fields) : $this->fields;
+
+        if (empty($fields))
+            return null;
+
+        return $this->transformer->transform($object, $fields);
     }
 }


### PR DESCRIPTION
Previous update handler dropped the entry from elastic and rebuilt from scratch.  This update enables the handler to take advantage of the "update" function.  This prevents myriad database hits when the updated entity has nested records being indexed.
