### PR TITLE
Fix documentation about `immediate`

### DIFF
--- a/Resources/doc/types.md
+++ b/Resources/doc/types.md
@@ -270,9 +270,9 @@ FOSElasticaBundle, since 3.0.0 performs its indexing in the postFlush Doctrine e
 instead of prePersist and preUpdate which means that indexing will only occur when there
 has been a successful flush. This new default makes more sense but in the instance where
 you want to perform indexing before the flush is confirmed you may set the `immediate`
-option on a type persistence configuration to false.
+option on a type persistence configuration to `true`.
 
 ```yaml
                     persistence:
-                        immediate: false
+                        immediate: true
 ```


### PR DESCRIPTION
Unless I misimplemented this, "immediate" means persist to ElasticSearch "immediately"; before flushing.  Default behavior is false; persist to ElasticSearch postFlush.
