### PR TITLE
Allow transform options to be passed to the FinderInterface

### DIFF
--- a/Doctrine/MongoDB/ElasticaToModelTransformer.php
+++ b/Doctrine/MongoDB/ElasticaToModelTransformer.php
@@ -3,6 +3,7 @@
 namespace FOS\ElasticaBundle\Doctrine\MongoDB;
 
 use FOS\ElasticaBundle\Doctrine\AbstractElasticaToModelTransformer;
+use Doctrine\ORM\Query;
 
 /**
  * Maps Elastica documents with Doctrine objects
@@ -15,18 +16,20 @@ class ElasticaToModelTransformer extends AbstractElasticaToModelTransformer
      * Fetch objects for theses identifier values.
      *
      * @param array   $identifierValues ids values
-     * @param Boolean $hydrate          whether or not to hydrate the objects, false returns arrays
+     * @param array   $options
      *
      * @return array of objects or arrays
      */
-    protected function findByIdentifiers(array $identifierValues, $hydrate)
+    protected function findByIdentifiers(array $identifierValues, array $options = array())
     {
+        $options = array_merge($this->options, $options);
+
         return $this->registry
             ->getManagerForClass($this->objectClass)
             ->getRepository($this->objectClass)
             ->{$this->options['query_builder_method']}($this->objectClass)
             ->field($this->options['identifier'])->in($identifierValues)
-            ->hydrate($hydrate)
+            ->hydrate($options['hydrate'])
             ->getQuery()
             ->execute()
             ->toArray();

--- a/Finder/FinderInterface.php
+++ b/Finder/FinderInterface.php
@@ -10,8 +10,9 @@ interface FinderInterface
      * @param mixed $query   Can be a string, an array or an \Elastica\Query object
      * @param int   $limit   How many results to get
      * @param array $options
+     * @param array $transformOptions Transform options
      *
      * @return array results
      */
-    public function find($query, $limit = null, $options = array());
+    public function find($query, $limit = null, $options = array(), $transformOptions = array());
 }

--- a/Finder/TransformedFinder.php
+++ b/Finder/TransformedFinder.php
@@ -30,21 +30,22 @@ class TransformedFinder implements PaginatedFinderInterface
      * @param string  $query
      * @param integer $limit
      * @param array   $options
+     * @param array   $transformOptions
      *
      * @return array of model objects
      **/
-    public function find($query, $limit = null, $options = array())
+    public function find($query, $limit = null, $options = array(), $transformOptions = array())
     {
         $results = $this->search($query, $limit, $options);
 
-        return $this->transformer->transform($results);
+        return $this->transformer->transform($results, $transformOptions);
     }
 
-    public function findHybrid($query, $limit = null, $options = array())
+    public function findHybrid($query, $limit = null, $options = array(), $transformOptions = array())
     {
         $results = $this->search($query, $limit, $options);
 
-        return $this->transformer->hybridTransform($results);
+        return $this->transformer->hybridTransform($results, $transformOptions);
     }
 
     /**
@@ -53,15 +54,16 @@ class TransformedFinder implements PaginatedFinderInterface
      * @param integer $id
      * @param array   $params
      * @param array   $query
+     * @param array   $transformOptions
      *
      * @return array of model objects
      **/
-    public function moreLikeThis($id, $params = array(), $query = array())
+    public function moreLikeThis($id, $params = array(), $query = array(), $transformOptions = array())
     {
         $doc = new Document($id);
         $results = $this->searchable->moreLikeThis($doc, $params, $query)->getResults();
 
-        return $this->transformer->transform($results);
+        return $this->transformer->transform($results, $transformOptions);
     }
 
     /**

--- a/Propel/ElasticaToModelTransformer.php
+++ b/Propel/ElasticaToModelTransformer.php
@@ -119,20 +119,22 @@ class ElasticaToModelTransformer extends AbstractElasticaToModelTransformer
      * If $hydrate is false, the returned array elements will be arrays.
      * Otherwise, the results will be hydrated to instances of the model class.
      *
-     * @param array   $identifierValues Identifier values
-     * @param boolean $hydrate          Whether or not to hydrate the results
+     * @param array $identifierValues Identifier values
+     * @param array $options transform options
      *
      * @return array
      */
