### PR TITLE
Add fos:elastica:populate --limit option.

### DIFF
--- a/Command/PopulateCommand.php
+++ b/Command/PopulateCommand.php
@@ -55,6 +55,7 @@ class PopulateCommand extends ContainerAwareCommand
             ->addOption('type', null, InputOption::VALUE_OPTIONAL, 'The type to repopulate')
             ->addOption('no-reset', null, InputOption::VALUE_NONE, 'Do not reset index before populating')
             ->addOption('offset', null, InputOption::VALUE_REQUIRED, 'Start indexing at offset', 0)
+            ->addOption('limit', null, InputOption::VALUE_REQUIRED, 'Populate at most this many documents', 0)
             ->addOption('sleep', null, InputOption::VALUE_REQUIRED, 'Sleep time between persisting iterations (microseconds)', 0)
             ->addOption('batch-size', null, InputOption::VALUE_REQUIRED, 'Index packet size (overrides provider config option)')
             ->addOption('ignore-errors', null, InputOption::VALUE_NONE, 'Do not stop on errors')
@@ -97,6 +98,9 @@ class PopulateCommand extends ContainerAwareCommand
         );
         if ($input->getOption('batch-size')) {
             $options['batch_size'] = (int) $input->getOption('batch-size');
+        }
+        if ($input->getOption('limit')) {
+            $options['limit'] = (int) $input->getOption('limit');
         }
 
         if ($input->isInteractive() && $reset && $input->getOption('offset')) {

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -514,6 +514,7 @@ class Configuration implements ConfigurationInterface
                             ->defaultValue($this->debug)
                             ->treatNullLike(true)
                         ->end()
+                        ->scalarNode('limit')->end()
                         ->scalarNode('query_builder_method')->defaultValue('createQueryBuilder')->end()
                         ->scalarNode('service')->end()
                     ->end()

--- a/Doctrine/AbstractProvider.php
+++ b/Doctrine/AbstractProvider.php
@@ -83,10 +83,12 @@ abstract class AbstractProvider extends BaseAbstractProvider
 
         $queryBuilder = $this->createQueryBuilder($options['query_builder_method']);
         $nbObjects = $this->countObjects($queryBuilder);
+        $limit = $options['limit'] ?: $nbObjects;
         $offset = $options['offset'];
 
         $objects = array();
-        for (; $offset < $nbObjects; $offset += $options['batch_size']) {
+        for ($count = 0; ($count < $limit) && ($offset < $nbObjects); $count += $options['batch_size'], $offset += $options['batch_size']) {
+            $sliceSize = $options['batch_size'];
             try {
                 $objects = $this->getSlice($queryBuilder, $options['batch_size'], $offset, $objects);
                 $objects = $this->filterObjects($options, $objects);
@@ -115,7 +117,7 @@ abstract class AbstractProvider extends BaseAbstractProvider
             usleep($options['sleep']);
 
             if (null !== $loggerClosure) {
-                $loggerClosure($options['batch_size'], $nbObjects);
+                $loggerClosure($sliceSize, $limit);
             }
         }
     }

--- a/Doctrine/AbstractProvider.php
+++ b/Doctrine/AbstractProvider.php
@@ -86,6 +86,10 @@ abstract class AbstractProvider extends BaseAbstractProvider
         $limit = $options['limit'] ?: $nbObjects;
         $offset = $options['offset'];
 
+        if (null !== $loggerClosure) {
+            $loggerClosure($offset, $nbObjects);
+        }
+
         $objects = array();
         for ($count = 0; ($count < $limit) && ($offset < $nbObjects); $count += $options['batch_size'], $offset += $options['batch_size']) {
             $sliceSize = $options['batch_size'];
@@ -117,7 +121,7 @@ abstract class AbstractProvider extends BaseAbstractProvider
             usleep($options['sleep']);
 
             if (null !== $loggerClosure) {
-                $loggerClosure($sliceSize, $limit);
+                $loggerClosure($sliceSize, $nbObjects);
             }
         }
     }

--- a/Provider/AbstractProvider.php
+++ b/Provider/AbstractProvider.php
@@ -106,12 +106,13 @@ abstract class AbstractProvider implements ProviderInterface
     {
         $this->resolver->setDefaults(array(
             'batch_size' => 100,
+            'limit' => 0,
             'skip_indexable_check' => false,
         ));
         $this->resolver->setAllowedTypes(array(
-            'batch_size' => 'int'
+            'batch_size' => 'int',
+            'limit' => 'int',
         ));
-
         $this->resolver->setRequired(array(
             'indexName',
             'typeName',

--- a/Tests/Functional/DataFixtures/LoadTypeObjects.php
+++ b/Tests/Functional/DataFixtures/LoadTypeObjects.php
@@ -5,12 +5,17 @@ namespace FOS\ElasticaBundle\Tests\Functional\DataFixtures;
 use Doctrine\Common\Persistence\ObjectManager;
 use FOS\ElasticaBundle\Tests\Functional\TypeObj;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class LoadTypeObjects implements ContainerAwareInterface
 // , FixtureInterface
 {
-    use ContainerAwareTrait;
+    private $container;
+
+    public function setContainer(ContainerInterface $container = null)
+    {
+        $this->container = $container;
+    }
 
     /**
      * {@inheritDoc}

--- a/Tests/Functional/DataFixtures/LoadTypeObjects.php
+++ b/Tests/Functional/DataFixtures/LoadTypeObjects.php
@@ -1,0 +1,29 @@
+<?php
+namespace FOS\ElasticaBundle\Tests\Functional\DataFixtures;
+
+// use Doctrine\Common\DataFixtures\FixtureInterface;
+use Doctrine\Common\Persistence\ObjectManager;
+use FOS\ElasticaBundle\Tests\Functional\TypeObj;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareTrait;
+
+class LoadTypeObjects implements ContainerAwareInterface
+// , FixtureInterface
+{
+    use ContainerAwareTrait;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function load(ObjectManager $manager) {
+        for ($i = 0; $i < 10; ++$i) {
+            $type = new TypeObj();
+            $type->id = $i;
+            $type->coll = $i + 1;
+            $type->field1 = $i + 2;
+            $type->field2 = $i + 3;
+            $manager->persist($type);
+        }
+        $manager->flush();
+    }
+}

--- a/Tests/Functional/PopulateTest.php
+++ b/Tests/Functional/PopulateTest.php
@@ -28,6 +28,7 @@ class PopulateTest extends WebTestCase
         $command = $this->application->find('fos:elastica:populate');
         $tester = new CommandTester($command);
         $tester->execute(array(
+            'command' => $command->getName(),
             '--batch-size' => 4,
             '--index' => 'index', 
             '--limit' => 10,
@@ -49,7 +50,7 @@ class PopulateTest extends WebTestCase
     private function createSchema() {
         $command = $this->application->find('doctrine:schema:create');
         $tester = new CommandTester($command);
-        $tester->execute(array());
+        $tester->execute(array(), array());
         $this->assertContains('Database schema created successfully', $tester->getDisplay());
     }
 

--- a/Tests/Functional/PopulateTest.php
+++ b/Tests/Functional/PopulateTest.php
@@ -1,0 +1,61 @@
+<?php
+namespace FOS\ElasticaBundle\Tests\Functional;
+
+use Doctrine\Bundle\DoctrineBundle\Command\Proxy\CreateSchemaDoctrineCommand;
+use FOS\ElasticaBundle\Command\PopulateCommand;
+use FOS\ElasticaBundle\Tests\Functional\DataFixtures\LoadTypeObjects;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * @group functional
+ */
+class PopulateTest extends WebTestCase
+{
+    private $application;
+    private $client;
+
+    public function setUp() {
+        $this->client = $this->createClient(array('test_case' => 'ORM'));
+        $this->application = new Application($this->client->getKernel());
+        $this->application->add(new CreateSchemaDoctrineCommand());
+        $this->application->add(new PopulateCommand());
+        $this->createSchema();
+        $this->loadFixtures();
+    }
+
+    public function testPopulate() {
+        $command = $this->application->find('fos:elastica:populate');
+        $tester = new CommandTester($command);
+        $tester->execute(array(
+            '--batch-size' => 4,
+            '--index' => 'index', 
+            '--limit' => 10,
+            '--no-reset' => true,
+            '--offset' => 2,
+            '--type' => 'type',
+        ));
+        $display = $tester->getDisplay();
+        foreach (array(0, 2, 6, 10) as $i) { 
+            $this->assertContains("$i/10", $display);
+        }
+        foreach (array(1, 3, 4, 5, 7, 8, 9) as $i) { 
+            $this->assertNotContains("$i/10", $display);
+        }
+        $this->assertContains('Populating index/type', $display);
+        $this->assertContains('Refreshing index', $display);
+    }
+
+    private function createSchema() {
+        $command = $this->application->find('doctrine:schema:create');
+        $tester = new CommandTester($command);
+        $tester->execute(array());
+        $this->assertContains('Database schema created successfully', $tester->getDisplay());
+    }
+
+    private function loadFixtures() {
+        $manager = $this->client->getContainer()->get('doctrine')->getManager();
+        $fixture = new LoadTypeObjects();
+        $fixture->load($manager);
+    }
+}

--- a/Tests/Functional/app/ORM/config.yml
+++ b/Tests/Functional/app/ORM/config.yml
@@ -3,11 +3,17 @@ imports:
 
 doctrine:
     dbal:
+        driver: pdo_sqlite
         path: %kernel.cache_dir%/db.sqlite
         charset:  UTF8
     orm:
         auto_generate_proxy_classes: false
         auto_mapping: false
+        mappings:
+            FOS\ElasticaBundle\Tests\Functional:
+                dir: %kernel.root_dir%/ORM/doctrine
+                prefix: FOS\ElasticaBundle\Tests\Functional
+                type: yml
 
 services:
     indexableService:

--- a/Tests/Functional/app/ORM/doctrine/TypeObj.orm.yml
+++ b/Tests/Functional/app/ORM/doctrine/TypeObj.orm.yml
@@ -1,0 +1,13 @@
+FOS\ElasticaBundle\Tests\Functional\TypeObj:
+    type: entity
+    repositoryClass: Doctrine\ORM\EntityRepository
+    id:
+        id:
+            type: integer
+    fields:
+        coll:
+            type: integer
+        field1:
+            type: integer
+        field2:
+            type: integer


### PR DESCRIPTION
I've reimplemented this PR (previous #799) against 3.1.0 to take advantage of the populateIndex() separation (that did not exist in 3.0.0). The default FOS\ElasticaBundle\Doctrine\MongoDB\SliceFetcher uses a `where primary_key > last_key` style of iteration that works great, but the skip($offset) call becomes prohibitive past a few million documents, slowing populate to a crawl (making --offset useless). We happen to have a sequentially indexed integer that we can use instead of the hash primary key, which lets me add the offset to the integer key to avoid the expensive skip call.

``` php
/**
 * {@inheritdoc}
 */
class SliceFetcher implements SliceFetcherInterface
{
    /**
     * {@inheritdoc}
     */
    public function fetch($queryBuilder, $limit, $offset, array $previousSlice, array $identifierFieldNames)
    {
        if (!$queryBuilder instanceof Builder) {
            throw new InvalidArgumentTypeException($queryBuilder, 'Doctrine\ODM\MongoDB\Query\Builder');
        }

        $lastObject = array_pop($previousSlice);
        if (!$lastObject) {
            $lastObject = $queryBuilder
                ->limit(1)
                ->sort(array('humanReadableId' => 'asc'))
                ->getQuery()
                ->getSingleResult();
            $lastObjectId = $lastObject->getHumanReadableId() + $offset;
        } else {
            $lastObjectId = $lastObject->getHumanReadableId();
        }

        return $queryBuilder
            ->field('humanReadableId')
                ->gt($lastObjectId)
            ->limit($limit)
            ->sort(array('humanReadableId' => 'asc'))
            ->getQuery()
            ->execute()
            ->toArray();
    }
}
```

There are gaps in the sequence, so I iterate over the span of integer ids instead of the number of documents in mongo. This amounts to around 3% inefficiency as some documents are submitted more than once. We more than make that back when we toss multiple processors at the problem:

``` bash
#!/bin/bash -ex
exec 1> >(tee /tmp/reindex.log) 2>&1
echo $$ >/tmp/reindex.pid
MONGO='ssh mongo1 mongo marketplace --quiet'
APP="sudo -u www-data php -d memory_limit=1G /usr/share/nginx/www/sites/sgmarketplace/app/console"
#DOCS=`echo 'db.products.count()' | $MONGO`
MIN=`echo 'db.products.find({humanReadableId:{$exists:true}}).sort({humanReadableId:1}).limit(1)[0].humanReadableId.valueOf()' | $MONGO`
MAX=`echo 'db.products.find().sort({humanReadableId:-1}).limit(1)[0].humanReadableId.valueOf()' | $MONGO`
DOCS=`expr $MAX - $MIN`
BATCH=1000
PROCS=`grep -c processor /proc/cpuinfo`
LIMIT=100000
$APP fos:elastica:reset
$APP fos:elastica:populate --index search --type store
eval echo {0..$DOCS..$LIMIT} |\
xargs -n1 -P$PROCS $APP fos:elastica:populate --no-reset --batch-size $BATCH --limit $LIMIT --index search --type product --offset
```

Final results, on a four processor machine, my populate time is cut down to roughly five hours from sixteen. We'll throw even more processors at it in production. ;)
