### PR TITLE
Gracefully handle debug.stopwatch absence

### DIFF
--- a/Resources/config/config.xml
+++ b/Resources/config/config.xml
@@ -18,7 +18,7 @@
             <argument /> <!-- callback -->
 
             <call method="setStopwatch">
-                <argument type="service" id="debug.stopwatch" />
+                <argument type="service" id="debug.stopwatch" on-invalid="ignore" />
             </call>
         </service>
 


### PR DESCRIPTION
Without `on-invalid="ignore"` you'll get the following exception when debugging is off

```
[Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException]                               
  The service "fos_elastica.client.default" has a dependency on a non-existent service "debug.stopwatch"
```
