### PR TITLE
add index populate events

### DIFF
--- a/DependencyInjection/FOSElasticaExtension.php
+++ b/DependencyInjection/FOSElasticaExtension.php
@@ -46,7 +46,7 @@ class FOSElasticaExtension extends Extension
             return;
         }
 
-        foreach (array('config', 'index', 'persister', 'provider', 'source', 'transformer') as $basename) {
+        foreach (array('config', 'index', 'persister', 'provider', 'source', 'transformer', 'listener') as $basename) {
             $loader->load(sprintf('%s.xml', $basename));
         }
 

--- a/Event/PopulateEvent.php
+++ b/Event/PopulateEvent.php
@@ -46,10 +46,10 @@ class PopulateEvent extends Event
     private $options;
 
     /**
-     * @param string  $index
-     * @param string  $type
-     * @param boolean $reset
-     * @param array   $options
+     * @param string      $index
+     * @param string|null $type
+     * @param boolean     $reset
+     * @param array       $options
      */
     public function __construct($index, $type, $reset, $options)
     {

--- a/Event/PopulateEvent.php
+++ b/Event/PopulateEvent.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * This file is part of the FOSElasticaBundle project.
+ *
+ * (c) FriendsOfSymfony <https://github.com/FriendsOfSymfony/FOSElasticaBundle/graphs/contributors>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\ElasticaBundle\Event;
+
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * Populate Event
+ *
+ * @author Oleg Andreyev <oleg.andreyev@intexsys.lv>
+ */
+class PopulateEvent extends Event
+{
+    const PRE_INDEX_POPULATE = 'elastica.index.index_pre_populate';
+    const POST_INDEX_POPULATE = 'elastica.index.index_post_populate';
+
+    const PRE_TYPE_POPULATE = 'elastica.index.type_pre_populate';
+    const POST_TYPE_POPULATE = 'elastica.index.type_post_populate';
+
+    /**
+     * @var string
+     */
+    private $index;
+
+    /**
+     * @var string
+     */
+    private $type;
+
+    /**
+     * @var bool
+     */
+    private $reset;
+
+    /**
+     * @var array
+     */
+    private $options;
+
+    /**
+     * @param string  $index
+     * @param string  $type
+     * @param boolean $reset
+     * @param array   $options
+     */
+    public function __construct($index, $type, $reset, $options)
+    {
+        $this->index   = $index;
+        $this->type    = $type;
+        $this->reset   = $reset;
+        $this->options = $options;
+    }
+
+    /**
+     * @return string
+     */
+    public function getIndex()
+    {
+        return $this->index;
+    }
+
+    /**
+     * @return string
+     */
+    public function getType()
+    {
+        return $this->type;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function isReset()
+    {
+        return $this->reset;
+    }
+
+    /**
+     * @return array
+     */
+    public function getOptions()
+    {
+        return $this->options;
+    }
+}

--- a/Event/ResetEvent.php
+++ b/Event/ResetEvent.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace FOS\ElasticaBundle\Event;
+
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * ResetEvent
+ *
+ * @author Oleg Andreyev <oleg.andreyev@intexsys.lv>
+ */
+class ResetEvent extends Event
+{
+    const PRE_INDEX_RESET = 'elastica.index.pre_reset';
+    const POST_INDEX_RESET = 'elastica.index.post_reset';
+
+    const PRE_TYPE_RESET = 'elastica.index.type_pre_reset';
+    const POST_TYPE_RESET = 'elastica.index.type_post_reset';
+
+    /**
+     * @var string
+     */
+    private $indexName;
+
+    /**
+     * @var string
+     */
+    private $indexType;
+
+    /**
+     * @var bool
+     */
+    private $populating;
+
+    /**
+     * @var bool
+     */
+    private $force;
+
+    /**
+     * @param string $indexName
+     * @param string $indexType
+     * @param bool   $populating
+     * @param bool   $force
+     */
+    public function __construct($indexName, $indexType, $populating = false, $force = false)
+    {
+        $this->indexName  = $indexName;
+        $this->indexType  = $indexType;
+        $this->populating = (bool)$populating;
+        $this->force      = (bool)$force;
+    }
+
+    /**
+     * @return string
+     */
+    public function getIndexName()
+    {
+        return $this->indexName;
+    }
+
+    /**
+     * @return string
+     */
+    public function getIndexType()
+    {
+        return $this->indexType;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function isPopulating()
+    {
+        return $this->populating;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function isForce()
+    {
+        return $this->force;
+    }
+}

--- a/EventListener/PopulateListener.php
+++ b/EventListener/PopulateListener.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * This file is part of the FOSElasticaBundle project.
+ *
+ * (c) FriendsOfSymfony <https://github.com/FriendsOfSymfony/FOSElasticaBundle/graphs/contributors>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\ElasticaBundle\EventListener;
+
+use FOS\ElasticaBundle\Event\PopulateEvent;
+use FOS\ElasticaBundle\Index\Resetter;
+
+/**
+ * PopulateListener
+ *
+ * @author Oleg Andreyev <oleg.andreyev@intexsys.lv>
+ */
+class PopulateListener
+{
+    /**
+     * @var Resetter
+     */
+    private $resetter;
+
+    /**
+     * @param Resetter $resetter
+     */
+    public function __construct(Resetter $resetter)
+    {
+        $this->resetter = $resetter;
+    }
+
+    /**
+     * @param PopulateEvent $event
+     */
+    public function preIndexPopulate(PopulateEvent $event)
+    {
+        if (!$event->isReset()) {
+            return;
+        }
+
+        if (null !== $event->getType()) {
+            $this->resetter->resetIndexType($event->getIndex(), $event->getType());
+        } else {
+            $this->resetter->resetIndex($event->getIndex(), true);
+        }
+    }
+
+    /**
+     * @param PopulateEvent $event
+     */
+    public function postIndexPopulate(PopulateEvent $event)
+    {
+        $this->resetter->postPopulate($event->getIndex());
+    }
+} 

--- a/Index/Resetter.php
+++ b/Index/Resetter.php
@@ -6,6 +6,8 @@ use Elastica\Index;
 use Elastica\Exception\ResponseException;
 use Elastica\Type\Mapping;
 use FOS\ElasticaBundle\Configuration\ConfigManager;
+use FOS\ElasticaBundle\Event\ResetEvent;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
  * Deletes and recreates indexes
@@ -18,7 +20,7 @@ class Resetter
     private $aliasProcessor;
 
     /***
-     * @var \FOS\ElasticaBundle\Configuration\Manager
+     * @var ConfigManager
      */
     private $configManager;
 
@@ -32,12 +34,30 @@ class Resetter
      */
     private $mappingBuilder;
 
-    public function __construct(ConfigManager $configManager, IndexManager $indexManager, AliasProcessor $aliasProcessor, MappingBuilder $mappingBuilder)
-    {
-        $this->aliasProcessor = $aliasProcessor;
-        $this->configManager = $configManager;
-        $this->indexManager = $indexManager;
-        $this->mappingBuilder = $mappingBuilder;
+    /**
+     * @var EventDispatcherInterface
+     */
+    private $eventDispatcher;
+
+    /**
+     * @param ConfigManager            $configManager
+     * @param IndexManager             $indexManager
+     * @param AliasProcessor           $aliasProcessor
+     * @param MappingBuilder           $mappingBuilder
+     * @param EventDispatcherInterface $eventDispatcher
+     */
+    public function __construct(
+        ConfigManager $configManager,
+        IndexManager $indexManager,
+        AliasProcessor $aliasProcessor,
+        MappingBuilder $mappingBuilder,
+        EventDispatcherInterface $eventDispatcher
+    ) {
+        $this->aliasProcessor  = $aliasProcessor;
+        $this->configManager   = $configManager;
+        $this->indexManager    = $indexManager;
+        $this->mappingBuilder  = $mappingBuilder;
+        $this->eventDispatcher = $eventDispatcher;
     }
 
     /**
@@ -61,6 +81,9 @@ class Resetter
      */
     public function resetIndex($indexName, $populating = false, $force = false)
     {
+        $event = new ResetEvent($indexName, null, $populating, $force);
+        $this->eventDispatcher->dispatch(ResetEvent::PRE_INDEX_RESET, $event);
+
         $indexConfig = $this->configManager->getIndexConfiguration($indexName);
         $index = $this->indexManager->getIndex($indexName);
 
@@ -74,6 +97,8 @@ class Resetter
         if (!$populating and $indexConfig->isUseAlias()) {
             $this->aliasProcessor->switchIndexAlias($indexConfig, $index, $force);
         }
+
+        $this->eventDispatcher->dispatch(ResetEvent::POST_INDEX_RESET, $event);
     }
 
     /**
@@ -86,6 +111,9 @@ class Resetter
      */
     public function resetIndexType($indexName, $typeName)
     {
+        $event = new ResetEvent($indexName, $typeName);
+        $this->eventDispatcher->dispatch(ResetEvent::PRE_TYPE_RESET, $event);
+
         $typeConfig = $this->configManager->getTypeConfiguration($indexName, $typeName);
         $type = $this->indexManager->getIndex($indexName)->getType($typeName);
 
@@ -103,6 +131,8 @@ class Resetter
         }
 
         $type->setMapping($mapping);
+
+        $this->eventDispatcher->dispatch(ResetEvent::POST_TYPE_RESET, $event);
     }
 
     /**

--- a/Resources/config/index.xml
+++ b/Resources/config/index.xml
@@ -41,6 +41,7 @@
             <argument type="service" id="fos_elastica.index_manager" />
             <argument type="service" id="fos_elastica.alias_processor" />
             <argument type="service" id="fos_elastica.mapping_builder" />
+            <argument type="service" id="event_dispatcher"/>
         </service>
 
         <!-- Abstract definition for all finders. -->

--- a/Resources/config/listener.xml
+++ b/Resources/config/listener.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="fos_elastica.populate_listener.class">FOS\ElasticaBundle\EventListener\PopulateListener</parameter>
+    </parameters>
+
+    <services>
+        <service id="fos_elastica.populate_listener" class="%fos_elastica.populate_listener.class%">
+            <tag name="kernel.event_listener" event="elastica.index.index_pre_populate" method="preIndexPopulate"/>
+            <tag name="kernel.event_listener" event="elastica.index.index_post_populate" method="postIndexPopulate"/>
+            <argument type="service" id="fos_elastica.resetter"/>
+        </service>
+    </services>
+</container>

--- a/Tests/EventListener/PopulateListenerTest.php
+++ b/Tests/EventListener/PopulateListenerTest.php
@@ -33,22 +33,47 @@ class PopulateListenerTest extends \PHPUnit_Framework_TestCase
         $this->listener->postIndexPopulate(new PopulateEvent('indexName', null, true, array()));
     }
 
-    public function testPreIndexPopulateWhenNoResetRequired()
+    public function preIndexPopulateDataProvider()
     {
-        $this->resetter->expects($this->never())->method('resetIndex');
-        $this->resetter->expects($this->never())->method('resetIndexType');
-        $this->listener->preIndexPopulate(new PopulateEvent('indexName', null, false, array()));
+        return array(
+            array(
+                array(
+                    array('resetIndex', $this->never()),
+                    array('resetIndexType', $this->never())
+                ),
+                array('indexName', true),
+                new PopulateEvent('indexName', null, false, array())
+            ),
+            array(
+                array(
+                    array('resetIndex', $this->once())
+                ),
+                array('indexName', true),
+                new PopulateEvent('indexName', null, true, array())
+            ),
+            array(
+                array(
+                    array('resetIndexType', $this->once())
+                ),
+                array('indexName', 'indexType'),
+                new PopulateEvent('indexName', 'indexType', true, array())
+            )
+        );
     }
 
-    public function testPreIndexPopulateWhenResetIsRequiredAndNoTypeIsSpecified()
+    /**
+     * @param array         $asserts
+     * @param array         $withArgs
+     * @param PopulateEvent $event
+     *
+     * @dataProvider preIndexPopulateDataProvider
+     */
+    public function testPreIndexPopulate(array $asserts, array $withArgs, PopulateEvent $event)
     {
-        $this->resetter->expects($this->once())->method('resetIndex')->with('indexName');
-        $this->listener->preIndexPopulate(new PopulateEvent('indexName', null, true, array()));
-    }
+        foreach ($asserts as $assert) {
+            $this->resetter->expects($assert[1])->method($assert[0])->with($withArgs[0], $withArgs[1]);
+        }
 
-    public function testPreIndexPopulateWhenResetIsRequiredAndTypeIsSpecified()
-    {
-        $this->resetter->expects($this->once())->method('resetIndexType')->with('indexName', 'indexType');
-        $this->listener->preIndexPopulate(new PopulateEvent('indexName', 'indexType', true, array()));
+        $this->listener->preIndexPopulate($event);
     }
 }

--- a/Tests/EventListener/PopulateListenerTest.php
+++ b/Tests/EventListener/PopulateListenerTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace FOS\ElasticaBundle\Tests\EventListener;
+
+use FOS\ElasticaBundle\Event\PopulateEvent;
+use FOS\ElasticaBundle\EventListener\PopulateListener;
+use PHPUnit_Framework_MockObject_MockObject;
+
+class PopulateListenerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var PHPUnit_Framework_MockObject_MockObject
+     */
+    private $resetter;
+
+    /**
+     * @var PopulateListener
+     */
+    private $listener;
+
+    protected function setUp()
+    {
+        $this->resetter = $this->getMockBuilder('FOS\ElasticaBundle\Index\Resetter')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->listener = new PopulateListener($this->resetter);
+    }
+
+    public function testPostIndexPopulate()
+    {
+        $this->resetter->expects($this->once())->method('postPopulate')->with('indexName');
+        $this->listener->postIndexPopulate(new PopulateEvent('indexName', null, true, array()));
+    }
+
+    public function testPreIndexPopulateWhenNoResetRequired()
+    {
+        $this->resetter->expects($this->never())->method('resetIndex');
+        $this->resetter->expects($this->never())->method('resetIndexType');
+        $this->listener->preIndexPopulate(new PopulateEvent('indexName', null, false, array()));
+    }
+
+    public function testPreIndexPopulateWhenResetIsRequiredAndNoTypeIsSpecified()
+    {
+        $this->resetter->expects($this->once())->method('resetIndex')->with('indexName');
+        $this->listener->preIndexPopulate(new PopulateEvent('indexName', null, true, array()));
+    }
+
+    public function testPreIndexPopulateWhenResetIsRequiredAndTypeIsSpecified()
+    {
+        $this->resetter->expects($this->once())->method('resetIndexType')->with('indexName', 'indexType');
+        $this->listener->preIndexPopulate(new PopulateEvent('indexName', 'indexType', true, array()));
+    }
+}

--- a/Tests/Index/ResetterTest.php
+++ b/Tests/Index/ResetterTest.php
@@ -36,8 +36,11 @@ class ResetterTest extends \PHPUnit_Framework_TestCase
         $this->mappingBuilder = $this->getMockBuilder('FOS\\ElasticaBundle\\Index\\MappingBuilder')
             ->disableOriginalConstructor()
             ->getMock();
+        $this->resetter = $this->getMockBuilder('FOS\ElasticaBundle\Index\Resetter')
+            ->disableOriginalConstructor()
+            ->getMock();
 
-        $this->resetter = new Resetter($this->configManager, $this->indexManager, $this->aliasProcessor, $this->mappingBuilder);
+        $this->resetter = new Resetter($this->configManager, $this->indexManager, $this->aliasProcessor, $this->mappingBuilder, $this->resetter);
 
         /*$this->indexConfigsByName = array(
             'foo' => array(


### PR DESCRIPTION
In my project we are using bulk indexing, and according to [doc](http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-update-settings.html#bulk) to increase performant for bulk indexing, we need to have ability call custom actions like: `refresh_interval` and `_optimize?max_num_segments=5`

To achieve that we've added `PRE_INDEX_POPULATE`, `PRE_TYPE_POPULATE`, `POST_TYPE_POPULATE`, `POST_INDEX_POPULATE`, `INDEX_RESET` events.