-    protected function findByIdentifiers(array $identifierValues, $hydrate)
+    protected function findByIdentifiers(array $identifierValues, array $options = array())
     {
+        $options = array_merge($this->options, $options);
+
         if (empty($identifierValues)) {
             return array();
         }
 
-        $query = $this->createQuery($this->objectClass, $this->options['identifier'], $identifierValues);
+        $query = $this->createQuery($this->objectClass, $options['identifier'], $identifierValues);
 
-        if (! $hydrate) {
+        if (!$options['hydrate']) {
             return $query->toArray();
         }
 

--- a/Propel/ElasticaToModelTransformer.php
+++ b/Propel/ElasticaToModelTransformer.php
@@ -51,21 +51,24 @@ class ElasticaToModelTransformer extends AbstractElasticaToModelTransformer
      * fetched from the database.
      *
      * @param array $elasticaObjects
+     * @param array $options
      *
      * @return array|\ArrayObject
      */
-    public function transform(array $elasticaObjects)
+    public function transform(array $elasticaObjects, array $options = array())
     {
+        $options = array_merge($this->options, $options);
+
         $ids = array();
         foreach ($elasticaObjects as $elasticaObject) {
             $ids[] = $elasticaObject->getId();
         }
 
-        $objects = $this->findByIdentifiers($ids, $this->options['hydrate']);
+        $objects = $this->findByIdentifiers($ids, $options['hydrate']);
 
         // Sort objects in the order of their IDs
         $idPos = array_flip($ids);
-        $identifier = $this->options['identifier'];
+        $identifier = $options['identifier'];
         $sortCallback = $this->getSortingClosure($idPos, $identifier);
 
         if (is_object($objects)) {
@@ -80,9 +83,11 @@ class ElasticaToModelTransformer extends AbstractElasticaToModelTransformer
     /**
      * {@inheritdoc}
      */
-    public function hybridTransform(array $elasticaObjects)
+    public function hybridTransform(array $elasticaObjects, array $options = array())
     {
-        $objects = $this->transform($elasticaObjects);
+        $options = array_merge($this->options, $options);
+
+        $objects = $this->transform($elasticaObjects, $options);
 
         $result = array();
         for ($i = 0, $j = count($elasticaObjects); $i < $j; $i++) {

--- a/Transformer/ElasticaToModelTransformerCollection.php
+++ b/Transformer/ElasticaToModelTransformerCollection.php
@@ -41,10 +41,11 @@ class ElasticaToModelTransformerCollection implements ElasticaToModelTransformer
 
     /**
      * @param Document[] $elasticaObjects
+     * @param array      $options
      *
      * @return array
      */
-    public function transform(array $elasticaObjects)
+    public function transform(array $elasticaObjects, array $options = array())
     {
         $sorted = array();
         foreach ($elasticaObjects as $object) {
@@ -53,7 +54,7 @@ class ElasticaToModelTransformerCollection implements ElasticaToModelTransformer
 
         $transformed = array();
         foreach ($sorted as $type => $objects) {
-            $transformedObjects = $this->transformers[$type]->transform($objects);
+            $transformedObjects = $this->transformers[$type]->transform($objects, $options);
             $identifierGetter = 'get'.ucfirst($this->transformers[$type]->getIdentifierField());
             $transformed[$type] = array_combine(
                 array_map(
@@ -76,9 +77,9 @@ class ElasticaToModelTransformerCollection implements ElasticaToModelTransformer
         return $result;
     }
 
-    public function hybridTransform(array $elasticaObjects)
+    public function hybridTransform(array $elasticaObjects, array $options = array())
     {
-        $objects = $this->transform($elasticaObjects);
+        $objects = $this->transform($elasticaObjects, $options);
 
         $result = array();
         for ($i = 0, $j = count($elasticaObjects); $i < $j; $i++) {

--- a/Transformer/ElasticaToModelTransformerInterface.php
+++ b/Transformer/ElasticaToModelTransformerInterface.php
@@ -12,12 +12,13 @@ interface ElasticaToModelTransformerInterface
      * model objects fetched from the doctrine repository.
      *
      * @param array $elasticaObjects array of elastica objects
+     * @param array $options         transform options
      *
      * @return array of model objects
      **/
-    public function transform(array $elasticaObjects);
+    public function transform(array $elasticaObjects, array $options = array());
 
-    public function hybridTransform(array $elasticaObjects);
+    public function hybridTransform(array $elasticaObjects, array $options = array());
 
     /**
      * Returns the object class used by the transformer.


### PR DESCRIPTION
Hi,

I've struggled lately to change the hydratation mode (and query builder) inline between two consecutive requests. As i've seen it's not possible (correct me if I'm wrong), it's only possible by defining it in configuration or using custom Provider.

This PR offers a way to pass transformOptions to the find / findHybrid / moreLikeThis method of the PaginatedFinderInterface.

This should not be a BC break.

If this PR is useless due to another better solution, please feel free to say it