### PR TITLE
fix error for empty type configuration

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -192,6 +192,10 @@ class Configuration implements ConfigurationInterface
             ->useAttributeAsKey('name')
             ->prototype('array')
                 ->treatNullLike(array())
+                ->beforeNormalization()
+                ->ifNull()
+                ->thenEmptyArray()
+                ->end()
                 // BC - Renaming 'mappings' node to 'properties'
                 ->beforeNormalization()
                 ->ifTrue(function($v) { return array_key_exists('mappings', $v); })

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -199,6 +199,24 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         $this->assertCount(3, $configuration['indexes']['test']['types']['test']['properties']);
     }
 
+    public function testUnconfiguredType()
+    {
+        $configuration = $this->getConfigs(array(
+                'clients' => array(
+                    'default' => array('url' => 'http://localhost:9200'),
+                ),
+                'indexes' => array(
+                    'test' => array(
+                        'types' => array(
+                            'test' => null
+                        )
+                    )
+                )
+            ));
+
+        $this->assertArrayHasKey('properties', $configuration['indexes']['test']['types']['test']);
+    }
+
     public function testNestedProperties()
     {
         $this->getConfigs(array(


### PR DESCRIPTION
I use elastica-bundle without configuration types, like this:

```fos_elastica:
    indexes:
        foo:
            types:
                bar:
                bar2:
```

This pull request fix warning:
"PHP Warning:  array_key_exists() expects parameter 2 to be array, null given in .../vendor/friendsofsymfony/elastica-bundle/DependencyInjection/Configuration.php on line 197" with such configuration

