### PR TITLE
Don't use parent identifier for objects/nested documents (3.0.x branch)

### DIFF
--- a/Tests/Transformer/ModelToElasticaAutoTransformerTest.php
+++ b/Tests/Transformer/ModelToElasticaAutoTransformerTest.php
@@ -121,6 +121,19 @@ class POPO
     {
         return $this->getUpper();
     }
+
+    public function getObjWithoutIdentifier()
+    {
+        return (object) array('foo' => 'foo', 'bar' => 'foo');
+    }
+
+    public function getSubWithoutIdentifier()
+    {
+        return array(
+            (object) array('foo' => 'foo', 'bar' => 'foo'),
+            (object) array('foo' => 'bar', 'bar' => 'bar'),
+        );
+    }
 }
 
 class ModelToElasticaAutoTransformerTest extends \PHPUnit_Framework_TestCase
@@ -377,6 +390,50 @@ class ModelToElasticaAutoTransformerTest extends \PHPUnit_Framework_TestCase
         ));
 
         $this->assertEquals("parent", $document->getParent());
+    }
+
+    public function testThatMappedObjectsDontNeedAnIdentifierField()
+    {
+        $transformer = $this->getTransformer();
+        $document    = $transformer->transform(new POPO(), array(
+            'objWithoutIdentifier' => array(
+                'type' => 'object',
+                'properties' => array(
+                    'foo' => array(),
+                    'bar' => array()
+                )
+            ),
+        ));
+        $data        = $document->getData();
+
+        $this->assertTrue(array_key_exists('objWithoutIdentifier', $data));
+        $this->assertInternalType('array', $data['objWithoutIdentifier']);
+        $this->assertEquals(array(
+            'foo' => 'foo',
+            'bar' => 'foo'
+        ), $data['objWithoutIdentifier']);
+    }
+
+    public function testThatNestedObjectsDontNeedAnIdentifierField()
+    {
+        $transformer = $this->getTransformer();
+        $document    = $transformer->transform(new POPO(), array(
+            'subWithoutIdentifier' => array(
+                'type' => 'nested',
+                'properties' => array(
+                    'foo' => array(),
+                    'bar' => array()
+                ),
+            ),
+        ));
+        $data        = $document->getData();
+
+        $this->assertTrue(array_key_exists('subWithoutIdentifier', $data));
+        $this->assertInternalType('array', $data['subWithoutIdentifier']);
+        $this->assertEquals(array(
+            array('foo' => 'foo', 'bar' => 'foo'),
+            array('foo' => 'bar', 'bar' => 'bar'),
+        ), $data['subWithoutIdentifier']);
     }
 
     /**

--- a/Transformer/ModelToElasticaAutoTransformer.php
+++ b/Transformer/ModelToElasticaAutoTransformer.php
@@ -59,6 +59,75 @@ class ModelToElasticaAutoTransformer implements ModelToElasticaTransformerInterf
     public function transform($object, array $fields)
     {
         $identifier = $this->propertyAccessor->getValue($object, $this->options['identifier']);
+        $document = $this->transformObjectToDocument($object, $fields, $identifier);
+
+        return $document;
+    }
+
+    /**
+     * transform a nested document or an object property into an array of ElasticaDocument.
+     *
+     * @param array|\Traversable|\ArrayAccess $objects the object to convert
+     * @param array                           $fields  the keys we want to have in the returned array
+     *
+     * @return array
+     */
+    protected function transformNested($objects, array $fields)
+    {
+        if (is_array($objects) || $objects instanceof \Traversable || $objects instanceof \ArrayAccess) {
+            $documents = array();
+            foreach ($objects as $object) {
+                $document = $this->transformObjectToDocument($object, $fields);
+                $documents[] = $document->getData();
+            }
+
+            return $documents;
+        } elseif (null !== $objects) {
+            $document = $this->transformObjectToDocument($objects, $fields);
+
+            return $document->getData();
+        }
+
+        return array();
+    }
+
+    /**
+     * Attempts to convert any type to a string or an array of strings.
+     *
+     * @param mixed $value
+     *
+     * @return string|array
+     */
+    protected function normalizeValue($value)
+    {
+        $normalizeValue = function (&$v) {
+            if ($v instanceof \DateTime) {
+                $v = $v->format('c');
+            } elseif (!is_scalar($v) && !is_null($v)) {
+                $v = (string) $v;
+            }
+        };
+
+        if (is_array($value) || $value instanceof \Traversable || $value instanceof \ArrayAccess) {
+            $value = is_array($value) ? $value : iterator_to_array($value, false);
+            array_walk_recursive($value, $normalizeValue);
+        } else {
+            $normalizeValue($value);
+        }
+
+        return $value;
+    }
+
+    /**
+     * Transforms the given object to an elastica document
+     *
+     * @param object $object the object to convert
+     * @param array  $fields the keys we want to have in the returned array
+     * @param string $identifier the identifier for the new document
+     * @return Document
+     */
+    protected function transformObjectToDocument($object, array $fields, $identifier = '')
+    {
         $document = new Document($identifier);
 
         foreach ($fields as $key => $mapping) {
@@ -93,59 +162,5 @@ class ModelToElasticaAutoTransformer implements ModelToElasticaTransformerInterf
         }
 
         return $document;
-    }
-
-    /**
-     * transform a nested document or an object property into an array of ElasticaDocument.
-     *
-     * @param array|\Traversable|\ArrayAccess $objects the object to convert
-     * @param array                           $fields  the keys we want to have in the returned array
-     *
-     * @return array
-     */
-    protected function transformNested($objects, array $fields)
-    {
-        if (is_array($objects) || $objects instanceof \Traversable || $objects instanceof \ArrayAccess) {
-            $documents = array();
-            foreach ($objects as $object) {
-                $document = $this->transform($object, $fields);
-                $documents[] = $document->getData();
-            }
-
-            return $documents;
-        } elseif (null !== $objects) {
-            $document = $this->transform($objects, $fields);
-
-            return $document->getData();
-        }
-
-        return array();
-    }
-
-    /**
-     * Attempts to convert any type to a string or an array of strings.
-     *
-     * @param mixed $value
-     *
-     * @return string|array
-     */
-    protected function normalizeValue($value)
-    {
-        $normalizeValue = function (&$v) {
-            if ($v instanceof \DateTime) {
-                $v = $v->format('c');
-            } elseif (!is_scalar($v) && !is_null($v)) {
-                $v = (string) $v;
-            }
-        };
-
-        if (is_array($value) || $value instanceof \Traversable || $value instanceof \ArrayAccess) {
-            $value = is_array($value) ? $value : iterator_to_array($value, false);
-            array_walk_recursive($value, $normalizeValue);
-        } else {
-            $normalizeValue($value);
-        }
-
-        return $value;
     }
 }


### PR DESCRIPTION
This fixes #357 for the 3.0.x branch.

See https://github.com/FriendsOfSymfony/FOSElasticaBundle/pull/918 for the PR to the 3.1.x branch.