### PR TITLE
Fix the BC layer for indexable callbacks

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -199,7 +199,17 @@ class Configuration implements ConfigurationInterface
                         isset($v['persistence']['listener']['is_indexable_callback']);
                 })
                 ->then(function ($v) {
-                    $v['indexable_callback'] = $v['persistence']['listener']['is_indexable_callback'];
+                    $callback = $v['persistence']['listener']['is_indexable_callback'];
+
+                    if (is_array($callback)) {
+                        list($class) = $callback + array(null);
+
+                        if (is_string($class) && !class_exists($class)) {
+                            $callback[0] = '@'.$class;
+                        }
+                    }
+
+                    $v['indexable_callback'] = $callback;
                     unset($v['persistence']['listener']['is_indexable_callback']);
 
                     return $v;


### PR DESCRIPTION
Using services was not based on a @ prefix in the string in the old API but based on the existence of the class.
This fixes the BC layer of #608 for people using public services.

There is still another BC break though, which I haven't fixed yet: the new API only allows to use public services, while the old API was allowing to use private services too
