### PR TITLE
Issue: Parent is missing in the fields list that causes RoutingMissingEx...

### DIFF
--- a/DependencyInjection/FOSElasticaExtension.php
+++ b/DependencyInjection/FOSElasticaExtension.php
@@ -391,7 +391,13 @@ class FOSElasticaExtension extends Extension
             $arguments[] = array(new Reference($callbackId), 'serialize');
         } else {
             $abstractId = 'fos_elastica.object_persister';
-            $arguments[] = $this->indexConfigs[$indexName]['types'][$typeName]['mapping']['properties'];
+            $mapping = $this->indexConfigs[$indexName]['types'][$typeName]['mapping'];
+            $argument = $mapping['properties'];
+            if(isset($mapping['_parent'])){
+                $argument['_parent'] = $mapping['_parent'];
+            }
+            $arguments[] = $argument;
+
         }
 
         $serviceId = sprintf('fos_elastica.object_persister.%s.%s', $indexName, $typeName);

--- a/Tests/Functional/DependencyInjection/FOSElasticaExtensionTest.php
+++ b/Tests/Functional/DependencyInjection/FOSElasticaExtensionTest.php
@@ -1,0 +1,36 @@
+<?php
+
+
+namespace FOS\ElasticaBundle\Tests\Functional\DependencyInjection;
+
+
+use FOS\ElasticaBundle\DependencyInjection\FOSElasticaExtension;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\Yaml\Yaml;
+
+class FOSElasticaExtensionTest extends \PHPUnit_Framework_TestCase
+{
+
+    /**
+     * @test
+     */
+    public function shouldAddParentParamToObjectPersisterCall()
+    {
+
+        $config = Yaml::parse(file_get_contents(__DIR__.'/config/config.yml'));
+
+        $containerBuilder = new ContainerBuilder;
+        $containerBuilder->setParameter('kernel.debug', true);
+
+        $extension = new FOSElasticaExtension;
+
+        $extension->load($config, $containerBuilder);
+
+        $this->assertTrue($containerBuilder->hasDefinition('fos_elastica.object_persister.test_index.child_field'));
+
+        $persisterCallDefinition = $containerBuilder->getDefinition('fos_elastica.object_persister.test_index.child_field');
+
+        $this->assertArrayHasKey('_parent', $persisterCallDefinition->getArguments()['index_3']);
+    }
+
+} 

--- a/Tests/Functional/DependencyInjection/FOSElasticaExtensionTest.php
+++ b/Tests/Functional/DependencyInjection/FOSElasticaExtensionTest.php
@@ -30,7 +30,8 @@ class FOSElasticaExtensionTest extends \PHPUnit_Framework_TestCase
 
         $persisterCallDefinition = $containerBuilder->getDefinition('fos_elastica.object_persister.test_index.child_field');
 
-        $arguments = $persisterCallDefinition->getArguments()['index_3'];
+        $arguments = $persisterCallDefinition->getArguments();
+        $arguments = $arguments['index_3'];
 
         $this->assertArrayHasKey('_parent', $arguments);
         $this->assertEquals('parent_field', $arguments['_parent']['type']);

--- a/Tests/Functional/DependencyInjection/FOSElasticaExtensionTest.php
+++ b/Tests/Functional/DependencyInjection/FOSElasticaExtensionTest.php
@@ -30,7 +30,10 @@ class FOSElasticaExtensionTest extends \PHPUnit_Framework_TestCase
 
         $persisterCallDefinition = $containerBuilder->getDefinition('fos_elastica.object_persister.test_index.child_field');
 
-        $this->assertArrayHasKey('_parent', $persisterCallDefinition->getArguments()['index_3']);
+        $arguments = $persisterCallDefinition->getArguments()['index_3'];
+
+        $this->assertArrayHasKey('_parent', $arguments);
+        $this->assertEquals('parent_field', $arguments['_parent']['type']);
     }
 
 } 

--- a/Tests/Functional/DependencyInjection/config/config.yml
+++ b/Tests/Functional/DependencyInjection/config/config.yml
@@ -1,0 +1,21 @@
+fos_elastica:
+    clients:
+        default:
+            url: http://localhost:9200
+    indexes:
+        test_index:
+            client: default
+            types:
+                parent_field:
+                    mappings:
+                        text: ~
+                    persistence:
+                        driver: orm
+                        model: foo_model
+                child_field:
+                    mappings:
+                        text: ~
+                    persistence:
+                        driver: orm
+                        model: foo_model
+                    _parent: { type: "parent_field", property: "parent" }


### PR DESCRIPTION
...ception on flushing

Having config:

```
                extra_field:
                    mappings:
                        text: ~
                        title: ~
                    _parent: { type: "user", property: "owner", identifier: "id" }
                    persistence:
                        driver: orm
                        model: Foo\CoreBundle\Entity\ExtraInfo
                        provider: ~
                        listener: ~
                        finder: ~
```

When building the project getting an exception on fixture loading when flushing ExtraInfo: 
```                                                                                      
  [Elastica\Exception\ResponseException]                                                
  RoutingMissingException[routing is required for [foo_dev]/[extra_field]/[1]] 
```

The  problem was that ObjectPersister got only the entity fields without the _parent field.
The reason was that the service in the ProjectContainer was generated incorrectly.

I'm not sure it's the best way to fix, please correct me if I'm wrong.

Closes #774 