### PR TITLE
Fix the progress logging for the last incomplete slice

### DIFF
--- a/Doctrine/AbstractProvider.php
+++ b/Doctrine/AbstractProvider.php
@@ -87,8 +87,10 @@ abstract class AbstractProvider extends BaseAbstractProvider
 
         $objects = array();
         for (; $offset < $nbObjects; $offset += $options['batch_size']) {
+            $sliceSize = $options['batch_size'];
             try {
                 $objects = $this->getSlice($queryBuilder, $options['batch_size'], $offset, $objects);
+                $sliceSize = count($objects);
                 $objects = $this->filterObjects($options, $objects);
 
                 if (!empty($objects)) {
@@ -115,7 +117,7 @@ abstract class AbstractProvider extends BaseAbstractProvider
             usleep($options['sleep']);
 
             if (null !== $loggerClosure) {
-                $loggerClosure($options['batch_size'], $nbObjects);
+                $loggerClosure($sliceSize, $nbObjects);
             }
         }
     }

--- a/Propel/Provider.php
+++ b/Propel/Provider.php
@@ -27,6 +27,7 @@ class Provider extends AbstractProvider
                 ->offset($offset)
                 ->find()
                 ->getArrayCopy();
+            $sliceSize = count($objects);
             $objects = $this->filterObjects($options, $objects);
             if (!empty($objects)) {
                 $this->objectPersister->insertMany($objects);
@@ -35,7 +36,7 @@ class Provider extends AbstractProvider
             usleep($options['sleep']);
 
             if ($loggerClosure) {
-                $loggerClosure($options['batch_size'], $nbObjects);
+                $loggerClosure($sliceSize, $nbObjects);
             }
         }
     }


### PR DESCRIPTION
This avoids increasing the max of the progress bar to the upper multiplier of the batch size.

@XWB @merk I made this change based on the master branch, as I suggest we stop maintaining 3 parallel branches of the bundle (3.0, 3.1 and master). We should try to maintain only the master branch (until we start working on the next major version in which case we will need a 3.x branch). This will simplify the bundle maintenance.