### PR TITLE
make sure headers is set prior to accessing

### DIFF
--- a/Client.php
+++ b/Client.php
@@ -28,7 +28,7 @@ class Client extends ElasticaClient
                 'host'      => $connection->getHost(),
                 'port'      => $connection->getPort(),
                 'transport' => $connection->getTransport(),
-                'headers'   => $connection->hasConfig('headers')?$connection->getConfig('headers'):array(),
+                'headers'   => $connection->hasConfig('headers') ? $connection->getConfig('headers') : array(),
             );
 
             $this->_logger->logQuery($path, $method, $data, $time, $connection_array, $query);


### PR DESCRIPTION
We have a fallback Null Transport agent and get the following error if it used when logging is enabled.

[Elastica\Exception\InvalidException] Config key is not set: headers 

PR resolves this issue. 
