### PR TITLE
Changed QueryBuilder method from ->where() to ->andWhere() ...

### DIFF
--- a/Doctrine/ORM/ElasticaToModelTransformer.php
+++ b/Doctrine/ORM/ElasticaToModelTransformer.php
@@ -29,7 +29,7 @@ class ElasticaToModelTransformer extends AbstractElasticaToModelTransformer
         $hydrationMode = $hydrate ? Query::HYDRATE_OBJECT : Query::HYDRATE_ARRAY;
 
         $qb = $this->getEntityQueryBuilder();
-        $qb->where($qb->expr()->in(static::ENTITY_ALIAS.'.'.$this->options['identifier'], ':values'))
+        $qb->andWhere($qb->expr()->in(static::ENTITY_ALIAS.'.'.$this->options['identifier'], ':values'))
             ->setParameter('values', $identifierValues);
 
         return $qb->getQuery()->setHydrationMode($hydrationMode)->execute();


### PR DESCRIPTION
...so it works with customised QueryBuilders which have an existing where clause (instead of over-writing any existing DQL 'where' part).

Before this change if you create a customised querybuilder (e.g. through the `persistence.elastica_to_model_transformer.query_builder_method` config setting) and that QB contained a where clause then Elastica would over-write it causing a QueryException along the lines of "Invalid parameter number: number of bound variables does not match number of tokens".
