### PR TITLE
Fixes wrong count for queries with joins in Doctrine ORM Provider

### DIFF
--- a/Doctrine/ORM/Provider.php
+++ b/Doctrine/ORM/Provider.php
@@ -61,7 +61,7 @@ class Provider extends AbstractProvider
         $rootAliases = $queryBuilder->getRootAliases();
 
         return $qb
-            ->select($qb->expr()->count($rootAliases[0]))
+            ->select($qb->expr()->countDistinct($rootAliases[0]))
             // Remove ordering for efficiency; it doesn't affect the count
             ->resetDQLPart('orderBy')
             ->getQuery()


### PR DESCRIPTION
Partially fixes #844 by adding distinct to the count query. With this fix, custom queries can use joins (though not fetch-joins) without breaking populate.