### PR TITLE
Count the number of results for the query directly

### DIFF
--- a/Paginator/RawPaginatorAdapter.php
+++ b/Paginator/RawPaginatorAdapter.php
@@ -121,7 +121,7 @@ class RawPaginatorAdapter implements PaginatorAdapterInterface
     public function getTotalHits($genuineTotal = false)
     {
         if (! isset($this->totalHits)) {
-            $this->totalHits = $this->searchable->search($this->query)->getTotalHits();
+            $this->totalHits = $this->searchable->count($this->query);
         }
 
         return $this->query->hasParam('size') && !$genuineTotal


### PR DESCRIPTION
You don't have to execute the entire query to just count the number of result.