### PR TITLE
Add stopwatch support for Elastica\Client

### DIFF
--- a/Resources/config/config.xml
+++ b/Resources/config/config.xml
@@ -16,6 +16,10 @@
         <service id="fos_elastica.client_prototype" class="%fos_elastica.client.class%" abstract="true">
             <argument type="collection" /> <!-- configuration -->
             <argument /> <!-- callback -->
+
+            <call method="setStopwatch">
+                <argument type="service" id="debug.stopwatch" />
+            </call>
         </service>
 
         <service id="fos_elastica.config_manager" class="FOS\ElasticaBundle\Configuration\ConfigManager">


### PR DESCRIPTION
Adds debugging stopwatch to the Client class which will add ES queries to the profiler timeline.
