### PR TITLE
[Feature] Allow to display a run-able cURL query in the web profiler 

### DIFF
--- a/Client.php
+++ b/Client.php
@@ -4,8 +4,6 @@ namespace FOS\ElasticaBundle;
 
 use Elastica\Client as ElasticaClient;
 use Elastica\Request;
-use Elastica\Transport\Http;
-use Elastica\Transport\Https;
 
 /**
  * @author Gordon Franke <info@nevalon.de>
@@ -21,14 +19,14 @@ class Client extends ElasticaClient
             $time = microtime(true) - $start;
 
             $connection = $this->getLastRequest()->getConnection();
-            $transport  = $connection->getTransportObject();
-            $full_host  = null;
 
-            if ($transport instanceof Http || $transport instanceof Https) {
-                $full_host = $connection->getTransport().'://'.$connection->getHost().':'.$connection->getPort();
-            }
+            $connection_array = array(
+                'host'      => $connection->getHost(),
+                'port'      => $connection->getPort(),
+                'transport' => $connection->getTransport(),
+            );
 
-            $this->_logger->logQuery($path, $method, $data, $time, $full_host);
+            $this->_logger->logQuery($path, $method, $data, $time, $connection_array);
         }
 
         return $response;

--- a/Logger/ElasticaLogger.php
+++ b/Logger/ElasticaLogger.php
@@ -38,9 +38,9 @@ class ElasticaLogger implements LoggerInterface
      * @param string $method Rest method to use (GET, POST, DELETE, PUT)
      * @param array  $data   arguments
      * @param float  $time   execution time
-     * @param string $full_host   host and port of the query
+     * @param array  $connection   host, port and transport of the query
      */
-    public function logQuery($path, $method, $data, $time, $full_host = null)
+    public function logQuery($path, $method, $data, $time, $connection = array())
     {
         if ($this->debug) {
             $this->queries[] = array(
@@ -48,7 +48,7 @@ class ElasticaLogger implements LoggerInterface
                 'method' => $method,
                 'data' => $data,
                 'executionMS' => $time,
-                'full_host' => $full_host
+                'connection' => $connection
             );
         }
 

--- a/Resources/views/Collector/elastica.html.twig
+++ b/Resources/views/Collector/elastica.html.twig
@@ -44,7 +44,7 @@
             {% for key, query in collector.queries %}
                 <li class="{{ cycle(['odd', 'even'], loop.index) }}">
                     <strong>Path</strong>: {{ query.path }}<br />
-                    <strong>Method</strong>: {{ query.method }}
+                    <strong>Method</strong>: {{ query.method }} <small>({{ query.connection.transport }} on {{ query.connection.host }}:{{ query.connection.port }})</small>
                     <div>
                         <code>{{ query.data|json_encode }}</code>
                     </div>
@@ -52,7 +52,7 @@
                         <strong>Time</strong>: {{ '%0.2f'|format(query.executionMS * 1000) }} ms
                     </small>
 
-                    {% if query.full_host %}
+                    {% if query.connection.transport in ['Http', 'Https'] %}{# cURL support only HTTP #}
                         <a href="#elastica_curl_query_{{ key }}" onclick="return curl_version(this);" style="text-decoration: none;" title="Get the cURL repeatable query">
                             <img alt="+" src="{{ asset('bundles/framework/images/blue_picto_more.gif') }}" style="display: inline; width: 12px; height: 12px; vertical-align: bottom;" />
                             <img alt="-" src="{{ asset('bundles/framework/images/blue_picto_less.gif') }}" style="display: none; width: 12px; height: 12px; vertical-align: bottom;" />
@@ -60,7 +60,7 @@
                         </a>
 
                         <div style="display: none;" id="elastica_curl_query_{{ key }}">
-                            <code>curl -X{{ query.method }} '{{ query.full_host }}/{{ query.path }}' -d '{{ query.data|json_encode }}'</code>
+                            <code>curl -X{{ query.method }} '{{ query.connection.transport|lower }}://{{ query.connection.host }}:{{ query.connection.port }}/{{ query.path }}' -d '{{ query.data|json_encode }}'</code>
                         </div>
                     {% endif %}
                 </li>

--- a/Tests/Logger/ElasticaLoggerTest.php
+++ b/Tests/Logger/ElasticaLoggerTest.php
@@ -35,17 +35,17 @@ class ElasticaLoggerTest extends \PHPUnit_Framework_TestCase
         $method = 'testMethod';
         $data   = array('data');
         $time   = 12;
-        $full_host = 'http://example.com:9200';
+        $connection = array('host' => 'localhost', 'port' => '8999', 'transport' => 'https');
 
         $expected = array(
             'path'        => $path,
             'method'      => $method,
             'data'        => $data,
             'executionMS' => $time,
-            'full_host'   => $full_host,
+            'connection'  => $connection,
         );
 
-        $elasticaLogger->logQuery($path, $method, $data, $time, $full_host);
+        $elasticaLogger->logQuery($path, $method, $data, $time, $connection);
         $returnedQueries = $elasticaLogger->getQueries();
         $this->assertEquals($expected, $returnedQueries[0]);
     }


### PR DESCRIPTION
This PR add a small [+] button on each query to open a new bloc wrapping the query in a cURL call, easy to copy and paste in a terminal.

When debugging Elasticsearch query, it's very important to be able to replay queries,
previously we were forced to manually copy and paste the method, path and query data.

![image](https://f.cloud.github.com/assets/225704/1703251/31dc1788-60b2-11e3-927d-1815f87468bf.png)

The only drawback was that the data collector was not storing the called host, so I also added it (as it can help debug on multi-node clusters) for HTTP and HTTPS transports. 
If another transport is used, I store NULL in the Logger.
