### PR TITLE
Updated installation instructions

### DIFF
--- a/Resources/doc/setup.md
+++ b/Resources/doc/setup.md
@@ -7,7 +7,7 @@ A) Install FOSElasticaBundle
 FOSElasticaBundle is installed using [Composer](https://getcomposer.org).
 
 ```bash
-$ php composer.phar require friendsofsymfony/elastica-bundle "~3.0"
+$ php composer.phar require friendsofsymfony/elastica-bundle
 ```
 
 ### Elasticsearch


### PR DESCRIPTION
In recent Composer versions, when you don't specify the dependency version, it installs the latest available stable version, so the command can be simplified.
