### PR TITLE
Add RawFinder for not transform results

### DIFF
--- a/DependencyInjection/FOSElasticaExtension.php
+++ b/DependencyInjection/FOSElasticaExtension.php
@@ -534,8 +534,16 @@ class FOSElasticaExtension extends Extension
         if (isset($typeConfig['finder']['service'])) {
             $finderId = $typeConfig['finder']['service'];
         } else {
+            // TransformedFinder
             $finderId = sprintf('fos_elastica.finder.%s.%s', $indexName, $typeName);
             $finderDef = new DefinitionDecorator('fos_elastica.finder');
+            $finderDef->replaceArgument(0, $typeRef);
+            $finderDef->replaceArgument(1, new Reference($elasticaToModelId));
+            $container->setDefinition($finderId, $finderDef);
+
+            // RawFinder
+            $finderId = sprintf('fos_elastica.finder.raw.%s.%s', $indexName, $typeName);
+            $finderDef = new DefinitionDecorator('fos_elastica.finder.raw');
             $finderDef->replaceArgument(0, $typeRef);
             $finderDef->replaceArgument(1, new Reference($elasticaToModelId));
             $container->setDefinition($finderId, $finderDef);

--- a/Finder/RawFinder.php
+++ b/Finder/RawFinder.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace FOS\ElasticaBundle\Finder;
+
+use Elastica\Document;
+use FOS\ElasticaBundle\Paginator\RawPaginatorAdapter;
+use FOS\ElasticaBundle\Paginator\FantaPaginatorAdapter;
+use Pagerfanta\Pagerfanta;
+use Elastica\SearchableInterface;
+use Elastica\Query;
+
+/**
+ * Finds elastica documents and map them to persisted objects
+ */
+class RawFinder implements PaginatedFinderInterface
+{
+    /**
+     * @var SearchableInterface
+     */
+    protected $searchable;
+
+    public function __construct(SearchableInterface $searchable)
+    {
+        $this->searchable  = $searchable;
+    }
+
+    /**
+     * Search for a query string
+     *
+     * @param string $query
+     * @param integer $limit
+     * @param array $options
+     * @return array of model objects
+     **/
+    public function find($query, $limit = null, $options = array())
+    {
+        return $this->search($query, $limit, $options);
+    }
+
+    /**
+     * Find documents similar to one with passed id.
+     *
+     * @param integer $id
+     * @param array $params
+     * @param array $query
+     * @return array of model objects
+     **/
+    public function moreLikeThis($id, $params = array(), $query = array())
+    {
+        $doc = new Document($id);
+
+        return $this->searchable->moreLikeThis($doc, $params, $query)->getResults();
+    }
+
+    /**
+     * @param $query
+     * @param null|int $limit
+     * @param array $options
+     * @return array
+     */
+    protected function search($query, $limit = null, $options = array())
+    {
+        $queryObject = Query::create($query);
+        if (null !== $limit) {
+            $queryObject->setSize($limit);
+        }
+        $results = $this->searchable->search($queryObject, $options)->getResults();
+
+        return $results;
+    }
+
+    /**
+     * Gets a paginator wrapping the result of a search
+     *
+     * @param string $query
+     * @param array $options
+     * @return Pagerfanta
+     */
+    public function findPaginated($query, $options = array())
+    {
+        $queryObject = Query::create($query);
+        $paginatorAdapter = $this->createPaginatorAdapter($queryObject, $options);
+
+        return new Pagerfanta(new FantaPaginatorAdapter($paginatorAdapter));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function createPaginatorAdapter($query, $options = array())
+    {
+        $query = Query::create($query);
+
+        return new RawPaginatorAdapter($this->searchable, $query, $options);
+    }
+}

--- a/Resources/config/index.xml
+++ b/Resources/config/index.xml
@@ -7,6 +7,7 @@
     <parameters>
         <parameter key="fos_elastica.alias_processor.class">FOS\ElasticaBundle\Index\AliasProcessor</parameter>
         <parameter key="fos_elastica.finder.class">FOS\ElasticaBundle\Finder\TransformedFinder</parameter>
+        <parameter key="fos_elastica.finder.raw.class">FOS\ElasticaBundle\Finder\RawFinder</parameter>
         <parameter key="fos_elastica.index.class">FOS\ElasticaBundle\Elastica\Index</parameter>
         <parameter key="fos_elastica.indexable.class">FOS\ElasticaBundle\Provider\Indexable</parameter>
         <parameter key="fos_elastica.index_manager.class">FOS\ElasticaBundle\Index\IndexManager</parameter>
@@ -45,6 +46,12 @@
 
         <!-- Abstract definition for all finders. -->
         <service id="fos_elastica.finder" class="%fos_elastica.finder.class%" public="true" abstract="true">
+            <argument /> <!-- searchable -->
+            <argument /> <!-- transformer -->
+        </service>
+
+        <!-- Abstract definition for all raw finders. -->
+        <service id="fos_elastica.finder.raw" class="%fos_elastica.finder.raw.class%" public="true" abstract="true">
             <argument /> <!-- searchable -->
             <argument /> <!-- transformer -->
         </service>


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | yes
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| License   | MIT

Added RawFinder for not transform results and get array of Elastic. 
Added new services "finder.raw"