### PR TITLE
[DX] changing AliasProcessor::setRootName, so to use "Y-m-d-Gis" instead of random string

### DIFF
--- a/Index/AliasProcessor.php
+++ b/Index/AliasProcessor.php
@@ -26,7 +26,12 @@ class AliasProcessor
      */
     public function setRootName(IndexConfig $indexConfig, Index $index)
     {
-        $index->overrideName(sprintf('%s_%s', $indexConfig->getElasticSearchName(), uniqid()));
+        $index->overrideName(
+            sprintf('%s_%s',
+                $indexConfig->getElasticSearchName(),
+                date('Y-m-d-Gis')
+            )
+        );
     }
 
     /**
@@ -116,7 +121,9 @@ class AliasProcessor
     /**
      * Returns array of indexes which are mapped to given alias
      *
+     * @param Client $client
      * @param string $aliasName Alias name
+     *
      * @return array
      */
     private function getAliasedIndexes(Client $client, $aliasName)


### PR DESCRIPTION
This is DX PR to improve index naming.

When I am viewing `/_plugin/head/` or any other plugins for ES, I as developer wanna see more verbose index name. 
So instead `<my-index-name>_53e4714c70333`, I'll see `<my-index-name_2014-08-08-94949>` which represent time of index creating, this could be useful for emergency cases when you need switch alias back to old index ASAP.
