### PR TITLE
2.0.x definition decorators

### DIFF
--- a/DependencyInjection/FOSElasticaExtension.php
+++ b/DependencyInjection/FOSElasticaExtension.php
@@ -70,10 +70,9 @@ class FOSElasticaExtension extends Extension
     {
         $clientIds = array();
         foreach ($clients as $name => $clientConfig) {
-            $clientDef = $container->getDefinition('fos_elastica.client');
-            $clientDef->replaceArgument(0, $clientConfig);
-
             $clientId = sprintf('fos_elastica.client.%s', $name);
+            $clientDef = new Definition('%fos_elastica.client.class%', array($clientConfig));
+            $clientDef->addMethodCall('setLogger', array(new Reference('fos_elastica.logger')));
 
             $container->setDefinition($clientId, $clientDef);
 

--- a/Resources/config/config.xml
+++ b/Resources/config/config.xml
@@ -27,13 +27,6 @@
             <argument type="service" id="fos_elastica.logger" />
         </service>
 
-        <service id="fos_elastica.client" class="%fos_elastica.client.class%">
-            <argument /> <!-- config -->
-            <call method="setLogger">
-                <argument type="service" id="fos_elastica.logger" />
-            </call>
-        </service>
-
         <service id="fos_elastica.index_manager" class="FOS\ElasticaBundle\IndexManager">
             <argument /> <!-- indexes -->
             <argument /> <!-- default index -->


### PR DESCRIPTION
This PR does two things:
- Attempt to prevent ID conflicts with abstract services by removing "prototype" from their ID. There are still edge cases where certain index/type name combinations could overwrite another service, but we can't solve that without breaking BC. See my inline comments explaining those cases.
- Create new definitions for each client configuration. This is preferable to #324, which would have broken the logger, and an alternative to the cloning done in #336.
