### PR TITLE
Revert declaring PaginateElasticaQuerySubscriber as a parameter, so not to break Knp compiler pass

### DIFF
--- a/Resources/config/config.xml
+++ b/Resources/config/config.xml
@@ -11,7 +11,6 @@
         <parameter key="fos_elastica.index_manager.class">FOS\ElasticaBundle\IndexManager</parameter>
         <parameter key="fos_elastica.resetter.class">FOS\ElasticaBundle\Resetter</parameter>
         <parameter key="fos_elastica.finder.class">FOS\ElasticaBundle\Finder\TransformedFinder</parameter>
-        <parameter key="fos_elastica.paginator_subscriber.class">FOS\ElasticaBundle\Subscriber\PaginateElasticaQuerySubscriber</parameter>
         <parameter key="fos_elastica.logger.class">FOS\ElasticaBundle\Logger\ElasticaLogger</parameter>
         <parameter key="fos_elastica.data_collector.class">FOS\ElasticaBundle\DataCollector\ElasticaDataCollector</parameter>
         <parameter key="fos_elastica.manager.class">FOS\ElasticaBundle\Manager\RepositoryManager</parameter>
@@ -88,7 +87,7 @@
             </call>
         </service>
 
-        <service id="fos_elastica.paginator.subscriber" class="%fos_elastica.paginator_subscriber.class%">
+        <service id="fos_elastica.paginator.subscriber" class="FOS\ElasticaBundle\Subscriber\PaginateElasticaQuerySubscriber">
             <call method="setRequest">
                 <argument type="service" id="request" on-invalid="null" strict="false" />
             </call>


### PR DESCRIPTION
Read more about this change here https://github.com/FriendsOfSymfony/FOSElasticaBundle/pull/555#issuecomment-40887438
