### PR TITLE
Support for using finder semantic config with index_name

### DIFF
--- a/DependencyInjection/FOSElasticaExtension.php
+++ b/DependencyInjection/FOSElasticaExtension.php
@@ -133,7 +133,11 @@ class FOSElasticaExtension extends Extension
                 )
             );
             if ($index['finder']) {
-                $this->loadIndexFinder($container, $name, $indexId);
+                if ($name == $indexName) {
+                    $this->loadIndexFinder($container, $name, $indexId);
+                } else {
+                    $this->loadIndexFinder($container, $indexName, $indexIds[$indexName], $name);
+                }
             }
             if (!empty($index['settings'])) {
                 $this->indexConfigs[$name]['config']['settings'] = $index['settings'];
@@ -154,9 +158,10 @@ class FOSElasticaExtension extends Extension
      * @param \Symfony\Component\DependencyInjection\ContainerBuilder $container
      * @param string $name The index name
      * @param string $indexId The index service identifier
+     * @param string $alias The index_name finder can be used as
      * @return string
      */
-    protected function loadIndexFinder(ContainerBuilder $container, $name, $indexId)
+    protected function loadIndexFinder(ContainerBuilder $container, $name, $indexId, $alias = null)
     {
         /* Note: transformer services may conflict with "collection.index", if
          * an index and type names were "collection" and an index, respectively.
@@ -165,7 +170,7 @@ class FOSElasticaExtension extends Extension
         $transformerDef = new DefinitionDecorator('fos_elastica.elastica_to_model_transformer.collection');
         $container->setDefinition($transformerId, $transformerDef);
 
-        $finderId = sprintf('fos_elastica.finder.%s', $name);
+        $finderId = sprintf('fos_elastica.finder.%s', ($alias) ? $alias : $name);
         $finderDef = new DefinitionDecorator('fos_elastica.finder');
         $finderDef->replaceArgument(0, new Reference($indexId));
         $finderDef->replaceArgument(1, new Reference($transformerId));


### PR DESCRIPTION
In the docs, it says that you can use a finder for the [entire index](https://github.com/FriendsOfSymfony/FOSElasticaBundle/blob/master/Resources/doc/usage.md#searching-the-entire-index) and that you can use [index_name](https://github.com/FriendsOfSymfony/FOSElasticaBundle/blob/master/Resources/doc/setup.md#c-basic-bundle-configuration) to refer to the index via a different name.

However, these two options are currently mutually exclusive, as there is no ElasticaToModelTransformer available for a finder defined on the aliased index service.

ex:

``` yaml
fos_elastica:
    clients:
        default: { host: localhost, port: 9200 }
    indexes:

        # Index aliases
        content:
            client: default
            index_name: content_mywebsite
            finder: ~

        # Index definitions
        content_mywebsite:
            client: default
            finder: ~
            types:
            # ...
```

This PR adds support for using a finder on an aliased index service by adding an $alias parameter to loadIndexFinder() and adjusting the parameters if using the index_name semantic config option.
