### PR TITLE
fixing missing flush event handler

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -654,6 +654,7 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('insert')->defaultTrue()->end()
                         ->scalarNode('update')->defaultTrue()->end()
                         ->scalarNode('delete')->defaultTrue()->end()
+                        ->scalarNode('flush')->defaultTrue()->end()
                         ->booleanNode('immediate')->defaultFalse()->end()
                         ->scalarNode('logger')
                             ->defaultFalse()


### PR DESCRIPTION
In [Move persistence node to its own method](https://github.com/FriendsOfSymfony/FOSElasticaBundle/commit/843c76b6cabd0fb71ef03cd95b9702e9dd41b2fc#diff-850942b3ba24ab03a40aaa81b6152852) the configuration-definition for the flush listener was accidentally removed. As the flush listener is no longer set to be enabled in the extensions getDoctrineEvents method by default, the flush listener is not set (and as we have

``` php
foreach ($eventMapping as $event => $doctrineEvents) {
           if (isset($typeConfig['listener'][$event]) && $typeConfig['listener'][$event]) {
                $events = array_merge($events, $doctrineEvents);
            }
        }
```

there is no way to get it set). 
This results in a situation were we are only able to have the modified objects on the list for index-update, but never actually sending the update to the ES host.
