### PR TITLE
Don't default url

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -96,7 +96,7 @@ class Configuration implements ConfigurationInterface
                                     ->children()
                                         ->scalarNode('url')
                                             ->validate()
-                                                ->ifTrue(function($url) { return substr($url, -1) !== '/'; })
+                                                ->ifTrue(function($url) { return $url && substr($url, -1) !== '/'; })
                                                 ->then(function($url) { return $url.'/'; })
                                             ->end()
                                         ->end()

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -219,4 +219,18 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         $this->assertArrayHasKey('properties', $mapping['children']['properties']['tags']);
         $this->assertArrayNotHasKey('properties', $mapping['children']['properties']['tags']['properties']['tag']);
     }
+
+    public function testClientConfigurationNoUrl()
+    {
+        $configuration = $this->getConfigs(array(
+            'clients' => array(
+                'default' => array(
+                    'host' => 'localhost',
+                    'port' => 9200,
+                ),
+            )
+        ));
+
+        $this->assertTrue(empty($configuration['clients']['default']['servers'][0]['url']));
+    }
 }


### PR DESCRIPTION
A recent change (6d2b7a836790dcb9ebe51e8f7ed606d560ef78bf) made it impossible to not use the `url` configuration for a client. Going without (only using `host` and `port`) would set `url` to just _/_, which would trigger the _Malformed URL_ exception in cURL.

The fix is simple though and I've provided a test to catch this error in the future.
