### PR TITLE
Scrutinizer Auto-Fixes

### DIFF
--- a/Configuration/ManagerInterface.php
+++ b/Configuration/ManagerInterface.php
@@ -27,7 +27,7 @@ interface ManagerInterface
     /**
      * Returns an array of known index names.
      *
-     * @return array
+     * @return integer[]
      */
     public function getIndexNames();
 

--- a/Configuration/TypeConfig.php
+++ b/Configuration/TypeConfig.php
@@ -77,6 +77,9 @@ class TypeConfig
         return $this->getConfig('search_analyzer');
     }
 
+    /**
+     * @param string $key
+     */
     private function getConfig($key)
     {
         return isset($this->config[$key]) ?

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -30,7 +30,7 @@ class Configuration implements ConfigurationInterface
     /**
      * Generates the configuration tree.
      *
-     * @return \Symfony\Component\Config\Definition\NodeInterface
+     * @return TreeBuilder
      */
     public function getConfigTreeBuilder()
     {

--- a/DependencyInjection/FOSElasticaExtension.php
+++ b/DependencyInjection/FOSElasticaExtension.php
@@ -82,7 +82,7 @@ class FOSElasticaExtension extends Extension
     /**
      * @param array $config
      * @param ContainerBuilder $container
-     * @return Configuration|null|\Symfony\Component\Config\Definition\ConfigurationInterface
+     * @return Configuration
      */
     public function getConfiguration(array $config, ContainerBuilder $container)
     {
@@ -523,7 +523,7 @@ class FOSElasticaExtension extends Extension
      *
      * @param array $typeConfig
      * @param ContainerBuilder $container
-     * @param $elasticaToModelId
+     * @param string $elasticaToModelId
      * @param Reference $typeRef
      * @param string $indexName
      * @param string $typeName

--- a/Doctrine/ORM/Provider.php
+++ b/Doctrine/ORM/Provider.php
@@ -3,7 +3,6 @@
 namespace FOS\ElasticaBundle\Doctrine\ORM;
 
 use Doctrine\ORM\QueryBuilder;
-use Elastica\Exception\Bulk\ResponseException as BulkResponseException;
 use FOS\ElasticaBundle\Doctrine\AbstractProvider;
 use FOS\ElasticaBundle\Exception\InvalidArgumentTypeException;
 

--- a/Elastica/Client.php
+++ b/Elastica/Client.php
@@ -31,6 +31,8 @@ class Client extends BaseClient
 
     /**
      * {@inheritdoc}
+     * @param string $path
+     * @param string $method
      */
     public function request($path, $method = Request::GET, $data = array(), array $query = array())
     {

--- a/Elastica/Index.php
+++ b/Elastica/Index.php
@@ -3,7 +3,6 @@
 namespace FOS\ElasticaBundle\Elastica;
 
 use Elastica\Index as BaseIndex;
-use Elastica\Type;
 
 /**
  * Overridden Elastica Index class that provides dynamic index name changes.
@@ -32,6 +31,9 @@ class Index extends BaseIndex
         return $this->originalName ?: $this->_name;
     }
 
+    /**
+     * @param string $type
+     */
     public function getType($type)
     {
         if (isset($this->typeCache[$type])) {

--- a/Exception/InvalidArgumentTypeException.php
+++ b/Exception/InvalidArgumentTypeException.php
@@ -4,6 +4,9 @@ namespace FOS\ElasticaBundle\Exception;
 
 class InvalidArgumentTypeException extends \InvalidArgumentException
 {
+    /**
+     * @param string $expectedType
+     */
     public function __construct($value, $expectedType)
     {
         parent::__construct(sprintf('Expected argument of type "%s", "%s" given', $expectedType, is_object($value) ? get_class($value) : gettype($value)));

--- a/Finder/TransformedFinder.php
+++ b/Finder/TransformedFinder.php
@@ -66,7 +66,7 @@ class TransformedFinder implements PaginatedFinderInterface
      * @param $query
      * @param null|int $limit
      * @param array $options
-     * @return array
+     * @return \Elastica\Result[]
      */
     protected function search($query, $limit = null, $options = array())
     {

--- a/Index/Resetter.php
+++ b/Index/Resetter.php
@@ -5,9 +5,7 @@ namespace FOS\ElasticaBundle\Index;
 use Elastica\Index;
 use Elastica\Exception\ResponseException;
 use Elastica\Type\Mapping;
-use FOS\ElasticaBundle\Configuration\IndexConfig;
 use FOS\ElasticaBundle\Configuration\ConfigManager;
-use FOS\ElasticaBundle\Elastica\Client;
 
 /**
  * Deletes and recreates indexes
@@ -109,7 +107,7 @@ class Resetter
     /**
      * A command run when a population has finished.
      *
-     * @param $indexName
+     * @param string $indexName
      */
     public function postPopulate($indexName)
     {

--- a/Manager/RepositoryManager.php
+++ b/Manager/RepositoryManager.php
@@ -69,6 +69,9 @@ class RepositoryManager implements RepositoryManagerInterface
         return 'FOS\ElasticaBundle\Repository';
     }
 
+    /**
+     * @param string $entityName
+     */
     private function createRepository($entityName)
     {
         if (!class_exists($repositoryName = $this->getRepositoryName($entityName))) {

--- a/Manager/RepositoryManagerInterface.php
+++ b/Manager/RepositoryManagerInterface.php
@@ -20,6 +20,7 @@ interface RepositoryManagerInterface
      * @param string $entityName
      * @param        $finder
      * @param string $repositoryName
+     * @return void
      */
     public function addEntity($entityName, FinderInterface $finder, $repositoryName = null);
 

--- a/Paginator/RawPaginatorAdapter.php
+++ b/Paginator/RawPaginatorAdapter.php
@@ -54,8 +54,8 @@ class RawPaginatorAdapter implements PaginatorAdapterInterface
     /**
      * Returns the paginated results.
      *
-     * @param $offset
-     * @param $itemCountPerPage
+     * @param integer $offset
+     * @param integer $itemCountPerPage
      * @throws \InvalidArgumentException
      * @return ResultSet
      */

--- a/Persister/ObjectPersister.php
+++ b/Persister/ObjectPersister.php
@@ -4,7 +4,6 @@ namespace FOS\ElasticaBundle\Persister;
 
 use Psr\Log\LoggerInterface;
 use Elastica\Exception\BulkException;
-use Elastica\Exception\NotFoundException;
 use FOS\ElasticaBundle\Transformer\ModelToElasticaTransformerInterface;
 use Elastica\Type;
 use Elastica\Document;

--- a/Persister/ObjectPersisterInterface.php
+++ b/Persister/ObjectPersisterInterface.php
@@ -15,6 +15,7 @@ interface ObjectPersisterInterface
      * The object will be transformed to an elastica document
      *
      * @param object $object
+     * @return void
      */
     function insertOne($object);
 
@@ -45,6 +46,7 @@ interface ObjectPersisterInterface
      * Bulk inserts an array of objects in the type
      *
      * @param array $objects array of domain model objects
+     * @return void
      */
     function insertMany(array $objects);
 
@@ -52,6 +54,7 @@ interface ObjectPersisterInterface
      * Bulk updates an array of objects in the type
      *
      * @param array $objects array of domain model objects
+     * @return void
      */
     function replaceMany(array $objects);
 
@@ -59,6 +62,7 @@ interface ObjectPersisterInterface
      * Bulk deletes an array of objects in the type
      *
      * @param array $objects array of domain model objects
+     * @return void
      */
     function deleteMany(array $objects);
 
@@ -66,6 +70,7 @@ interface ObjectPersisterInterface
      * Bulk deletes records from an array of identifiers
      *
      * @param array $identifiers array of domain model object identifiers
+     * @return void
      */
     public function deleteManyByIdentifiers(array $identifiers);
 }

--- a/Persister/ObjectSerializerPersister.php
+++ b/Persister/ObjectSerializerPersister.php
@@ -17,6 +17,9 @@ class ObjectSerializerPersister extends ObjectPersister
 {
     protected $serializer;
 
+    /**
+     * @param string $objectClass
+     */
     public function __construct(Type $type, ModelToElasticaTransformerInterface $transformer, $objectClass, $serializer)
     {
         parent::__construct($type, $transformer, $objectClass, array());

--- a/Propel/ElasticaToModelTransformer.php
+++ b/Propel/ElasticaToModelTransformer.php
@@ -170,6 +170,7 @@ class ElasticaToModelTransformer implements ElasticaToModelTransformerInterface
 
     /**
      * @see https://github.com/doctrine/common/blob/master/lib/Doctrine/Common/Util/Inflector.php
+     * @param string $str
      */
     private function camelize($str)
     {

--- a/Repository.php
+++ b/Repository.php
@@ -19,21 +19,35 @@ class Repository
         $this->finder = $finder;
     }
 
+    /**
+     * @param string $query
+     * @param integer $limit
+     */
     public function find($query, $limit = null, $options = array())
     {
         return $this->finder->find($query, $limit, $options);
     }
 
+    /**
+     * @param string $query
+     * @param integer $limit
+     */
     public function findHybrid($query, $limit = null, $options = array())
     {
         return $this->finder->findHybrid($query, $limit, $options);
     }
 
+    /**
+     * @param string $query
+     */
     public function findPaginated($query, $options = array())
     {
         return $this->finder->findPaginated($query, $options);
     }
 
+    /**
+     * @param string $query
+     */
     public function createPaginatorAdapter($query, $options = array())
     {
         return $this->finder->createPaginatorAdapter($query, $options);

--- a/Tests/Doctrine/AbstractListenerTest.php
+++ b/Tests/Doctrine/AbstractListenerTest.php
@@ -173,8 +173,14 @@ abstract class ListenerTest extends \PHPUnit_Framework_TestCase
 
     abstract protected function getListenerClass();
 
+    /**
+     * @return string
+     */
     abstract protected function getObjectManagerClass();
 
+    /**
+     * @return string
+     */
     abstract protected function getClassMetadataClass();
 
     private function createLifecycleEventArgs()
@@ -205,6 +211,11 @@ abstract class ListenerTest extends \PHPUnit_Framework_TestCase
             ->getMock();
     }
 
+    /**
+     * @param Listener\Entity $object
+     * @param string $indexName
+     * @param string $typeName
+     */
     private function getMockPersister($object, $indexName, $typeName)
     {
         $mock = $this->getMockBuilder('FOS\ElasticaBundle\Persister\ObjectPersister')
@@ -235,6 +246,12 @@ abstract class ListenerTest extends \PHPUnit_Framework_TestCase
         return $mock;
     }
 
+    /**
+     * @param string $indexName
+     * @param string $typeName
+     * @param Listener\Entity $object
+     * @param boolean $return
+     */
     private function getMockIndexable($indexName, $typeName, $object, $return = null)
     {
         $mock = $this->getMock('FOS\ElasticaBundle\Provider\IndexableInterface');
@@ -256,6 +273,9 @@ class Entity
 {
     private $id;
 
+    /**
+     * @param integer $id
+     */
     public function __construct($id)
     {
         $this->id = $id;

--- a/Tests/Doctrine/AbstractProviderTest.php
+++ b/Tests/Doctrine/AbstractProviderTest.php
@@ -214,7 +214,7 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @return \FOS\ElasticaBundle\Doctrine\AbstractProvider|\PHPUnit_Framework_MockObject_MockObject
+     * @return \PHPUnit_Framework_MockObject_MockObject
      */
     private function getMockAbstractProvider()
     {

--- a/Tests/FOSElasticaBundleTest.php
+++ b/Tests/FOSElasticaBundleTest.php
@@ -3,7 +3,6 @@
 namespace FOS\ElasticaBundle\Tests\Resetter;
 
 use FOS\ElasticaBundle\FOSElasticaBundle;
-use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 
 class FOSElasticaBundleTest extends \PHPUnit_Framework_TestCase
 {

--- a/Tests/Logger/ElasticaLoggerTest.php
+++ b/Tests/Logger/ElasticaLoggerTest.php
@@ -22,7 +22,7 @@ class ElasticaLoggerTest extends \PHPUnit_Framework_TestCase
     /**
      * @param string $level
      * @param string $message
-     * @param array $context
+     * @param string[] $context
      * @return ElasticaLogger
      */
     private function getMockLoggerForLevelMessageAndContext($level, $message, $context)

--- a/Tests/Persister/ObjectSerializerPersisterTest.php
+++ b/Tests/Persister/ObjectSerializerPersisterTest.php
@@ -2,9 +2,7 @@
 
 namespace FOS\ElasticaBundle\Tests\ObjectSerializerPersister;
 
-use FOS\ElasticaBundle\Persister\ObjectPersister;
 use FOS\ElasticaBundle\Persister\ObjectSerializerPersister;
-use FOS\ElasticaBundle\Transformer\ModelToElasticaAutoTransformer;
 use FOS\ElasticaBundle\Transformer\ModelToElasticaIdentifierTransformer;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 

--- a/Tests/Transformer/ElasticaToModelTransformerCollectionTest.php
+++ b/Tests/Transformer/ElasticaToModelTransformerCollectionTest.php
@@ -157,6 +157,9 @@ class POPO
     public $id;
     public $data;
 
+    /**
+     * @param integer $id
+     */
     public function __construct($id, $data)
     {
         $this->data = $data;

--- a/Transformer/ModelToElasticaIdentifierTransformer.php
+++ b/Transformer/ModelToElasticaIdentifierTransformer.php
@@ -13,7 +13,7 @@ class ModelToElasticaIdentifierTransformer extends ModelToElasticaAutoTransforme
     /**
      * Creates an elastica document with the id of the doctrine object as id
      *
-     * @param object $object the object to convert
+     * @param \FOS\ElasticaBundle\Tests\Transformer\ModelToElasticaIdentifierTransformer\POPO $object the object to convert
      * @param array  $fields the keys we want to have in the returned array
      *
      * @return Document


### PR DESCRIPTION
@merk requested this pull request.

This patch was automatically generated as part of the following inspection:
https://scrutinizer-ci.com/g/FriendsOfSymfony/FOSElasticaBundle/inspections/e8d87377-9526-4728-908c-33ebef9402ca

Enabled analysis tools:
- PHP Analyzer
- PHP PDepend
- External Code Coverage
- PHP Similarity Analyzer
- PHP Change Tracking Analyzer
