### PR TITLE
Update settings when resetting a specific type

### DIFF
--- a/Index/Resetter.php
+++ b/Index/Resetter.php
@@ -136,7 +136,9 @@ class Resetter
         }
 
         if (!empty($settings)) {
+            $index->close();
             $index->setSettings($settings);
+            $index->open();
         }
 
         $mapping = new Mapping();

--- a/Index/Resetter.php
+++ b/Index/Resetter.php
@@ -118,7 +118,11 @@ class Resetter
     public function resetIndexType($indexName, $typeName)
     {
         $typeConfig = $this->configManager->getTypeConfiguration($indexName, $typeName);
-        $type = $this->indexManager->getIndex($indexName)->getType($typeName);
+        $index = $this->indexManager->getIndex($indexName);
+        $type = $index->getType($typeName);
+
+        $indexConfig = $this->configManager->getIndexConfiguration($indexName);
+        $settings = $indexConfig->getSettings();
 
         $event = new TypeResetEvent($indexName, $typeName);
         $this->dispatcher->dispatch(TypeResetEvent::PRE_TYPE_RESET, $event);
@@ -129,6 +133,10 @@ class Resetter
             if (strpos($e->getMessage(), 'TypeMissingException') === false) {
                 throw $e;
             }
+        }
+
+        if (!empty($settings)) {
+            $index->setSettings($settings);
         }
 
         $mapping = new Mapping();

--- a/Tests/Index/ResetterTest.php
+++ b/Tests/Index/ResetterTest.php
@@ -140,7 +140,8 @@ class ResetterTest extends \PHPUnit_Framework_TestCase
     public function testResetType()
     {
         $typeConfig = new TypeConfig('type', array(), array());
-        $this->mockType('type', 'index', $typeConfig);
+        $indexConfig = new IndexConfig('index', array(), array());
+        $this->mockType('type', 'index', $typeConfig, $indexConfig);
 
         $this->dispatcherExpects(array(
             array(TypeResetEvent::PRE_TYPE_RESET, $this->isInstanceOf('FOS\\ElasticaBundle\\Event\\TypeResetEvent')),
@@ -151,6 +152,33 @@ class ResetterTest extends \PHPUnit_Framework_TestCase
             ->method('request')
             ->withConsecutive(
                 array('index/type/', 'DELETE'),
+                array('index/type/_mapping', 'PUT', array('type' => array()), array())
+            );
+
+        $this->resetter->resetIndexType('index', 'type');
+    }
+
+    public function testResetTypeWithChangedSettings()
+    {
+        $settingsValue = array(
+            'analysis' => array(
+                'analyzer' => array(
+                    'test_analyzer' => array(
+                        'type' => 'standard',
+                        'tokenizer' => 'standard'
+                    )
+                )
+            )
+        );
+        $typeConfig = new TypeConfig('type', array(), array());
+        $indexConfig = new IndexConfig('index', array(), array('settings' => $settingsValue));
+        $this->mockType('type', 'index', $typeConfig, $indexConfig);
+
+        $this->elasticaClient->expects($this->exactly(3))
+            ->method('request')
+            ->withConsecutive(
+                array('index/type/', 'DELETE'),
+                array('index/_settings', 'PUT', $settingsValue),
                 array('index/type/_mapping', 'PUT', array('type' => array()), array())
             );
 
@@ -224,20 +252,24 @@ class ResetterTest extends \PHPUnit_Framework_TestCase
         return $index;
     }
 
-    private function mockType($typeName, $indexName, TypeConfig $config, $mapping = array())
+    private function mockType($typeName, $indexName, TypeConfig $typeConfig, IndexConfig $indexConfig, $mapping = array())
     {
         $this->configManager->expects($this->atLeast(1))
             ->method('getTypeConfiguration')
             ->with($indexName, $typeName)
-            ->will($this->returnValue($config));
+            ->will($this->returnValue($typeConfig));
         $index = new Index($this->elasticaClient, $indexName);
         $this->indexManager->expects($this->once())
             ->method('getIndex')
             ->with($indexName)
             ->willReturn($index);
+        $this->configManager->expects($this->atLeast(1))
+            ->method('getIndexConfiguration')
+            ->with($indexName)
+            ->will($this->returnValue($indexConfig));
         $this->mappingBuilder->expects($this->once())
             ->method('buildTypeMapping')
-            ->with($config)
+            ->with($typeConfig)
             ->willReturn($mapping);
 
         return $index;

--- a/Tests/Index/ResetterTest.php
+++ b/Tests/Index/ResetterTest.php
@@ -174,11 +174,13 @@ class ResetterTest extends \PHPUnit_Framework_TestCase
         $indexConfig = new IndexConfig('index', array(), array('settings' => $settingsValue));
         $this->mockType('type', 'index', $typeConfig, $indexConfig);
 
-        $this->elasticaClient->expects($this->exactly(3))
+        $this->elasticaClient->expects($this->exactly(5))
             ->method('request')
             ->withConsecutive(
                 array('index/type/', 'DELETE'),
+                array('index/_close', 'POST'),
                 array('index/_settings', 'PUT', $settingsValue),
+                array('index/_open', 'POST'),
                 array('index/type/_mapping', 'PUT', array('type' => array()), array())
             );
 


### PR DESCRIPTION
This should fix #853 when a user reset a specific type in an index and wants his changed settings (_analyzer_, _filters_, etc) to be taken into account.