### PR TITLE
Add option to enable logger and define logger class

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -76,8 +76,9 @@ class Configuration implements ConfigurationInterface
                                 return array(
                                     'servers' => array(
                                         array(
-                                            'host' => $v['host'],
-                                            'port' => $v['port'],
+                                            'host'   => $v['host'],
+                                            'port'   => $v['port'],
+                                            'logger' => $v['logger']
                                         )
                                     )
                                 );
@@ -89,7 +90,8 @@ class Configuration implements ConfigurationInterface
                                 return array(
                                     'servers' => array(
                                         array(
-                                            'url' => $v['url'],
+                                            'url'    => $v['url'],
+                                            'logger' => $v['logger']
                                         )
                                     )
                                 );
@@ -102,6 +104,11 @@ class Configuration implements ConfigurationInterface
                                         ->scalarNode('url')->end()
                                         ->scalarNode('host')->end()
                                         ->scalarNode('port')->end()
+                                        ->scalarNode('logger')
+                                            ->defaultValue('fos_elastica.logger')
+                                            ->treatNullLike('fos_elastica.logger')
+                                            ->treatTrueLike('fos_elastica.logger')
+                                        ->end()
                                     ->end()
                                 ->end()
                             ->end()

--- a/DependencyInjection/FOSElasticaExtension.php
+++ b/DependencyInjection/FOSElasticaExtension.php
@@ -73,7 +73,10 @@ class FOSElasticaExtension extends Extension
         foreach ($clients as $name => $clientConfig) {
             $clientId = sprintf('fos_elastica.client.%s', $name);
             $clientDef = new Definition('%fos_elastica.client.class%', array($clientConfig));
-            $clientDef->addMethodCall('setLogger', array(new Reference('fos_elastica.logger')));
+            $logger = $clientConfig['servers'][0]['logger'];
+            if (false !== $logger) {
+                $clientDef->addMethodCall('setLogger', array(new Reference($logger)));
+            }
             $clientDef->addTag('fos_elastica.client');
 
             $container->setDefinition($clientId, $clientDef);


### PR DESCRIPTION
Fixes #118

Add the option to disable the logger and optionally specify the logger class.

The logger is enabled by default, but you can disable it per client by adding the `enable_logger` option:

```
fos_elastica:
    clients:
        default: { host: localhost, port: 9200, enable_logger : false}
```

You can also override the logger class by specifying a service id in the `logger_class` option:

```
fos_elastica:
    clients:
        default: { host: localhost, port: 9200, logger_class: my.logger.service.id }
```

This might not be the most elegant solution, but I'm open for ideas if somebody has a different implementation.

@TODO: documentation
