### PR TITLE
Support for asynchronous persistence

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -525,6 +525,7 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('delete')->defaultTrue()->end()
                         ->scalarNode('flush')->defaultTrue()->end()
                         ->booleanNode('immediate')->defaultFalse()->end()
+                        ->booleanNode('async')->defaultFalse()->end()
                         ->scalarNode('logger')
                             ->defaultFalse()
                             ->treatNullLike('fos_elastica.logger')

--- a/DependencyInjection/FOSElasticaExtension.php
+++ b/DependencyInjection/FOSElasticaExtension.php
@@ -482,16 +482,16 @@ class FOSElasticaExtension extends Extension
         $listenerId = sprintf('fos_elastica.listener.%s.%s', $indexName, $typeName);
         $listenerDef = new DefinitionDecorator($abstractListenerId);
         $listenerDef->replaceArgument(0, new Reference($objectPersisterId));
-        $listenerDef->replaceArgument(2, array(
-            'identifier' => $typeConfig['identifier'],
-            'indexName' => $indexName,
-            'typeName' => $typeName,
-        ));
         $listenerDef->replaceArgument(3, $typeConfig['listener']['logger'] ?
             new Reference($typeConfig['listener']['logger']) :
             null
         );
-
+        $listenerConfig = array(
+            'identifier' => $typeConfig['identifier'],
+            'indexName' => $indexName,
+            'typeName' => $typeName
+        );
+        
         $tagName = null;
         switch ($typeConfig['driver']) {
             case 'orm':
@@ -501,6 +501,18 @@ class FOSElasticaExtension extends Extension
                 $tagName = 'doctrine_mongodb.odm.event_listener';
                 break;
         }
+
+        if($typeConfig['listener']['async']) {
+            $listenerDef->setPublic(true);
+            $listenerDef->addTag(
+                'kernel.event_listener',
+                array('event' => 'kernel.terminate', 'method' => 'onKernelTerminate')
+            );
+            $listenerConfig['async'] = true;
+            $listenerConfig['defer'] = true;
+        }
+
+        $listenerDef->replaceArgument(2, $listenerConfig);
 
         if (null !== $tagName) {
             foreach ($this->getDoctrineEvents($typeConfig) as $event) {

--- a/Resources/doc/types.md
+++ b/Resources/doc/types.md
@@ -308,6 +308,20 @@ You can also choose to only listen for some of the events:
 
 > **Propel** doesn't support this feature yet.
 
+### Asnychronous index update
+
+You can also tell ElasticaBundle to update the indexes after Symfony response has returned. 
+This is useful when you want your responses to return quickly and not be slowed down by round 
+trips to your Elasticsearch instance. All updates to Elasticsearch will be batched up and 
+only fire after the `kernel.terminate` event.
+
+```yaml
+                    persistence:
+                        listener:
+                            async: true
+```
+
+
 Flushing Method
 ---------------
 


### PR DESCRIPTION
Added a new configuration option that defers Doctrine caused updates until after `kernel.terminate`. Useful for when fast response times are important.
