### PR TITLE
Add PaginatorAdapterInterface as one of FantaPaginatorAdapter's interfaces

### DIFF
--- a/Paginator/FantaPaginatorAdapter.php
+++ b/Paginator/FantaPaginatorAdapter.php
@@ -4,7 +4,7 @@ namespace FOS\ElasticaBundle\Paginator;
 
 use Pagerfanta\Adapter\AdapterInterface;
 
-class FantaPaginatorAdapter implements AdapterInterface
+class FantaPaginatorAdapter implements AdapterInterface, PaginatorAdapterInterface
 {
     private $adapter;
 


### PR DESCRIPTION
Not having `PaginatorAdapterInterface` as one of `FantaPaginatorAdapter`'s interfaces kind of go against the purpose of having a `PaginatorAdapterInterface` in the first place...