### PR TITLE
Cast identifier to string

### DIFF
--- a/Transformer/ModelToElasticaAutoTransformer.php
+++ b/Transformer/ModelToElasticaAutoTransformer.php
@@ -67,7 +67,7 @@ class ModelToElasticaAutoTransformer implements ModelToElasticaTransformerInterf
      **/
     public function transform($object, array $fields)
     {
-        $identifier = $this->propertyAccessor->getValue($object, $this->options['identifier']);
+        $identifier = (string)$this->propertyAccessor->getValue($object, $this->options['identifier']);
         $document = new Document($identifier);
 
         foreach ($fields as $key => $mapping) {


### PR DESCRIPTION
When identifier is an object (i.e. UUID) we cast it to string when building the Elastic document. See #925 for details.