### PR TITLE
Added support for getting documents in unified Doctrine Listener

### DIFF
--- a/Doctrine/Listener.php
+++ b/Doctrine/Listener.php
@@ -188,7 +188,6 @@ class Listener implements EventSubscriber
      */
     private function getDoctrineObject(EventArgs $eventArgs)
     {
-
         if (method_exists($eventArgs, 'getObject')) {
             return $eventArgs->getObject();
         } elseif (method_exists($eventArgs, 'getEntity')) {
@@ -198,7 +197,6 @@ class Listener implements EventSubscriber
         }
 
         throw new \RuntimeException('Unable to retrieve object from EventArgs.');
-
     }
 
     /**


### PR DESCRIPTION
Commit 1d700261abb7b7f39c56550cac0732e807240b35 unified a single Doctrine Listener class, but only has support for the ORM version of LifecycleEventArgs by explicitly calling getEntity. This PR adds support for the doctrine ODM LifecycleEventArgs. Using mongodb-odm results in an error in the Listener class pre/post event methods:

FatalErrorException: Error: Call to undefined method Doctrine\ODM\MongoDB\Event\LifecycleEventArgs::getEntity() in /my/app/vendor/friendsofsymfony/elastica-bundle/FOS/ElasticaBundle/Doctrine/Listener.php line 209
