### PR TITLE
Normalize objects to strings

### DIFF
--- a/Transformer/ModelToElasticaAutoTransformer.php
+++ b/Transformer/ModelToElasticaAutoTransformer.php
@@ -159,6 +159,8 @@ class ModelToElasticaAutoTransformer implements ModelToElasticaTransformerInterf
         $normalizeValue = function (&$v) {
             if ($v instanceof \DateTime) {
                 $v = $v->format('c');
+            } elseif (is_object($v)) {
+                $v = $v->__toString();
             } elseif (!is_scalar($v) && !is_null($v)) {
                 $v = (string) $v;
             }


### PR DESCRIPTION
Persisting a Many to One ORM Relationship, throws this error when populating:
```
Fatal error: Method Proxies\__CG__\...\Entity\...::__toString() must not throw an exception in .../vendor/friendsofsymfony/elastica-bundle/Transformer/ModelToElasticaAutoTransformer.php on line 0
```

Symfony 2.3.28
Doctrine 2.5.0