### PR TITLE
Use the new Search annotation

### DIFF
--- a/Manager/RepositoryManager.php
+++ b/Manager/RepositoryManager.php
@@ -59,7 +59,7 @@ class RepositoryManager implements RepositoryManagerInterface
         }
 
         $refClass   = new \ReflectionClass($entityName);
-        $annotation = $this->reader->getClassAnnotation($refClass, 'FOS\\ElasticaBundle\\Configuration\\Search');
+        $annotation = $this->reader->getClassAnnotation($refClass, 'FOS\\ElasticaBundle\\Annotation\\Search');
         if ($annotation) {
             $this->entities[$entityName]['repositoryName']
                 = $annotation->repositoryClass;

--- a/Resources/doc/cookbook/custom-repositories.md
+++ b/Resources/doc/cookbook/custom-repositories.md
@@ -58,7 +58,7 @@ Alternatively you can specify the custom repository using an annotation in the e
 
 namespace Application\UserBundle\Entity;
 
-use FOS\ElasticaBundle\Configuration\Search;
+use FOS\ElasticaBundle\Annotation\Search;
 
 /**
  * @Search(repositoryClass="Acme\ElasticaBundle\SearchRepository\UserRepository")


### PR DESCRIPTION
Use "FOS\ElasticaBundle\Annotation\Search" instead of "FOS\ElasticaBundle\Configuration\Search" in the repository manager.
Update the cookbook

fix issue #693
