### PR TITLE
stop config from adding empty arrays into type mappings

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -351,8 +351,16 @@ class Configuration implements ConfigurationInterface
             ->useAttributeAsKey('name')
             ->prototype('array')
                 ->validate()
-                ->ifTrue(function($v) { return isset($v['fields']) && empty($v['fields']); })
-                    ->then(function($v) { unset($v['fields']); return $v; })
+                    ->always()
+                    ->then(function($v) {
+                        foreach (array('fields','properties') as $prop) {
+                            if (isset($v[$prop]) && empty($v[$prop])) {
+                                unset($v[$prop]);
+                            }
+                        }
+                        
+                        return $v;
+                    })
                 ->end()
                 ->treatNullLike(array())
                 ->addDefaultsIfNotSet()
@@ -464,8 +472,16 @@ class Configuration implements ConfigurationInterface
                 ->useAttributeAsKey('name')
                 ->prototype('array')
                     ->validate()
-                        ->ifTrue(function($v) { return isset($v['fields']) && empty($v['fields']); })
-                        ->then(function($v) { unset($v['fields']); return $v; })
+                        ->always()
+                        ->then(function($v) {
+                            foreach (array('fields','properties') as $prop) {
+                                if (isset($v[$prop]) && empty($v[$prop])) {
+                                    unset($v[$prop]);
+                                }
+                            }
+
+                            return $v;
+                        })
                     ->end()
                     ->treatNullLike(array())
                     ->addDefaultsIfNotSet()

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -147,4 +147,60 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         $this->assertArrayNotHasKey('fields', $configuration['indexes']['test']['types']['test']['mappings']['children']['properties']['content']);
         $this->assertArrayHasKey('fields', $configuration['indexes']['test']['types']['test']['mappings']['children']['properties']['title']);
     }
+
+    public function testEmptyPropertiesIndexIsUnset()
+    {
+        $config = array(
+            'indexes' => array(
+                'test' => array(
+                    'types' => array(
+                        'test' => array(
+                            'mappings' => array(
+                                'title' => array(
+                                    'type' => 'string',
+                                    'fields' => array(
+                                        'autocomplete' => null
+                                    )
+                                ),
+                                'content' => null,
+                                'children' => array(
+                                    'type' => 'object',
+                                    'properties' => array(
+                                        'title' => array(
+                                            'type' => 'string',
+                                            'fields' => array(
+                                                'autocomplete' => null
+                                            )
+                                        ),
+                                        'content' => null,
+                                        'tags' => array(
+                                            'properties' => array(
+                                                'tag' => array(
+                                                    'type' => 'string',
+                                                    'index' => 'not_analyzed'
+                                                )
+                                            )
+                                        )
+                                    )
+                                ),
+                            )
+                        )
+                    )
+                )
+            )
+        );
+
+        $processor = new Processor();
+
+        $configuration = $processor->processConfiguration(new Configuration(array($config)), array($config));
+
+        $mapping = $configuration['indexes']['test']['types']['test']['mappings'];
+        $this->assertArrayNotHasKey('properties', $mapping['content']);
+        $this->assertArrayNotHasKey('properties', $mapping['title']);
+        $this->assertArrayHasKey('properties', $mapping['children']);
+        $this->assertArrayNotHasKey('properties', $mapping['children']['properties']['title']);
+        $this->assertArrayNotHasKey('properties', $mapping['children']['properties']['content']);
+        $this->assertArrayHasKey('properties', $mapping['children']['properties']['tags']);
+        $this->assertArrayNotHasKey('properties', $mapping['children']['properties']['tags']['properties']['tag']);
+    }
 }


### PR DESCRIPTION
Fix for #561

There may be other fields affected by this - I'm not sure, though.  If so, we should be able to just add them into the array of fields being scanned in each section.
