### PR TITLE
New options to fos:elastica:populate command: offset, sleep, batch-size

### DIFF
--- a/Doctrine/AbstractProvider.php
+++ b/Doctrine/AbstractProvider.php
@@ -31,22 +31,27 @@ abstract class AbstractProvider extends BaseAbstractProvider
     /**
      * @see FOS\ElasticaBundle\Provider\ProviderInterface::populate()
      */
-    public function populate(\Closure $loggerClosure = null)
+    public function populate(\Closure $loggerClosure = null, array $options = array())
     {
         $queryBuilder = $this->createQueryBuilder();
         $nbObjects = $this->countObjects($queryBuilder);
+        $offset = isset($options['offset']) ? intval($options['offset']) : 0;
+        $sleep = isset($options['sleep']) ? intval($options['sleep']) : 0;
+        $batchSize = isset($options['batch-size']) ? intval($options['batch-size']) : $this->options['batch_size'];
 
-        for ($offset = 0; $offset < $nbObjects; $offset += $this->options['batch_size']) {
+        for (; $offset < $nbObjects; $offset += $batchSize) {
             if ($loggerClosure) {
                 $stepStartTime = microtime(true);
             }
-            $objects = $this->fetchSlice($queryBuilder, $this->options['batch_size'], $offset);
+            $objects = $this->fetchSlice($queryBuilder, $batchSize, $offset);
 
             $this->objectPersister->insertMany($objects);
 
             if ($this->options['clear_object_manager']) {
                 $this->managerRegistry->getManagerForClass($this->objectClass)->clear();
             }
+
+            usleep($sleep);
 
             if ($loggerClosure) {
                 $stepNbObjects = count($objects);

--- a/Propel/Provider.php
+++ b/Propel/Provider.php
@@ -14,22 +14,27 @@ class Provider extends AbstractProvider
     /**
      * @see FOS\ElasticaBundle\Provider\ProviderInterface::populate()
      */
-    public function populate(\Closure $loggerClosure = null)
+    public function populate(\Closure $loggerClosure = null, array $options = array())
     {
         $queryClass = $this->objectClass . 'Query';
         $nbObjects = $queryClass::create()->count();
+        $offset = isset($options['offset']) ? intval($options['offset']) : 0;
+        $sleep = isset($options['sleep']) ? intval($options['sleep']) : 0;
+        $batchSize = isset($options['batch-size']) ? intval($options['batch-size']) : $this->options['batch_size'];
 
-        for ($offset = 0; $offset < $nbObjects; $offset += $this->options['batch_size']) {
+        for (; $offset < $nbObjects; $offset += $batchSize) {
             if ($loggerClosure) {
                 $stepStartTime = microtime(true);
             }
 
             $objects = $queryClass::create()
-                ->limit($this->options['batch_size'])
+                ->limit($batchSize)
                 ->offset($offset)
                 ->find();
 
             $this->objectPersister->insertMany($objects->getArrayCopy());
+
+            usleep($sleep);
 
             if ($loggerClosure) {
                 $stepNbObjects = count($objects);

--- a/Provider/ProviderInterface.php
+++ b/Provider/ProviderInterface.php
@@ -13,7 +13,8 @@ interface ProviderInterface
      * Persists all domain objects to ElasticSearch for this provider.
      *
      * @param \Closure $loggerClosure
+     * @param array    $options
      * @return
      */
-    function populate(\Closure $loggerClosure = null);
+    function populate(\Closure $loggerClosure = null, array $options = array());
 }

--- a/README.md
+++ b/README.md
@@ -327,8 +327,9 @@ Its class must implement `FOS\ElasticaBundle\Provider\ProviderInterface`.
              * Insert the repository objects in the type index
              *
              * @param \Closure $loggerClosure
+             * @param array    $options
              */
-            public function populate(\Closure $loggerClosure = null)
+            public function populate(\Closure $loggerClosure = null, array $options = array())
             {
                 if ($loggerClosure) {
                     $loggerClosure('Indexing users');


### PR DESCRIPTION
I've added some new options to the `fos:elastica:populate` command.
I've also modified the `ProviderInterface::populate` function signature: added the `$options` array parameter as the second parameter.

The `fos:elastica:populate` command now passes the `$input->getOptions()` array to the `$provider->populate` call, thus providers can be controlled by the command parameters.

New options in `fos:elastica:populate` command:
- `offset`: indexing offset can be given (default: 0)
- `sleep`: sleep time (in microseconds) between object persisting iterations can be given (default: 0)
- `batch-size`: indexing batch size can be given, it overrides the one configured in the provider
