### PR TITLE
add default value for new elastica "compression" param

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -123,6 +123,7 @@ class Configuration implements ConfigurationInterface
                                             ->treatNullLike('fos_elastica.logger')
                                             ->treatTrueLike('fos_elastica.logger')
                                         ->end()
+                                        ->booleanNode('compression')->defaultValue(false)->end()
                                         ->arrayNode('headers')
                                             ->useAttributeAsKey('name')
                                             ->prototype('scalar')->end()

--- a/README.md
+++ b/README.md
@@ -17,14 +17,14 @@ Documentation
 
 Documentation for FOSElasticaBundle is in `Resources/doc/index.md`
 
-[Read the documentation for 3.0.x (master)](https://github.com/FriendsOfSymfony/FOSElasticaBundle/blob/master/Resources/doc/index.md)
+[Read the documentation for 3.0.x](https://github.com/FriendsOfSymfony/FOSElasticaBundle/blob/3.0.x/Resources/doc/index.md)
 
 [Read the documentation for 2.1.x](https://github.com/FriendsOfSymfony/FOSElasticaBundle/blob/2.1.x/README.md)
 
 Installation
 ------------
 
-Installation instructions can be found in the [documentation](https://github.com/FriendsOfSymfony/FOSElasticaBundle/blob/master/Resources/doc/setup.md)
+Installation instructions can be found in the [documentation](https://github.com/FriendsOfSymfony/FOSElasticaBundle/blob/3.0.x/Resources/doc/setup.md)
 
 License
 -------

--- a/Resources/doc/cookbook/compression.md
+++ b/Resources/doc/cookbook/compression.md
@@ -1,0 +1,13 @@
+Http compression
+==========================================
+
+By default, FOSElasticaBundle and elastica do not compress the http request but you can do it with a simple configuration:
+
+```yaml
+# app/config/config.yml
+fos_elastica:
+    clients:
+        default:
+            host: example.com
+            compression: true
+```

--- a/Resources/doc/index.md
+++ b/Resources/doc/index.md
@@ -15,7 +15,7 @@ Cookbook Entries
 * [Aliased Indexes](cookbook/aliased-indexes.md)
 * [Custom Repositories](cookbook/custom-repositories.md)
 * [HTTP Headers for Elastica](cookbook/elastica-client-http-headers.md)
-* Performance - [Logging](cookbook/logging.md)
+* Performance - [Logging](cookbook/logging.md) - [Compression](cookbook/compression.md)
 * [Manual Providers](cookbook/manual-provider.md)
 * [Clustering - Multiple Connections](cookbook/multiple-connections.md)
 * [Suppressing server errors](cookbook/suppress-server-errors.md)


### PR DESCRIPTION
After updating ruflin/elastica with this PR https://github.com/ruflin/Elastica/pull/927, the populate command was failing :

```
[Elastica\Exception\InvalidException]  
  Param compression does not exist
```

This PR simply add the compression param to fix the command and update the documentation to add the compression section 