### PR TITLE
Allow ordering by unmapped fields

### DIFF
--- a/Subscriber/PaginateElasticaQuerySubscriber.php
+++ b/Subscriber/PaginateElasticaQuerySubscriber.php
@@ -66,7 +66,7 @@ class PaginateElasticaQuerySubscriber implements EventSubscriberInterface
 
             // set sort on active query
             $event->target->getQuery()->setSort(array(
-                $sortField => array('order' => $dir),
+                $sortField => array('order' => $dir, 'ignore_unmapped' => true),
             ));
         }
     }


### PR DESCRIPTION
Prevent error caused by ordering on empty fields