### PR TITLE
Applied standard installation template

### DIFF
--- a/Resources/doc/setup.md
+++ b/Resources/doc/setup.md
@@ -1,40 +1,50 @@
 Step 1: Setting up the bundle
 =============================
 
-A) Install FOSElasticaBundle
-----------------------------
+A: Download the Bundle
+----------------------
 
-FOSElasticaBundle is installed using [Composer](https://getcomposer.org).
+Open a command console, enter your project directory and execute the
+following command to download the latest stable version of this bundle:
 
 ```bash
-$ php composer.phar require friendsofsymfony/elastica-bundle
+$ composer require friendsofsymfony/elastica-bundle "~3.0"
 ```
+
+This command requires you to have Composer installed globally, as explained
+in the [installation chapter](https://getcomposer.org/doc/00-intro.md)
+of the Composer documentation.
 
 ### Elasticsearch
 
-Instructions for installing and deploying Elasticsearch may be found
-[here](http://www.elasticsearch.org/guide/reference/setup/installation/).
+Instructions for installing and deploying Elasticsearch may be found [here](http://www.elasticsearch.org/guide/reference/setup/installation/).
 
+Step 2: Enable the Bundle
+-------------------------
 
-B) Enable FOSElasticaBundle
----------------------------
-
-Enable FOSElasticaBundle in your AppKernel:
+Then, enable the bundle by adding the following line in the `app/AppKernel.php`
+file of your project:
 
 ```php
 <?php
 // app/AppKernel.php
 
-public function registerBundles()
+// ...
+class AppKernel extends Kernel
 {
-    $bundles = array(
+    public function registerBundles()
+    {
+        $bundles = array(
+            // ...
+            new FOS\ElasticaBundle\FOSElasticaBundle(),
+        );
+        
         // ...
-        new FOS\ElasticaBundle\FOSElasticaBundle(),
-    );
+    }
 }
 ```
 
-C) Basic Bundle Configuration
+C: Basic Bundle Configuration
 -----------------------------
 
 The basic minimal configuration for FOSElasticaBundle is one client with one Elasticsearch
@@ -68,7 +78,7 @@ fos_elastica:
 In this case, the service `fos_elastica.index.search` will be using an Elasticsearch
 index of search_dev.
 
-D) Defining index types
+D: Defining index types
 -----------------------
 
 By default, FOSElasticaBundle requires each type that is to be indexed to be mapped.
@@ -122,7 +132,7 @@ Below is an example for the Doctrine ORM.
 There are a significant number of options available for types, that can be
 [found here](types.md)
 
-E) Populating the Elasticsearch index
+E: Populating the Elasticsearch index
 -------------------------------------
 
 When using the providers and listeners that come with the bundle, any new or modified
@@ -137,7 +147,7 @@ $ php app/console fos:elastica:populate
 The command will also create all indexes and types defined if they do not already exist
 on the Elasticsearch server.
 
-F) Usage
+F: Usage
 --------
 
 Usage documentation for the bundle is available [here](usage.md)


### PR DESCRIPTION
*The Symfony Documenators started an initiative to make all bundle installation documentation consistent and  easy to understand for beginners. That'll improve the DX for starters using 3rd party bundles. The template can be found here: http://symfony.com/doc/current/cookbook/bundles/best_practices.html#installation-instructions*

I would like to ask you to use this template in your documentation.

If you have any comments on the template, please open an issue in the `symfony/symfony-docs` repository. Feedback will brings us to the ultimate template.