### PR TITLE
Refactor custom provider doc

### DIFF
--- a/Resources/doc/cookbook/manual-provider.md
+++ b/Resources/doc/cookbook/manual-provider.md
@@ -1,33 +1,51 @@
-Manual provider
+Custom provider
 ===============
 
-Create a service with the tag "fos_elastica.provider" and attributes for the
-index and type for which the service will provide.
+Usually the index gets populated from the database using the `orm` or `propel`
+provider. But sometimes you might want to index stuff not stored in the
+database. For example you want to index users from another backend or files
+from some storage or some remote resources.
+
+First you need to remove the `provider` stuff from the `config.yml`:
 
 ```yaml
 # app/config/config.yml
+fos_elastica:
+    indexes:
+        app:
+            types:
+                user:
+                    mappings:
+                        id: ~
+                        username: ~
+```
+
+Next create a service with the tag `fos_elastica.provider` and attributes for
+the index and type for which the service will provide.
+
+```yaml
+# app/config/services.yml
 services:
     acme.search_provider.user:
         class: Acme\UserBundle\Provider\UserProvider
         arguments:
             - @fos_elastica.index.website.user
         tags:
-            - { name: fos_elastica.provider, index: website, type: user }
+            - { name: fos_elastica.provider, index: app, type: user }
 ```
 
 Its class must implement `FOS\ElasticaBundle\Provider\ProviderInterface`.
 
 ```php
-
 namespace Acme\UserBundle\Provider;
 
-use FOS\ElasticaBundle\Provider\ProviderInterface;
-use Elastica\Type;
 use Elastica\Document;
+use Elastica\Type;
+use FOS\ElasticaBundle\Provider\ProviderInterface;
 
 class UserProvider implements ProviderInterface
 {
-    protected $userType;
+    private $userType;
 
     public function __construct(Type $userType)
     {
@@ -35,22 +53,43 @@ class UserProvider implements ProviderInterface
     }
 
     /**
-     * Insert the repository objects in the type index
+     * Insert the objects in the user type
      *
      * @param \Closure $loggerClosure
      * @param array    $options
      */
     public function populate(\Closure $loggerClosure = null, array $options = array())
     {
-        if ($loggerClosure) {
-            $loggerClosure('Indexing users');
+        // some logic to load our users from somewhere
+
+        $usersCount = count($users);
+        foreach ($users as $user) {
+            if ($loggerClosure) {
+                // first argument is step size, second argument total count
+                // will display a nice progress bar while populating
+                $loggerClosure(1, $usersCount);
+            }
+
+            $document = new Document();
+            $document->setData(array(
+                'id' => $user['id'],
+                'username' => $user['username'],
+            ));
+            $this->userType->addDocuments(array($document));
         }
 
-        $document = new Document();
-        $document->setData(array('username' => 'Bob'));
-        $this->userType->addDocuments(array($document));
     }
 }
 ```
 
-You will find a more complete implementation example in `src/FOS/ElasticaBundle/Doctrine/AbstractProvider.php`.
+Finally run `app/console` to populate your search index:
+
+```shell
+$ app/console fos:elastica:populate
+431/431 [============================] 100%
+Populating app/user
+Refreshing app
+```
+
+And you are done! Congratulations!
+


### PR DESCRIPTION
The term "manual provider" was misleading. I did not want to rename the
file to avoid breaking existing links.

Example for index configuration added, improved markup, ordered imports
alphabetically, fixed error with usage of $loggerClosure.

I also added a loop to the provider to illustrate a more "realistic" use
case.