### PR TITLE
Add support for include_in_parent and include_in_root options

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -415,6 +415,10 @@ class Configuration implements ConfigurationInterface
         }
 
         if (isset($nestings['properties'])) {
+            $node
+                ->booleanNode('include_in_parent')->end()
+                ->booleanNode('include_in_root')->end()
+            ;
             $this->addNestedFieldConfig($node, $nestings, 'properties');
         }
     }


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #121 |
| License | MIT |

This adds support for `include_in_parent` and `include_in_root` in nested fields and objects.
