### PR TITLE
fix warning if no aliases

### DIFF
--- a/Index/AliasProcessor.php
+++ b/Index/AliasProcessor.php
@@ -125,9 +125,11 @@ class AliasProcessor
         $aliasedIndexes = array();
 
         foreach ($aliasesInfo as $indexName => $indexInfo) {
-            $aliases = array_keys($indexInfo['aliases']);
-            if (in_array($aliasName, $aliases)) {
-                $aliasedIndexes[] = $indexName;
+            if (isset($indexInfo['aliases'])) {
+                $aliases = array_keys($indexInfo['aliases']);
+                if (in_array($aliasName, $aliases)) {
+                    $aliasedIndexes[] = $indexName;
+                }
             }
         }
 


### PR DESCRIPTION
PHP Warning:  array_keys() expects parameter 1 to be array, AliasProcessor.php on line 128
