### PR TITLE
[FEATURE] Use static instantiation with max depth check

### DIFF
--- a/Serializer/Callback.php
+++ b/Serializer/Callback.php
@@ -43,7 +43,7 @@ class Callback
 
     public function serialize($object)
     {
-        $context = $this->serializer instanceof SerializerInterface ? new SerializationContext() : array();
+        $context = $this->serializer instanceof SerializerInterface ? SerializationContext::create()->enableMaxDepthChecks() : array();
 
         if ($this->groups) {
             $context->setGroups($this->groups);


### PR DESCRIPTION
I'm going to contact the guys from JMS Serializer aswell, since they also have locations where they instantiate a context without any parameters and i cannot figure out why you want this option to be disabled at all.

They've built in a nice feature for limiting the maximal depth of serialization.
This will not cause any harm at all, if its not used in the annotations (@JMS\MaxDepth)
But enabling this, will atleast make sure that depth limiting (exclusion pattern) works.
