### PR TITLE
Fix an error when batch size is empty

### DIFF
--- a/Command/PopulateCommand.php
+++ b/Command/PopulateCommand.php
@@ -90,8 +90,10 @@ class PopulateCommand extends ContainerAwareCommand
         $index = $input->getOption('index');
         $type = $input->getOption('type');
         $reset = !$input->getOption('no-reset');
+        $batchSize = $input->getOption('batch-size');
+        
         $options = array(
-            'batch_size' => $input->getOption('batch-size'),
+            'batch_size' => !empty( $batchSize ) ? $batchSize : 1,
             'ignore_errors' => $input->getOption('ignore-errors'),
             'offset' => $input->getOption('offset'),
             'sleep' => $input->getOption('sleep')


### PR DESCRIPTION
if batch size is null or empty , doPopulate will loop forever on the
first type indexing