### PR TITLE
Fix PHP notice when using indexes without defined types

### DIFF
--- a/Configuration/Source/ContainerSource.php
+++ b/Configuration/Source/ContainerSource.php
@@ -41,13 +41,16 @@ class ContainerSource implements SourceInterface
         $indexes = array();
         foreach ($this->configArray as $config) {
             $types = array();
-            foreach ($config['types'] as $typeConfig) {
-                $types[$typeConfig['name']] = new TypeConfig(
-                    $typeConfig['name'],
-                    $typeConfig['mapping'],
-                    $typeConfig['config']
-                );
-                // TODO: handle prototypes..
+
+            if (isset($config['types'])) {
+                foreach ($config['types'] as $typeConfig) {
+                    $types[$typeConfig['name']] = new TypeConfig(
+                        $typeConfig['name'],
+                        $typeConfig['mapping'],
+                        $typeConfig['config']
+                    );
+                    // TODO: handle prototypes..
+                }
             }
 
             $index = new IndexConfig($config['name'], $types, array(


### PR DESCRIPTION
This fixes a PHP notice that comes up when executing the `fos:elastica:populate` command if one on the indexes in `config.yml` doesn't define any associated type. Example:

```yaml
fos_elastica:
    indexes:
        my_index: ~
        my_index2:
            types:
                # ...
```

I didn't add any unit test for this, as this is just a simple bug.