### PR TITLE
Additional change for 2.5 ProgressBar support

### DIFF
--- a/Command/PopulateCommand.php
+++ b/Command/PopulateCommand.php
@@ -170,7 +170,7 @@ class PopulateCommand extends ContainerAwareCommand
             $progress->setMessage(sprintf('<info>Populating</info> <comment>%s/%s</comment>', $index, $type));
             $progress->advance($increment);
 
-            if ($progress->getProgress() >= $progress->getMaxSteps()) {
+            if ($progress->getProgressPercent() >= 1.0) {
                 $progress->finish();
             }
         };


### PR DESCRIPTION
getProgress() is not available and getStep() throws a deprecation warning.