### PR TITLE
Configuration Bug: Restored noDeepMerging

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -73,6 +73,7 @@ class Configuration implements ConfigurationInterface
                 ->arrayNode('clients')
                     ->useAttributeAsKey('id')
                     ->prototype('array')
+                        ->performNoDeepMerging()
                         // BC - Renaming 'servers' node to 'connections'
                         ->beforeNormalization()
                         ->ifTrue(function($v) { return isset($v['servers']); })


### PR DESCRIPTION
When performNoDeepMerging is not used, Symfony environment-specific server configurations no longer work.

Example:

```
# config.yml
fos_elastica:
    clients:
        default:
            servers:
                - { host: develastic01.mydomain.com, port: 9200 }
```

```
# confg_prod.yml

fos_elastica:
    clients:
        default:
            servers:
                - { host: elasticvm01.mydomain.com, port: 9200, logger: true }
                - { host: elasticvm02.mydomain.com, port: 9200, logger: true }
```

In the production environment this results in all three servers being used (with the development server being hit first). This changed in 55dcf6859ab9616028d2da2355b581737efb3802 (Jul 3 @merk).

Before this change, the server default configuration in the production environment was overwritten with the two values specified in the production config.
