### PR TITLE
Fix the handling of the parent mapping in the configuration

### DIFF
--- a/DependencyInjection/FOSElasticaExtension.php
+++ b/DependencyInjection/FOSElasticaExtension.php
@@ -393,7 +393,14 @@ class FOSElasticaExtension extends Extension
             $arguments[] = array(new Reference($callbackId), 'serialize');
         } else {
             $abstractId = 'fos_elastica.object_persister';
-            $arguments[] = $this->indexConfigs[$indexName]['types'][$typeName]['mapping']['properties'];
+            $fields = $this->indexConfigs[$indexName]['types'][$typeName]['mapping']['properties'];
+
+            // Add the _parent configuration as a field as the transformer needs to know about it and expects it this way.
+            if (isset($this->indexConfigs[$indexName]['types'][$typeName]['mapping']['_parent'])) {
+                $fields['_parent'] = $this->indexConfigs[$indexName]['types'][$typeName]['mapping']['_parent'];
+            }
+
+            $arguments[] = $fields;
         }
 
         $serviceId = sprintf('fos_elastica.object_persister.%s.%s', $indexName, $typeName);

--- a/Transformer/ModelToElasticaAutoTransformer.php
+++ b/Transformer/ModelToElasticaAutoTransformer.php
@@ -62,7 +62,7 @@ class ModelToElasticaAutoTransformer implements ModelToElasticaTransformerInterf
         $document = new Document($identifier);
 
         foreach ($fields as $key => $mapping) {
-            if ($key == '_parent') {
+            if ($key === '_parent') {
                 $property = (null !== $mapping['property'])?$mapping['property']:$mapping['type'];
                 $value = $this->propertyAccessor->getValue($object, $property);
                 $document->setParent($this->propertyAccessor->getValue($value, $mapping['identifier']));


### PR DESCRIPTION
This fixes a regression introduced in 3.0 in #629. The issue is because of the refactoring of https://github.com/FriendsOfSymfony/FOSElasticaBundle/pull/629/files#diff-e0950e36ea63dd2c4b5151242670298cL244 where adding the parent in the replacement of typeFields was missing.

Closes #774