### PR TITLE
Typo in manual-provider.md

### DIFF
--- a/Resources/doc/cookbook/manual-provider.md
+++ b/Resources/doc/cookbook/manual-provider.md
@@ -8,7 +8,7 @@ index and type for which the service will provide.
 # app/config/config.yml
 services:
     acme.search_provider.user:
-        class: Acme\UserBundle\Search\UserProvider
+        class: Acme\UserBundle\Provider\UserProvider
         arguments:
             - @fos_elastica.index.website.user
         tags:


### PR DESCRIPTION
Typo in class path