### PR TITLE
Genuine ES behaviour for getTotalHits()

### DIFF
--- a/Paginator/RawPaginatorAdapter.php
+++ b/Paginator/RawPaginatorAdapter.php
@@ -100,15 +100,18 @@ class RawPaginatorAdapter implements PaginatorAdapterInterface
     /**
      * Returns the number of results.
      *
+     * @param boolean $genuineTotal make the function return the `hits.total`
+     * value of the search result in all cases, instead of limiting it to the
+     * `size` request parameter.
      * @return integer The number of results.
      */
-    public function getTotalHits()
+    public function getTotalHits($genuineTotal = false)
     {
         if ( ! isset($this->totalHits)) {
             $this->totalHits = $this->searchable->search($this->query)->getTotalHits();
         }
 
-        return $this->query->hasParam('size')
+        return $this->query->hasParam('size') && !$genuineTotal
             ? min($this->totalHits, (integer) $this->query->getParam('size'))
             : $this->totalHits;
     }


### PR DESCRIPTION
In response to the issue #746

This minor edit allows RawPaginatorAdapter::getTotalHits() to return the real total count (i.e. all matching documents).

By default, the total is limited to the size query parameter, which doesn't comply with elasticsearch api.

It is useful when you only need to count the number of documents that correspond to a given query, without actually retrieving any document.
