### PR TITLE
Return repository in Manager Class MongoDB

### DIFF
--- a/Doctrine/MongoDB/ElasticaToModelTransformer.php
+++ b/Doctrine/MongoDB/ElasticaToModelTransformer.php
@@ -22,6 +22,7 @@ class ElasticaToModelTransformer extends AbstractElasticaToModelTransformer
     {
         return $this->registry
             ->getManagerForClass($this->objectClass)
+            ->getRepository($this->objectClass)
             ->{$this->options['query_builder_method']}($this->objectClass)
             ->field($this->options['identifier'])->in($identifierValues)
             ->hydrate($hydrate)


### PR DESCRIPTION
With doctrine mongodb and configuration:

```
persistence:
    driver: mongodb
    model: Vivados\Bundle\MainBundle\Document\Property
    elastica_to_model_transformer:
       ignore_missing: true
       query_builder_method: createSearchQueryBuilder
```

the following error occurs:
Call to undefined method Doctrine\ODM\MongoDB\DocumentManager::createSearchQueryBuilder()

If i add the method ->getRepository($this->objectClass) this issue disappears.
