### PR TITLE
Populate command: use isInteractive() instead of option

### DIFF
--- a/Command/PopulateCommand.php
+++ b/Command/PopulateCommand.php
@@ -67,10 +67,9 @@ class PopulateCommand extends ContainerAwareCommand
         $index         = $input->getOption('index');
         $type          = $input->getOption('type');
         $reset         = $input->getOption('no-reset') ? false : true;
-        $noInteraction = $input->getOption('no-interaction');
         $options       = $input->getOptions();
 
-        if (!$noInteraction && $reset && $input->getOption('offset')) {
+        if ($input->isInteractive() && $reset && $input->getOption('offset')) {
             /** @var DialogHelper $dialog */
             $dialog = $this->getHelperSet()->get('dialog');
             if (!$dialog->askConfirmation($output, '<question>You chose to reset the index and start indexing with an offset. Do you really want to do that?</question>', true)) {


### PR DESCRIPTION
Using `$input->getOption('no-interaction');` can cause problems ("[InvalidArgumentException] The "--no-interaction" option does not exist.") because the command itself does not define this option. IMHO using `$input->isInteractive()` is the proper way.
