### PR TITLE
Ensure Doctrine objects with collection (ReferenceMany) changes are updated in Elasticsearch

### DIFF
--- a/Doctrine/Listener.php
+++ b/Doctrine/Listener.php
@@ -215,12 +215,8 @@ class Listener implements EventSubscriber
      * Provides a unified method for scheduling Doctrine objects with collection changes (e.g. ReferenceMany) to be
      * updated in Elasticsearch
      *
-     * Note: The PersistentCollection class for both the Doctrine ORM and the MongoDB ODM contain the 'getOwner'
-     * method. Be that as it may, the Doctrine\Common\Collections\Collection interface does not strictly
-     * require/define this method. As such, the method_exists() check is used
-     *
      * @param   EventArgs           $eventArgs
-     * @return  UnitOfWork          An instance implementing ObjectManager
+     * @return  void
      */
     private function scheduleObjectsWithCollectionChanges(EventArgs $eventArgs)
     {
@@ -233,13 +229,9 @@ class Listener implements EventSubscriber
     /**
      * Provides a unified method for retrieving a set of collection changes from the Doctrine UnitOfWork
      *
-     * Note: The UnitOfWork class for both the Doctrine ORM and the MongoDB ODM contain these methods.
-     * Be that as it may, no Doctrine\Common interface exists for the UnitOfWork, so these methods are not strictly
-     * required/defined. As such, the method_exists() check is used
      *
-     * @param   EventArgs           $eventArgs
-     * @return  UnitOfWork          An instance implementing ObjectManager
-     * @throws  \RuntimeException   if no valid getter is found.
+     * @param   EventArgs  $eventArgs
+     * @return  array      An array of PersistentCollection objects
      */
     private function getCollectionChanges(EventArgs $eventArgs)
     {

--- a/Tests/Doctrine/AbstractListenerTest.php
+++ b/Tests/Doctrine/AbstractListenerTest.php
@@ -64,7 +64,7 @@ abstract class ListenerTest extends \PHPUnit_Framework_TestCase
 
         $persister->expects($this->once())
             ->method('replaceMany')
-            ->with(array($entity));
+            ->with(array(spl_object_hash($entity) => $entity));
         $persister->expects($this->never())
             ->method('deleteById');
 
@@ -102,7 +102,7 @@ abstract class ListenerTest extends \PHPUnit_Framework_TestCase
             ->method('replaceOne');
         $persister->expects($this->once())
             ->method('deleteManyByIdentifiers')
-            ->with(array($entity->getId()));
+            ->with(array(spl_object_hash($entity) => $entity->getId()));
 
         $postFlushEventArgs = $this->createPostFlushEventArgs($this->getMockObjectManager());
         $listener->postFlush($postFlushEventArgs);
@@ -135,7 +135,7 @@ abstract class ListenerTest extends \PHPUnit_Framework_TestCase
 
         $persister->expects($this->once())
             ->method('deleteManyByIdentifiers')
-            ->with(array($entity->getId()));
+            ->with(array(spl_object_hash($entity) => $entity->getId()));
 
         $postFlushEventArgs = $this->createPostFlushEventArgs($this->getMockObjectManager());
         $listener->postFlush($postFlushEventArgs);
@@ -169,7 +169,7 @@ abstract class ListenerTest extends \PHPUnit_Framework_TestCase
 
         $persister->expects($this->once())
             ->method('deleteManyByIdentifiers')
-            ->with(array($entity->identifier));
+            ->with(array(spl_object_hash($entity) => $entity->identifier));
 
         $postFlushEventArgs = $this->createPostFlushEventArgs($this->getMockObjectManager());
         $listener->postFlush($postFlushEventArgs);

--- a/Tests/Doctrine/MongoDB/ListenerTest.php
+++ b/Tests/Doctrine/MongoDB/ListenerTest.php
@@ -23,6 +23,11 @@ class ListenerTest extends BaseListenerTest
         return 'Doctrine\ODM\MongoDB\Event\LifecycleEventArgs';
     }
 
+    protected function getPostFlushEventArgsClass()
+    {
+        return 'Doctrine\ODM\MongoDB\Event\PostFlushEventArgs';
+    }
+
     protected function getListenerClass()
     {
         return 'FOS\ElasticaBundle\Doctrine\Listener';
@@ -31,5 +36,10 @@ class ListenerTest extends BaseListenerTest
     protected function getObjectManagerClass()
     {
         return 'Doctrine\ODM\MongoDB\DocumentManager';
+    }
+
+    protected function getUnitOfWorkClass()
+    {
+        return 'Doctrine\ODM\MongoDB\UnitOfWork';
     }
 }

--- a/Tests/Doctrine/ORM/ListenerTest.php
+++ b/Tests/Doctrine/ORM/ListenerTest.php
@@ -23,6 +23,11 @@ class ListenerTest extends BaseListenerTest
         return 'Doctrine\ORM\Event\LifecycleEventArgs';
     }
 
+    protected function getPostFlushEventArgsClass()
+    {
+        return 'Doctrine\ORM\Event\PostFlushEventArgs';
+    }
+
     protected function getListenerClass()
     {
         return 'FOS\ElasticaBundle\Doctrine\Listener';
@@ -31,5 +36,10 @@ class ListenerTest extends BaseListenerTest
     protected function getObjectManagerClass()
     {
         return 'Doctrine\ORM\EntityManager';
+    }
+
+    protected function getUnitOfWorkClass()
+    {
+        return 'Doctrine\ORM\UnitOfWork';
     }
 }


### PR DESCRIPTION
This PR adds support to the Doctrine Listener to ensure that when a Collection (e.g. ReferenceMany) is modified on an Object (Entity/Document) it is updated in Elasticsearch.

Use case:
- If Object A has a ReferenceMany that is modified (added to or removed from) it currently doesn't schedule an Elasticsearch update for Object A.
- This is because the UnitOfWork does not fire a postUpdate event on changes to collections, but rather must be processed postFlush as a Collection Update or Removal.

The update and insertion logic for scheduling an Object was moved into their own methods for reusability. These methods also now key the scheduled Object by its spl_object_hash. This was done to ensure that if an Object has multiple collection changes it is only sent to the ObjectPersister once.

Similar to @solocommand's getDoctrineObject, the getObjectManager, getUnitOfWork, and getCollectionChanges methods ensure that the appropriate getter is used to retrieve the corresponding service. These utilize method_exists checks since the interfaces don't define the methods (though they exist in both the ORM and ODM versions). Please view in-line docblocks for more information.