### PR TITLE
Fix load clients dependency

### DIFF
--- a/DependencyInjection/FOSElasticaExtension.php
+++ b/DependencyInjection/FOSElasticaExtension.php
@@ -71,8 +71,7 @@ class FOSElasticaExtension extends Extension
     {
         $clientIds = array();
         foreach ($clients as $name => $clientConfig) {
-            $clientDef = $container->getDefinition('fos_elastica.client');
-            $clientDef->replaceArgument(0, $clientConfig);
+            $clientDef = new Definition('%fos_elastica.client.class%', array($clientConfig));
 
             $clientId = sprintf('fos_elastica.client.%s', $name);
 


### PR DESCRIPTION
There is a bug when declare multiple clients (see #320).

It's happen because <code>$container->getDefinition('fos_elastica.client')</code> return the same object reference for each client. So the last client host and port is used for all clients.

By creating a new definition, there is no sharing of the same definition object.
