### PR TITLE
Doctrine listener exception fix

### DIFF
--- a/Resources/config/mongodb.xml
+++ b/Resources/config/mongodb.xml
@@ -29,7 +29,7 @@
             <argument /> <!-- object persister -->
             <argument type="service" id="fos_elastica.indexable" />
             <argument type="collection" /> <!-- configuration -->
-            <argument /> <!-- logger -->
+            <argument type="service" on-invalid="ignore" /> <!-- logger -->
         </service>
 
         <service id="fos_elastica.elastica_to_model_transformer.prototype.mongodb" class="%fos_elastica.elastica_to_model_transformer.prototype.mongodb.class%" public="false" abstract="true">

--- a/Resources/config/orm.xml
+++ b/Resources/config/orm.xml
@@ -29,7 +29,7 @@
             <argument /> <!-- object persister -->
             <argument type="service" id="fos_elastica.indexable" />
             <argument type="collection" /> <!-- configuration -->
-            <argument on-invalid="ignore" /> <!-- logger -->
+            <argument type="service" on-invalid="ignore" /> <!-- logger -->
         </service>
 
         <service id="fos_elastica.elastica_to_model_transformer.prototype.orm" class="%fos_elastica.elastica_to_model_transformer.prototype.orm.class%" public="false" abstract="true">

--- a/Tests/Doctrine/AbstractProviderTest.php
+++ b/Tests/Doctrine/AbstractProviderTest.php
@@ -19,7 +19,7 @@ class AbstractProviderTest extends \PHPUnit_Framework_TestCase
     {
         $this->objectClass = 'objectClass';
         $this->options = array('debug_logging' => true, 'indexName' => 'index', 'typeName' => 'type');
-<
+
         $this->objectPersister = $this->getMockObjectPersister();
         $this->managerRegistry = $this->getMockManagerRegistry();
         $this->objectManager = $this->getMockObjectManager();


### PR DESCRIPTION
After update I became receiving following exception:
```
[Symfony\Component\Debug\Exception\ContextErrorException]
  Catchable Fatal Error: Argument 4 passed to FOS\ElasticaBundle\Doctrine\Listener::__construct() must implement interface
   Psr\Log\LoggerInterface, string given, called in /var/www/Kolektado/app/cache/dev/appDevDebugProjectContainer.php on li
  ne 1727 and defined in /var/www/Kolektado/vendor/friendsofsymfony/elastica-bundle/Doctrine/Listener.php line 79
```