### PR TITLE
adjust to symfony 3.0 development having started

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: php
 
 php:
   - 5.3
+  - 5.4
   - 5.5
   - 5.6
 
@@ -10,9 +11,11 @@ matrix:
     - php: 5.5
       env: SYMFONY_VERSION='2.3.*'
     - php: 5.5
+      env: SYMFONY_VERSION='2.4.*'
+    - php: 5.5
       env: SYMFONY_VERSION='2.5.*'
     - php: 5.5
-      env: SYMFONY_VERSION='dev-master'
+      env: SYMFONY_VERSION='2.6.*'
 
 before_script:
   - /usr/share/elasticsearch/bin/elasticsearch -v


### PR DESCRIPTION
whenever there is a new 2.x branch in symfony, we should add it to the matrix. this is the same as before, i just use 2.7.\* instead of dev-master. using 2.\* gives too many options, exploding composer.
