### PR TITLE
Make fetchSlice compatible with custom repo method

### DIFF
--- a/Doctrine/ORM/Provider.php
+++ b/Doctrine/ORM/Provider.php
@@ -9,7 +9,7 @@ use FOS\ElasticaBundle\Exception\InvalidArgumentTypeException;
 class Provider extends AbstractProvider
 {
     const ENTITY_ALIAS = 'a';
-    
+
     /**
      * @see FOS\ElasticaBundle\Doctrine\AbstractProvider::countObjects()
      */
@@ -50,12 +50,13 @@ class Provider extends AbstractProvider
          */
         $orderBy = $queryBuilder->getDQLPart('orderBy');
         if (empty($orderBy)) {
+            $rootAliases = $queryBuilder->getRootAliases();
             $identifierFieldNames = $this->managerRegistry
                 ->getManagerForClass($this->objectClass)
                 ->getClassMetadata($this->objectClass)
                 ->getIdentifierFieldNames();
             foreach ($identifierFieldNames as $fieldName) {
-                $queryBuilder->addOrderBy(static::ENTITY_ALIAS.'.'.$fieldName);
+                $queryBuilder->addOrderBy($rootAliases[0].'.'.$fieldName);
             }
         }
 


### PR DESCRIPTION
If a user configures query_builder_method for the doctrine provider, and does not alias the root entity to equal `Provider::ENTITY_ALIAS` then a DQL error will occur during index population.

``` yaml
# config.yml
fos_elastica:
    # ...
    persistence:
        provider:
            query_builder_method: indexingQueryBuilder
```

``` php
<?php

class AcmeRepository
{
    public function indexingQueryBuilder()
    {
        $qb = $this->createQueryBuilder('acme');

        $qb
            ->addSelect('categories')
            ->leftJoin('acme.categories', 'categories')
        ;

        return $qb;
    }
}
```

Causes this error:

> [Semantical Error] [...] near 'a.id ASC': Error: 'a' is not defined.

This is because FOS\ElasticaBundle\Doctrine\ORM\Provider adds an orderBy statement in fetchSlices, but the alias is hard coded to the constant `Provider::ENTITY_ALIAS`. This is a regression over previous versions of the bundle (introduced in b11b4299ef58d3c964a227f889527f2c484cc2c3 9 months ago).

This PR makes the alias dynamic in the same way that `Provider::countObjects` handles the alias.
