### PR TITLE
Ability to delete an index if expecting an alias

### DIFF
--- a/Command/ResetCommand.php
+++ b/Command/ResetCommand.php
@@ -33,6 +33,7 @@ class ResetCommand extends ContainerAwareCommand
             ->setName('fos:elastica:reset')
             ->addOption('index', null, InputOption::VALUE_OPTIONAL, 'The index to reset')
             ->addOption('type', null, InputOption::VALUE_OPTIONAL, 'The type to reset')
+            ->addOption('force', null, InputOption::VALUE_NONE, 'Force index deletion if same name as alias')
             ->setDescription('Reset search indexes')
         ;
     }
@@ -53,6 +54,7 @@ class ResetCommand extends ContainerAwareCommand
     {
         $index  = $input->getOption('index');
         $type   = $input->getOption('type');
+        $force  = (true == $input->getOption('force'));
 
         if (null === $index && null !== $type) {
             throw new \InvalidArgumentException('Cannot specify type option without an index.');
@@ -69,7 +71,7 @@ class ResetCommand extends ContainerAwareCommand
 
             foreach ($indexes as $index) {
                 $output->writeln(sprintf('<info>Resetting</info> <comment>%s</comment>', $index));
-                $this->resetter->resetIndex($index);
+                $this->resetter->resetIndex($index, false, $force);
             }
         }
     }

--- a/Exception/AliasIsIndexException.php
+++ b/Exception/AliasIsIndexException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace FOS\ElasticaBundle\Exception;
+
+class AliasIsIndexException extends \Exception
+{
+    public function __construct($indexName)
+    {
+        parent::__construct(sprintf('Expected alias %s instead of index', $indexName));
+    }
+}
+

--- a/Index/Resetter.php
+++ b/Index/Resetter.php
@@ -45,10 +45,10 @@ class Resetter
     /**
      * Deletes and recreates all indexes
      */
-    public function resetAllIndexes($populating = false)
+    public function resetAllIndexes($populating = false, $force = false)
     {
         foreach ($this->configManager->getIndexNames() as $name) {
-            $this->resetIndex($name, $populating);
+            $this->resetIndex($name, $populating, $force);
         }
     }
 
@@ -58,9 +58,10 @@ class Resetter
      *
      * @param string $indexName
      * @param bool $populating
+     * @param bool $force If index exists with same name as alias, remove it
      * @throws \InvalidArgumentException if no index exists for the given name
      */
-    public function resetIndex($indexName, $populating = false)
+    public function resetIndex($indexName, $populating = false, $force = false)
     {
         $indexConfig = $this->configManager->getIndexConfiguration($indexName);
         $index = $this->indexManager->getIndex($indexName);
@@ -73,7 +74,7 @@ class Resetter
         $index->create($mapping, true);
 
         if (!$populating and $indexConfig->isUseAlias()) {
-            $this->aliasProcessor->switchIndexAlias($indexConfig, $index);
+            $this->aliasProcessor->switchIndexAlias($indexConfig, $index, $force);
         }
     }
 


### PR DESCRIPTION
We've noticed a case where sometimes an index is present with the same name as the alias, which can be problematic.  This pr add an option to be able to delete the index if present while doing a reset.
