### PR TITLE
Allow TransformedFinder to be used by the outside world

### DIFF
--- a/Finder/TransformedFinder.php
+++ b/Finder/TransformedFinder.php
@@ -3,6 +3,7 @@
 namespace FOS\ElasticaBundle\Finder;
 
 use Elastica\Document;
+use Elastica\ResultSet;
 use FOS\ElasticaBundle\Transformer\ElasticaToModelTransformerInterface;
 use FOS\ElasticaBundle\Paginator\TransformedPaginatorAdapter;
 use FOS\ElasticaBundle\Paginator\FantaPaginatorAdapter;
@@ -36,6 +37,26 @@ class TransformedFinder implements PaginatedFinderInterface
         $results = $this->search($query, $limit);
 
         return $this->transformer->transform($results);
+    }
+
+    /**
+     * Transform a given \Elastica\ResultSet
+     *
+     * @param \Elastica\ResultSet $resultSet
+     * @return array of model objects
+     */
+    public function transform(ResultSet $resultSet)
+    {
+        return $this->transformer->transform($resultSet->getResults());
+    }
+
+    /**
+     * @param \Elastica\ResultSet $resultSet
+     * @return array of model objects
+     */
+    public function hybridTransform(ResultSet $resultSet)
+    {
+        return $this->transformer->transform($resultSet->getResults());
     }
 
     public function findHybrid($query, $limit = null)


### PR DESCRIPTION
This is a small API enhancement. When using Finder actually, there is no way to deal with Facet or other cool Elastica stuffs.

If I want to play this query:

```php
$query = \Elastica\Query::create("afsy");
$date_facet = new DateHistogram('years');
$date_facet->setField('published_at');
$date_facet->setInterval('year');
$query->addFacet($date_facet);
```

And retreive both a list of Entities AND my Facets, I can't find a way.

Here is what we can do with this PR:

```php
$articles = $this->get('fos_elastica.index.afsy.article')->search($query);

$facets = $articles->getFacets();
$years  = $facets['years']['entries'];

$entities = $this->get('fos_elastica.finder.afsy.article')->transform($articles);

var_dump($years, $entities);
````

We fetch the results from the type, get the facets or anything else from the `ResultSet`, and then send the results to `TransformedFinder` for translation into entities.

What do you thing about it?