### PR TITLE
Fix propel usage

### DIFF
--- a/Propel/Provider.php
+++ b/Propel/Provider.php
@@ -43,6 +43,23 @@ class Provider extends AbstractProvider
     /**
      * {@inheritDoc}
      */
+    protected function configureOptions()
+    {
+        parent::configureOptions();
+
+        $this->resolver->setDefaults(array(
+            'clear_object_manager' => true,
+            'debug_logging'        => false,
+            'ignore_errors'        => false,
+            'offset'               => 0,
+            'query_builder_method' => 'createQueryBuilder',
+            'sleep'                => 0
+        ));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
     protected function disableLogging()
     {
     }


### PR DESCRIPTION
Without this fix I got:

```
  [Symfony\Component\OptionsResolver\Exception\InvalidOptionsException]
  The options "clear_object_manager", "debug_logging", "ignore_errors", "offset", "query_builder_method", "sleep" do
  not exist. Known options are: "batch_size", "indexName", "skip_indexable_check", "typeName"
```