### PR TITLE
Added support for option "format" on "date" mapping type

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -339,6 +339,7 @@ class Configuration implements ConfigurationInterface
             ->scalarNode('index_options')->end()
             ->scalarNode('ignore_above')->end()
             ->scalarNode('position_offset_gap')->end()
+            ->scalarNode('format')->end()
         ;
 
         if (isset($nestings['fields'])) {


### PR DESCRIPTION
Added posibility to specify the date format:

``` yaml
mappings:
    username: ~
    profile:
        type: nested
        properties:
            name: { boost: 2.0 }
            gender: ~
            birthday: { type: date, format: "yyyy-MM-dd" }
```

http://www.elasticsearch.org/guide/reference/mapping/date-format/
