### PR TITLE
Make it possible to disable flush event through configuration

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -288,6 +288,7 @@ class Configuration implements ConfigurationInterface
                                     ->scalarNode('insert')->defaultTrue()->end()
                                     ->scalarNode('update')->defaultTrue()->end()
                                     ->scalarNode('delete')->defaultTrue()->end()
+                                    ->scalarNode('flush')->defaultTrue()->end()
                                     ->booleanNode('immediate')->defaultFalse()->end()
                                     ->scalarNode('logger')
                                         ->defaultFalse()

--- a/DependencyInjection/FOSElasticaExtension.php
+++ b/DependencyInjection/FOSElasticaExtension.php
@@ -465,9 +465,6 @@ class FOSElasticaExtension extends Extension
      */
     private function getDoctrineEvents(array $typeConfig)
     {
-        // Flush always calls depending on actions scheduled in lifecycle listeners
-        $typeConfig['listener']['flush'] = true;
-
         switch ($typeConfig['driver']) {
             case 'orm':
                 $eventsClass = '\Doctrine\ORM\Events';


### PR DESCRIPTION
This PR makes it possible again to disable the flush event. We are using a distributed way to index our entities which should not happen during postFlush. But there is no way to disable the behavior.
