### PR TITLE
Fix mongodb populate falling down performances for big collections

### DIFF
--- a/Doctrine/AbstractProvider.php
+++ b/Doctrine/AbstractProvider.php
@@ -54,12 +54,13 @@ abstract class AbstractProvider extends BaseAbstractProvider
         $batchSize = isset($options['batch-size']) ? intval($options['batch-size']) : $this->options['batch_size'];
         $ignoreErrors = isset($options['ignore-errors']) ? $options['ignore-errors'] : $this->options['ignore_errors'];
         $manager = $this->managerRegistry->getManagerForClass($this->objectClass);
+        $objects = array();
 
         for (; $offset < $nbObjects; $offset += $batchSize) {
             if ($loggerClosure) {
                 $stepStartTime = microtime(true);
             }
-            $objects = $this->fetchSlice($queryBuilder, $batchSize, $offset);
+            $objects = $this->fetchSlice($queryBuilder, $batchSize, $offset, $objects);
             if ($loggerClosure) {
                 $stepNbObjects = count($objects);
             }
@@ -133,9 +134,10 @@ abstract class AbstractProvider extends BaseAbstractProvider
      * @param object  $queryBuilder
      * @param integer $limit
      * @param integer $offset
+     * @param array   $previousSlice
      * @return array
      */
-    protected abstract function fetchSlice($queryBuilder, $limit, $offset);
+    protected abstract function fetchSlice($queryBuilder, $limit, $offset, array $previousSlice);
 
     /**
      * Creates the query builder, which will be used to fetch objects to index.

--- a/Doctrine/MongoDB/Provider.php
+++ b/Doctrine/MongoDB/Provider.php
@@ -59,25 +59,15 @@ class Provider extends AbstractProvider
     /**
      * @see FOS\ElasticaBundle\Doctrine\AbstractProvider::fetchSlice()
      */
-    protected function fetchSlice($queryBuilder, $limit, $offset, array $previousSlice)
+    protected function fetchSlice($queryBuilder, $limit, $offset)
     {
         if (!$queryBuilder instanceof Builder) {
             throw new InvalidArgumentTypeException($queryBuilder, 'Doctrine\ODM\MongoDB\Query\Builder');
         }
 
-        $lastObject = array_pop($previousSlice);
-
-        if ($lastObject) {
-            $queryBuilder
-                ->field('_id')->gt($lastObject->getId())
-                ->skip(0);
-        } else {
-            $queryBuilder->skip($offset);
-        }
-
         return $queryBuilder
+            ->skip($offset)
             ->limit($limit)
-            ->sort(array('_id' => 'asc'))
             ->getQuery()
             ->execute()
             ->toArray();

--- a/Doctrine/MongoDB/Provider.php
+++ b/Doctrine/MongoDB/Provider.php
@@ -59,15 +59,25 @@ class Provider extends AbstractProvider
     /**
      * @see FOS\ElasticaBundle\Doctrine\AbstractProvider::fetchSlice()
      */
-    protected function fetchSlice($queryBuilder, $limit, $offset)
+    protected function fetchSlice($queryBuilder, $limit, $offset, array $previousSlice)
     {
         if (!$queryBuilder instanceof Builder) {
             throw new InvalidArgumentTypeException($queryBuilder, 'Doctrine\ODM\MongoDB\Query\Builder');
         }
 
+        $lastObject = array_pop($previousSlice);
+
+        if ($lastObject) {
+            $queryBuilder
+                ->field('_id')->gt($lastObject->getId())
+                ->skip(0);
+        } else {
+            $queryBuilder->skip($offset);
+        }
+
         return $queryBuilder
             ->limit($limit)
-            ->skip($offset)
+            ->sort(array('_id' => 'asc'))
             ->getQuery()
             ->execute()
             ->toArray();

--- a/Doctrine/MongoDB/SliceFetcher.php
+++ b/Doctrine/MongoDB/SliceFetcher.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace FOS\ElasticaBundle\Doctrine\MongoDB;
+
+use Doctrine\ODM\MongoDB\Query\Builder;
+use FOS\ElasticaBundle\Exception\InvalidArgumentTypeException;
+use FOS\ElasticaBundle\Doctrine\SliceFetcherInterface;
+
+/**
+ * Fetches a slice of objects
+ *
+ * @author Thomas Prelot <tprelot@gmail.com>
+ */
+class SliceFetcher implements SliceFetcherInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function fetch($queryBuilder, $limit, $offset, array $previousSlice, array $identifierFieldNames)
+    {
+        if (!$queryBuilder instanceof Builder) {
+            throw new InvalidArgumentTypeException($queryBuilder, 'Doctrine\ODM\MongoDB\Query\Builder');
+        }
+
+        $lastObject = array_pop($previousSlice);
+
+        if ($lastObject) {
+            $queryBuilder
+                ->field('_id')->gt($lastObject->getId())
+                ->skip(0)
+            ;
+        } else {
+            $queryBuilder->skip($offset);
+        }
+
+        return $queryBuilder
+            ->limit($limit)
+            ->sort(array('_id' => 'asc'))
+            ->getQuery()
+            ->execute()
+            ->toArray()
+        ;
+    }
+}

--- a/Doctrine/ORM/Provider.php
+++ b/Doctrine/ORM/Provider.php
@@ -70,7 +70,7 @@ class Provider extends AbstractProvider
     /**
      * @see FOS\ElasticaBundle\Doctrine\AbstractProvider::fetchSlice()
      */
-    protected function fetchSlice($queryBuilder, $limit, $offset)
+    protected function fetchSlice($queryBuilder, $limit, $offset, array $previousSlice)
     {
         if (!$queryBuilder instanceof QueryBuilder) {
             throw new InvalidArgumentTypeException($queryBuilder, 'Doctrine\ORM\QueryBuilder');

--- a/Doctrine/ORM/Provider.php
+++ b/Doctrine/ORM/Provider.php
@@ -70,7 +70,7 @@ class Provider extends AbstractProvider
     /**
      * @see FOS\ElasticaBundle\Doctrine\AbstractProvider::fetchSlice()
      */
-    protected function fetchSlice($queryBuilder, $limit, $offset, array $previousSlice)
+    protected function fetchSlice($queryBuilder, $limit, $offset)
     {
         if (!$queryBuilder instanceof QueryBuilder) {
             throw new InvalidArgumentTypeException($queryBuilder, 'Doctrine\ORM\QueryBuilder');

--- a/Doctrine/ORM/SliceFetcher.php
+++ b/Doctrine/ORM/SliceFetcher.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace FOS\ElasticaBundle\Doctrine\ORM;
+
+use Doctrine\ORM\QueryBuilder;
+use FOS\ElasticaBundle\Exception\InvalidArgumentTypeException;
+use FOS\ElasticaBundle\Doctrine\SliceFetcherInterface;
+
+/**
+ * Fetches a slice of objects
+ *
+ * @author Thomas Prelot <tprelot@gmail.com>
+ */
+class SliceFetcher implements SliceFetcherInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function fetch($queryBuilder, $limit, $offset, array $previousSlice, array $identifierFieldNames)
+    {
+        if (!$queryBuilder instanceof QueryBuilder) {
+            throw new InvalidArgumentTypeException($queryBuilder, 'Doctrine\ORM\QueryBuilder');
+        }
+
+        /**
+         * An orderBy DQL  part is required to avoid feching the same row twice.
+         * @see http://stackoverflow.com/questions/6314879/does-limit-offset-length-require-order-by-for-pagination
+         * @see http://www.postgresql.org/docs/current/static/queries-limit.html
+         * @see http://www.sqlite.org/lang_select.html#orderby
+         */
+        $orderBy = $queryBuilder->getDQLPart('orderBy');
+        if (empty($orderBy)) {
+            $rootAliases = $queryBuilder->getRootAliases();
+            
+            foreach ($identifierFieldNames as $fieldName) {
+                $queryBuilder->addOrderBy($rootAliases[0].'.'.$fieldName);
+            }
+        }
+
+        return $queryBuilder
+            ->setFirstResult($offset)
+            ->setMaxResults($limit)
+            ->getQuery()
+            ->getResult()
+        ;
+    }
+}

--- a/Doctrine/SliceFetcherInterface.php
+++ b/Doctrine/SliceFetcherInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace FOS\ElasticaBundle\Doctrine;
+
+/**
+ * Fetches a slice of objects
+ *
+ * @author Thomas Prelot <tprelot@gmail.com>
+ */
+interface SliceFetcherInterface
+{
+    /**
+     * Fetches a slice of objects using the query builder.
+     *
+     * @param object  $queryBuilder
+     * @param integer $limit
+     * @param integer $offset
+     * @param array   $previousSlice
+     * @param array   $identifierFieldNames
+     * @return array
+     */
+    function fetch($queryBuilder, $limit, $offset, array $previousSlice, array $identifierFieldNames);
+}

--- a/Resources/config/mongodb.xml
+++ b/Resources/config/mongodb.xml
@@ -5,20 +5,24 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <parameters>
+        <parameter key="fos_elastica.slice_fetcher.mongodb.class">FOS\ElasticaBundle\Doctrine\MongoDB\SliceFetcher</parameter>
         <parameter key="fos_elastica.provider.prototype.mongodb.class">FOS\ElasticaBundle\Doctrine\MongoDB\Provider</parameter>
         <parameter key="fos_elastica.listener.prototype.mongodb.class">FOS\ElasticaBundle\Doctrine\Listener</parameter>
         <parameter key="fos_elastica.elastica_to_model_transformer.prototype.mongodb.class">FOS\ElasticaBundle\Doctrine\MongoDB\ElasticaToModelTransformer</parameter>
         <parameter key="fos_elastica.manager.mongodb.class">FOS\ElasticaBundle\Doctrine\RepositoryManager</parameter>
     </parameters>
 
-
     <services>
+        <service id="fos_elastica.slice_fetcher.mongodb" class="%fos_elastica.slice_fetcher.mongodb.class%">
+        </service>
+
         <service id="fos_elastica.provider.prototype.mongodb" class="%fos_elastica.provider.prototype.mongodb.class%" public="true" abstract="true">
             <argument /> <!-- object persister -->
             <argument type="service" id="fos_elastica.indexable" />
             <argument /> <!-- model -->
             <argument type="collection" /> <!-- options -->
-            <argument type="service" id="doctrine_mongodb" />
+            <argument type="service" id="doctrine_mongodb" /> <!-- manager registry -->
+            <argument type="service" id="fos_elastica.slice_fetcher.mongodb" /> <!-- slice fetcher -->
         </service>
 
         <service id="fos_elastica.listener.prototype.mongodb" class="%fos_elastica.listener.prototype.mongodb.class%" public="false" abstract="true">

--- a/Resources/config/orm.xml
+++ b/Resources/config/orm.xml
@@ -4,20 +4,25 @@
            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
-	<parameters>
-		<parameter key="fos_elastica.provider.prototype.orm.class">FOS\ElasticaBundle\Doctrine\ORM\Provider</parameter>
-		<parameter key="fos_elastica.listener.prototype.orm.class">FOS\ElasticaBundle\Doctrine\Listener</parameter>
-		<parameter key="fos_elastica.elastica_to_model_transformer.prototype.orm.class">FOS\ElasticaBundle\Doctrine\ORM\ElasticaToModelTransformer</parameter>
-		<parameter key="fos_elastica.manager.orm.class">FOS\ElasticaBundle\Doctrine\RepositoryManager</parameter>
-	</parameters>
-	
+    <parameters>
+        <parameter key="fos_elastica.slice_fetcher.orm.class">FOS\ElasticaBundle\Doctrine\ORM\SliceFetcher</parameter>
+        <parameter key="fos_elastica.provider.prototype.orm.class">FOS\ElasticaBundle\Doctrine\ORM\Provider</parameter>
+        <parameter key="fos_elastica.listener.prototype.orm.class">FOS\ElasticaBundle\Doctrine\Listener</parameter>
+        <parameter key="fos_elastica.elastica_to_model_transformer.prototype.orm.class">FOS\ElasticaBundle\Doctrine\ORM\ElasticaToModelTransformer</parameter>
+        <parameter key="fos_elastica.manager.orm.class">FOS\ElasticaBundle\Doctrine\RepositoryManager</parameter>
+    </parameters>
+    
     <services>
+        <service id="fos_elastica.slice_fetcher.orm" class="%fos_elastica.slice_fetcher.orm.class%">
+        </service>
+
         <service id="fos_elastica.provider.prototype.orm" class="%fos_elastica.provider.prototype.orm.class%" public="true" abstract="true">
             <argument /> <!-- object persister -->
             <argument type="service" id="fos_elastica.indexable" />
             <argument /> <!-- model -->
             <argument type="collection" /> <!-- options -->
-            <argument type="service" id="doctrine" />
+            <argument type="service" id="doctrine" /> <!-- manager registry -->
+            <argument type="service" id="fos_elastica.slice_fetcher.orm" /> <!-- slice fetcher -->
         </service>
 
         <service id="fos_elastica.listener.prototype.orm" class="%fos_elastica.listener.prototype.orm.class%" public="false" abstract="true">


### PR DESCRIPTION
Using skip to retrieve slices of data is not performant when the amount of documents skipped is important. It decreases the performances of the command `fos:elastica:populate` for each retrieved slice until it crashes (30s timeout).

http://docs.mongodb.org/manual/reference/method/cursor.skip/

To fix this problem, a solution is to retrieve a slice from the last object of the previous slice. Mongo can then use an index to find the slice instead of browsing all the collection.