### PR TITLE
fix dependency on elastic extension

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "symfony/console": "~2.1",
         "symfony/form": "~2.1",
         "symfony/property-access": "~2.2",
-        "ruflin/elastica": ">=0.90.10, <1.4.0",
+        "ruflin/elastica": ">=0.90.10, <1.4-dev",
         "psr/log": "~1.0"
     },
     "require-dev":{


### PR DESCRIPTION
i had a weird error in which just installing the bundle with "friendsofsymfony/elastica-bundle":     "~3.0.2",
game me a version back even before it had a composer! :blush:
i checked and found out composer gets really confused or glitchy with packages not following semver.
In any case 1.3.0 is out, and i remove the 4th digit which i think composer ignores totally or gets confused about.
