### PR TITLE
Fixed parameter name to kernel.environment

### DIFF
--- a/Resources/doc/setup.md
+++ b/Resources/doc/setup.md
@@ -74,7 +74,7 @@ Symfony application, use the example below:
 fos_elastica:
     indexes:
         app:
-            index_name: app_%kernel.env%
+            index_name: app_%kernel.environment%
 ```
 
 In this case, the service `fos_elastica.index.app` will relate to an ElasticSearch index


### PR DESCRIPTION
The parameter %kernel.env% does not exist. It throws the error message 'You have requested a non-existent parameter "kernel.env". Did you mean this: "kernel.environment"?'