### PR TITLE
Don't run resetter postPopulate if --no-reset. #797

### DIFF
--- a/Command/PopulateCommand.php
+++ b/Command/PopulateCommand.php
@@ -125,8 +125,11 @@ class PopulateCommand extends ContainerAwareCommand
             $provider->populate($loggerClosure, $options);
         }
 
+        if ($reset) {
+            $this->resetter->postPopulate($index);
+        }
+
         $output->writeln(sprintf('<info>Refreshing</info> <comment>%s</comment>', $index));
-        $this->resetter->postPopulate($index);
         $this->indexManager->getIndex($index)->refresh();
     }
 


### PR DESCRIPTION
This prevents my alias from getting deleted. It generally seems reasonable not to call any methods on the resetter with the --no-reset option set.