### PR TITLE
Fix symfony 2.3 compatibility with 3.1

### DIFF
--- a/Provider/AbstractProvider.php
+++ b/Provider/AbstractProvider.php
@@ -108,7 +108,9 @@ abstract class AbstractProvider implements ProviderInterface
             'batch_size' => 100,
             'skip_indexable_check' => false,
         ));
-        $this->resolver->setAllowedTypes('batch_size', 'int');
+        $this->resolver->setAllowedTypes(array(
+            'batch_size' => 'int'
+        ));
 
         $this->resolver->setRequired(array(
             'indexName',


### PR DESCRIPTION
Uses the deprecated interface for setting allowed types