### PR TITLE
An orderBy DQL  part is required to avoid feching the same row twice

### DIFF
--- a/Doctrine/ORM/Provider.php
+++ b/Doctrine/ORM/Provider.php
@@ -54,7 +54,6 @@ class Provider extends AbstractProvider
                 ->getManagerForClass($this->objectClass)
                 ->getClassMetadata($this->objectClass)
                 ->getIdentifierFieldNames();
-            sort($identifierFieldNames);
             foreach ($identifierFieldNames as $fieldName) {
                 $queryBuilder->addOrderBy(static::ENTITY_ALIAS.'.'.$fieldName);
             }


### PR DESCRIPTION
When the ORM provider fetch a new slice, an "order by" is needed because major DB systems don't guarantee the row order without it.

I detected that some entities are being indexed twice, whereas others are being ignored.
