### PR TITLE
Avoid Doctrine\Listener::getSubscribedEvents() call 

### DIFF
--- a/DependencyInjection/FOSElasticaExtension.php
+++ b/DependencyInjection/FOSElasticaExtension.php
@@ -464,18 +464,22 @@ class FOSElasticaExtension extends Extension
         $listenerId = sprintf('fos_elastica.listener.%s.%s', $indexName, $typeName);
         $listenerDef = new DefinitionDecorator($abstractListenerId);
         $listenerDef->replaceArgument(0, new Reference($objectPersisterId));
-        $listenerDef->replaceArgument(1, $this->getDoctrineEvents($typeConfig));
-        $listenerDef->replaceArgument(3, array(
+        $listenerDef->replaceArgument(2, array(
             'identifier' => $typeConfig['identifier'],
             'indexName' => $indexName,
             'typeName' => $typeName,
         ));
         if ($typeConfig['listener']['logger']) {
-            $listenerDef->replaceArgument(4, new Reference($typeConfig['listener']['logger']));
+            $listenerDef->replaceArgument(3, new Reference($typeConfig['listener']['logger']));
         }
 
         switch ($typeConfig['driver']) {
-            case 'orm': $listenerDef->addTag('doctrine.event_subscriber'); break;
+            case 'orm':
+                foreach ($this->getDoctrineEvents($typeConfig) as $event) {
+                    $listenerDef->addTag('doctrine.event_listener', array('event' => $event));
+                }
+
+                break;
             case 'mongodb': $listenerDef->addTag('doctrine_mongodb.odm.event_subscriber'); break;
         }
 

--- a/Doctrine/Listener.php
+++ b/Doctrine/Listener.php
@@ -2,7 +2,6 @@
 
 namespace FOS\ElasticaBundle\Doctrine;
 
-use Doctrine\Common\EventSubscriber;
 use Doctrine\Common\Persistence\Event\LifecycleEventArgs;
 use FOS\ElasticaBundle\Persister\ObjectPersisterInterface;
 use FOS\ElasticaBundle\Persister\ObjectPersister;
@@ -14,7 +13,7 @@ use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
  * Automatically update ElasticSearch based on changes to the Doctrine source
  * data. One listener is generated for each Doctrine entity / ElasticSearch type.
  */
-class Listener implements EventSubscriber
+class Listener
 {
     /**
      * Object persister
@@ -22,13 +21,6 @@ class Listener implements EventSubscriber
      * @var ObjectPersister
      */
     protected $objectPersister;
-
-    /**
-     * List of subscribed events
-     *
-     * @var array
-     */
-    protected $events;
 
     /**
      * Configuration for the listener
@@ -74,14 +66,12 @@ class Listener implements EventSubscriber
      * Constructor.
      *
      * @param ObjectPersisterInterface $objectPersister
-     * @param array $events
      * @param IndexableInterface $indexable
      * @param array $config
      * @param null $logger
      */
     public function __construct(
         ObjectPersisterInterface $objectPersister,
-        array $events,
         IndexableInterface $indexable,
         array $config = array(),
         $logger = null
@@ -89,7 +79,6 @@ class Listener implements EventSubscriber
         $this->config = array_merge(array(
             'identifier' => 'id',
         ), $config);
-        $this->events = $events;
         $this->indexable = $indexable;
         $this->objectPersister = $objectPersister;
         $this->propertyAccessor = PropertyAccess::createPropertyAccessor();
@@ -97,14 +86,6 @@ class Listener implements EventSubscriber
         if ($logger) {
             $this->objectPersister->setLogger($logger);
         }
-    }
-
-    /**
-     * @see Doctrine\Common\EventSubscriber::getSubscribedEvents()
-     */
-    public function getSubscribedEvents()
-    {
-        return $this->events;
     }
 
     /**

--- a/Resources/config/orm.xml
+++ b/Resources/config/orm.xml
@@ -22,7 +22,6 @@
 
         <service id="fos_elastica.listener.prototype.orm" class="%fos_elastica.listener.prototype.orm.class%" public="false" abstract="true">
             <argument /> <!-- object persister -->
-            <argument type="collection" /> <!-- events -->
             <argument type="service" id="fos_elastica.indexable" />
             <argument type="collection" /> <!-- configuration -->
             <argument on-invalid="ignore" /> <!-- logger -->

--- a/Tests/Doctrine/AbstractListenerTest.php
+++ b/Tests/Doctrine/AbstractListenerTest.php
@@ -16,7 +16,7 @@ abstract class ListenerTest extends \PHPUnit_Framework_TestCase
         $eventArgs = $this->createLifecycleEventArgs($entity, $this->getMockObjectManager());
         $indexable = $this->getMockIndexable('index', 'type', $entity, true);
 
-        $listener = $this->createListener($persister, array(), $indexable, array('indexName' => 'index', 'typeName' => 'type'));
+        $listener = $this->createListener($persister, $indexable, array('indexName' => 'index', 'typeName' => 'type'));
         $listener->postPersist($eventArgs);
 
         $this->assertEquals($entity, current($listener->scheduledForInsertion));
@@ -35,7 +35,7 @@ abstract class ListenerTest extends \PHPUnit_Framework_TestCase
         $eventArgs = $this->createLifecycleEventArgs($entity, $this->getMockObjectManager());
         $indexable = $this->getMockIndexable('index', 'type', $entity, false);
 
-        $listener = $this->createListener($persister, array(), $indexable, array('indexName' => 'index', 'typeName' => 'type'));
+        $listener = $this->createListener($persister, $indexable, array('indexName' => 'index', 'typeName' => 'type'));
         $listener->postPersist($eventArgs);
 
         $this->assertEmpty($listener->scheduledForInsertion);
@@ -55,7 +55,7 @@ abstract class ListenerTest extends \PHPUnit_Framework_TestCase
         $eventArgs = $this->createLifecycleEventArgs($entity, $this->getMockObjectManager());
         $indexable = $this->getMockIndexable('index', 'type', $entity, true);
 
-        $listener = $this->createListener($persister, array(), $indexable, array('indexName' => 'index', 'typeName' => 'type'));
+        $listener = $this->createListener($persister, $indexable, array('indexName' => 'index', 'typeName' => 'type'));
         $listener->postUpdate($eventArgs);
 
         $this->assertEquals($entity, current($listener->scheduledForUpdate));
@@ -89,7 +89,7 @@ abstract class ListenerTest extends \PHPUnit_Framework_TestCase
             ->with($entity, 'id')
             ->will($this->returnValue($entity->getId()));
 
-        $listener = $this->createListener($persister, array(), $indexable, array('indexName' => 'index', 'typeName' => 'type'));
+        $listener = $this->createListener($persister, $indexable, array('indexName' => 'index', 'typeName' => 'type'));
         $listener->postUpdate($eventArgs);
 
         $this->assertEmpty($listener->scheduledForUpdate);
@@ -124,7 +124,7 @@ abstract class ListenerTest extends \PHPUnit_Framework_TestCase
             ->with($entity, 'id')
             ->will($this->returnValue($entity->getId()));
 
-        $listener = $this->createListener($persister, array(), $indexable, array('indexName' => 'index', 'typeName' => 'type'));
+        $listener = $this->createListener($persister, $indexable, array('indexName' => 'index', 'typeName' => 'type'));
         $listener->preRemove($eventArgs);
 
         $this->assertEquals($entity->getId(), current($listener->scheduledForDeletion));
@@ -157,7 +157,7 @@ abstract class ListenerTest extends \PHPUnit_Framework_TestCase
             ->with($entity, 'identifier')
             ->will($this->returnValue($entity->getId()));
 
-        $listener = $this->createListener($persister, array(), $indexable, array('identifier' => 'identifier', 'indexName' => 'index', 'typeName' => 'type'));
+        $listener = $this->createListener($persister, $indexable, array('identifier' => 'identifier', 'indexName' => 'index', 'typeName' => 'type'));
         $listener->preRemove($eventArgs);
 
         $this->assertEquals($entity->identifier, current($listener->scheduledForDeletion));


### PR DESCRIPTION
... on each page where doctrine is active.

The problem:

Classes FOSElasticaBundle shouldn't be loaded (providers, indexes, http client) until first call.

If there's at least one `Doctrine\Listener` registered in the application, then the following code for `\Symfony\Bridge\Doctrine\ContainerAwareEventManagerDoctrine` will be generated in `app/cache/dev/appDevDebugProjectContainer.php`:

    $c = new \Symfony\Bridge\Doctrine\ContainerAwareEventManager($this);
    $c->addEventSubscriber($this->get('fos_elastica.listener.index.type'));

Inside `addEventSubscriber()` non-static `Doctrine\Listener::getSubscribedEvents()` is called for each subscriber.

As far as we use proxy-services, after `Doctrine\Listener::getSubscribedEvents()` is called, dependencies for `Doctrine\Listener` start resolving.
