### PR TITLE
Fix: Catchable Fatal Error: Argument 2 passed to FOS\ElasticaBundle\Doctrine\Listener

### DIFF
--- a/Resources/config/mongodb.xml
+++ b/Resources/config/mongodb.xml
@@ -23,7 +23,6 @@
 
         <service id="fos_elastica.listener.prototype.mongodb" class="%fos_elastica.listener.prototype.mongodb.class%" public="false" abstract="true">
             <argument /> <!-- object persister -->
-            <argument type="collection" /> <!-- events -->
             <argument type="service" id="fos_elastica.indexable" />
             <argument type="collection" /> <!-- configuration -->
             <argument /> <!-- logger -->


### PR DESCRIPTION
The Change was merged in https://github.com/FriendsOfSymfony/FOSElasticaBundle/commit/d731443aa5ad7a12c133bd1d7b97fa242c546e1e

-> XML for mongodb was not changed

Catchable Fatal Error: Argument 2 passed to FOS\ElasticaBundle\Doctrine\Listener::__construct() must implement interface FOS\ElasticaBundle\Provider\IndexableInterface, array given, called in /var/www/app/app/cache/dev/appDevDebugProjectContainer.php on line 2006 and defined