### PR TITLE
[DX] Use consistent index name in documentation

### DIFF
--- a/Resources/doc/cookbook/aliased-indexes.md
+++ b/Resources/doc/cookbook/aliased-indexes.md
@@ -13,7 +13,7 @@ true.
 ```yaml
 fos_elastica:
     indexes:
-        website:
+        app:
             use_alias: true
 ```
 
@@ -30,16 +30,16 @@ options on how to handle this:
 ```yaml
 fos_elastica:
     indexes:
-        website:
+        app:
             use_alias: true
-            index_name: website_prod
+            index_name: app_prod
 ```
 
 ```bash
 $ curl -XPOST 'http://localhost:9200/_aliases' -d '
 {
     "actions" : [
-        { "add" : { "index" : "website", "alias" : "website_prod" } }
+        { "add" : { "index" : "app", "alias" : "app_prod" } }
     ]
 }'
 ```

--- a/Resources/doc/cookbook/custom-repositories.md
+++ b/Resources/doc/cookbook/custom-repositories.md
@@ -28,7 +28,7 @@ fos_elastica:
     clients:
         default: { host: localhost, port: 9200 }
     indexes:
-        website:
+        app:
             client: default
             types:
                 user:

--- a/Resources/doc/cookbook/manual-provider.md
+++ b/Resources/doc/cookbook/manual-provider.md
@@ -10,9 +10,9 @@ services:
     acme.search_provider.user:
         class: Acme\UserBundle\Provider\UserProvider
         arguments:
-            - @fos_elastica.index.website.user
+            - @fos_elastica.index.app.user
         tags:
-            - { name: fos_elastica.provider, index: website, type: user }
+            - { name: fos_elastica.provider, index: app, type: user }
 ```
 
 Its class must implement `FOS\ElasticaBundle\Provider\ProviderInterface`.

--- a/Resources/doc/serializer.md
+++ b/Resources/doc/serializer.md
@@ -31,7 +31,7 @@ for a type in this case:
 ```yaml
 fos_elastica:
     indexes:
-        search:
+        app:
             types:
                 user:
                     serializer:

--- a/Resources/doc/types.md
+++ b/Resources/doc/types.md
@@ -61,7 +61,7 @@ applied when dynamic introduction of fields / objects happens.
 ```yaml
 fos_elastica:
     indexes:
-        site:
+        app:
             types:
                 user:
                     dynamic_templates:
@@ -87,7 +87,7 @@ Note that object can autodetect properties
 ```yaml
 fos_elastica:
     indexes:
-        website:
+        app:
             types:
                 post:
                     mappings:
@@ -113,7 +113,7 @@ Parent fields
 ```yaml
 fos_elastica:
     indexes:
-        website:
+        app:
             types:
                 comment:
                     mappings:

--- a/Resources/doc/usage.md
+++ b/Resources/doc/usage.md
@@ -10,8 +10,10 @@ allowing you to use relationships of returned entities. For more information abo
 configuration options for this kind of searching, please see the [types](types.md)
 documentation.
 
+> This example assumes you have defined an index `app` and a type `user` in your `config.yml`.
+
 ```php
-$finder = $this->container->get('fos_elastica.finder.search.user');
+$finder = $this->container->get('fos_elastica.finder.app.user');
 
 // Option 1. Returns all users who have example.net in any of their mapped fields
 $results = $finder->find('example.net');
@@ -59,15 +61,15 @@ configuration as per below:
 ```yaml
 fos_elastica:
     indexes:
-        website:
+        app:
             finder: ~
 ```
 
-You can now use the index wide finder service `fos_elastica.finder.website`:
+You can now use the index wide finder service `fos_elastica.finder.app`:
 
 ```php
 /** var FOS\ElasticaBundle\Finder\MappedFinder */
-$finder = $this->container->get('fos_elastica.finder.website');
+$finder = $this->container->get('fos_elastica.finder.app');
 
 // Returns a mixed array of any objects mapped
 $results = $finder->find('bob');
@@ -159,7 +161,7 @@ Assuming a type is configured as follows:
 ```yaml
 fos_elastica:
     indexes:
-        site:
+        app:
             settings:
                 index:
                     analysis:
@@ -183,7 +185,7 @@ fos_elastica:
 The following code will execute a search against the Elasticsearch server:
 
 ```php
-$finder = $this->container->get('fos_elastica.finder.site.article');
+$finder = $this->container->get('fos_elastica.finder.app.article');
 $boolQuery = new \Elastica\Query\Bool();
 
 $fieldQuery = new \Elastica\Query\Match();


### PR DESCRIPTION
I found it confusing that there are different index names used
throughout the documentation. I think using the index name "app"
consistently everywhere makes the docs easier to understand.