### PR TITLE
fix link to documentation of custom repositories

### DIFF
--- a/Resources/doc/usage.md
+++ b/Resources/doc/usage.md
@@ -101,7 +101,7 @@ $users = $repository->find('bob');
 ```
 
 For more information about customising repositories, see the cookbook entry
-[Custom Repositories](custom-repositories.md).
+[Custom Repositories](cookbook/custom-repositories.md).
 
 Using a custom query builder method for transforming results
 ------------------------------------------------------------


### PR DESCRIPTION
This link to documentation custom repositories is broken
