### PR TITLE
Fixes multiple updates on multiple flush executions

### DIFF
--- a/Doctrine/Listener.php
+++ b/Doctrine/Listener.php
@@ -258,17 +258,21 @@ class Listener implements EventSubscriber
 
     /**
      * Persist scheduled objects to ElasticSearch
+     * After persisting, clear the scheduled queue to prevent multiple data updates when using multiple flush calls
      */
     private function persistScheduled()
     {
         if (count($this->scheduledForInsertion)) {
             $this->objectPersister->insertMany($this->scheduledForInsertion);
+            $this->scheduledForInsertion = array();
         }
         if (count($this->scheduledForUpdate)) {
             $this->objectPersister->replaceMany($this->scheduledForUpdate);
+            $this->scheduledForUpdate = array();
         }
         if (count($this->scheduledForDeletion)) {
             $this->objectPersister->deleteManyByIdentifiers($this->scheduledForDeletion);
+            $this->scheduledForDeletion = array();
         }
     }
 


### PR DESCRIPTION
Imagine the following situation: 
I've got a sync with an external database, which syncs about 30.000 persons every night. The persons are also in the Elastic db for fast searching, and I want to update automatically when needed. However, the update to Elastic takes up more and more memory after every update, and executes every update multiple times. 

This is caused by the persistScheduled command. This is called on every flush execution, which is done a lot during our sync. But as the scheduled queue for persist/update/delete is not cleared after the persist action to Elastic, every flush command accumulates more and more updates which finally causes the script to run out of memory. 

This PR clears the scheduled list after the update is done. This should ensure much less memory usage and faster execution when using multiple flush commands. 
