### PR TITLE
Doctrine provider: memory allocation caused by "entire batch was filtered away"

### DIFF
--- a/Doctrine/AbstractProvider.php
+++ b/Doctrine/AbstractProvider.php
@@ -69,6 +69,10 @@ abstract class AbstractProvider extends BaseAbstractProvider
                     $loggerClosure('<info>Entire batch was filtered away, skipping...</info>');
                 }
 
+                if ($this->options['clear_object_manager']) {
+                    $manager->clear();
+                }
+
                 continue;
             }
 

--- a/Tests/Doctrine/AbstractProviderTest.php
+++ b/Tests/Doctrine/AbstractProviderTest.php
@@ -122,6 +122,32 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
         $provider->populate();
     }
 
+    public function testPopulateShouldClearObjectManagerForFilteredBatch()
+    {
+        $nbObjects = 1;
+        $objects = array(1);
+
+        $provider = $this->getMockAbstractProvider();
+
+        $provider->expects($this->any())
+            ->method('countObjects')
+            ->will($this->returnValue($nbObjects));
+
+        $provider->expects($this->any())
+            ->method('fetchSlice')
+            ->will($this->returnValue($objects));
+
+        $this->indexable->expects($this->any())
+            ->method('isObjectIndexable')
+            ->with('index', 'type', $this->anything())
+            ->will($this->returnValue(false));
+
+        $this->objectManager->expects($this->once())
+            ->method('clear');
+
+        $provider->populate();
+    }
+
     public function testPopulateInvokesLoggerClosure()
     {
         $nbObjects = 1;


### PR DESCRIPTION
If there is a big number of objects filtered away while indexing, it causes memory allocation issue due real objects remain inside of Doctrine UoW.
