### PR TITLE
Removed duplicate methods

### DIFF
--- a/Persister/ObjectSerializerPersister.php
+++ b/Persister/ObjectSerializerPersister.php
@@ -24,69 +24,6 @@ class ObjectSerializerPersister extends ObjectPersister
     }
 
     /**
-     * Insert one object into the type
-     * The object will be transformed to an elastica document
-     *
-     * @param object $object
-     */
-    public function insertOne($object)
-    {
-        $document = $this->transformToElasticaDocument($object);
-        $this->type->addDocument($document);
-    }
-
-    /**
-     * Replaces one object in the type
-     *
-     * @param object $object
-     * @return null
-     */
-    public function replaceOne($object)
-    {
-        $document = $this->transformToElasticaDocument($object);
-        $this->type->deleteById($document->getId());
-        $this->type->addDocument($document);
-    }
-
-    /**
-     * Deletes one object in the type
-     *
-     * @param object $object
-     * @return null
-     **/
-    public function deleteOne($object)
-    {
-        $document = $this->transformToElasticaDocument($object);
-        $this->type->deleteById($document->getId());
-    }
-
-    /**
-     * Deletes one object in the type by id
-     *
-     * @param mixed $id
-     *
-     * @return null
-     **/
-    public function deleteById($id)
-    {
-        $this->type->deleteById($id);
-    }
-
-    /**
-     * Inserts an array of objects in the type
-     *
-     * @param array $objects array of domain model objects
-     **/
-    public function insertMany(array $objects)
-    {
-        $docs = array();
-        foreach ($objects as $object) {
-            $docs[] = $this->transformToElasticaDocument($object);
-        }
-        $this->type->addDocuments($docs);
-    }
-
-    /**
      * Transforms an object to an elastica document
      * with just the identifier set
      *


### PR DESCRIPTION
Removed some methods that were duplicates of the parent class (`Persister/ObjectSerializerPersister.php`) as discussed in https://github.com/FriendsOfSymfony/FOSElasticaBundle/commit/5b6a1f7bd656f6c8490035aa309334cdce415457#commitcomment-4849694
