### PR TITLE
Allow elastica dependency based on semver

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "symfony/console": "~2.1",
         "symfony/form": "~2.1",
         "symfony/property-access": "~2.2",
-        "ruflin/elastica": ">=0.90.10.0, <1.4-dev",
+        "ruflin/elastica": ">=0.90.10.0, <2.0-dev",
         "psr/log": "~1.0"
     },
     "require-dev":{


### PR DESCRIPTION
Considering semantic version, just allow any 1.\* version. Otherwise we would need to increase this restriction with every minor version elastica releases. See https://github.com/FriendsOfSymfony/FOSElasticaBundle/commit/33ee047f83175ada2ef471db8ce5f8e5ab4a6050

Please also make a new tag.
