### PR TITLE
Allow driverless types

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -556,6 +556,12 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('service')->end()
                     ->end()
                 ->end()
+                ->arrayNode('persister')
+                    ->addDefaultsIfNotSet()
+                    ->children()
+                        ->scalarNode('service')->end()
+                    ->end()
+                ->end()
             ->end();
 
         return $node;

--- a/DependencyInjection/FOSElasticaExtension.php
+++ b/DependencyInjection/FOSElasticaExtension.php
@@ -318,7 +318,9 @@ class FOSElasticaExtension extends Extension
      */
     private function loadTypePersistenceIntegration(array $typeConfig, ContainerBuilder $container, Reference $typeRef, $indexName, $typeName)
     {
-        $this->loadDriver($container, $typeConfig['driver']);
+        if (isset($typeConfig['driver'])) {
+            $this->loadDriver($container, $typeConfig['driver']);
+        }
 
         $elasticaToModelTransformerId = $this->loadElasticaToModelTransformer($typeConfig, $container, $indexName, $typeName);
         $modelToElasticaTransformerId = $this->loadModelToElasticaTransformer($typeConfig, $container, $indexName, $typeName);
@@ -415,6 +417,10 @@ class FOSElasticaExtension extends Extension
      */
     private function loadObjectPersister(array $typeConfig, Reference $typeRef, ContainerBuilder $container, $indexName, $typeName, $transformerId)
     {
+        if (isset($typeConfig['persister']['service'])) {
+            return $typeConfig['persister']['service'];
+        }
+
         $arguments = array(
             $typeRef,
             new Reference($transformerId),

--- a/Tests/DependencyInjection/FOSElasticaExtensionTest.php
+++ b/Tests/DependencyInjection/FOSElasticaExtensionTest.php
@@ -29,4 +29,20 @@ class FOSElasticaExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertArrayHasKey('_parent', $arguments);
         $this->assertEquals('parent_field', $arguments['_parent']['type']);
     }
+
+    public function testExtensionSupportsDriverlessTypePersistence()
+    {
+        $config = Yaml::parse(file_get_contents(__DIR__.'/fixtures/driverless_type.yml'));
+
+        $containerBuilder = new ContainerBuilder();
+        $containerBuilder->setParameter('kernel.debug', true);
+
+        $extension = new FOSElasticaExtension();
+        $extension->load($config, $containerBuilder);
+
+        $this->assertTrue($containerBuilder->hasDefinition('fos_elastica.index.test_index'));
+        $this->assertTrue($containerBuilder->hasDefinition('fos_elastica.index.test_index.driverless'));
+        $this->assertFalse($containerBuilder->hasDefinition('fos_elastica.elastica_to_model_transformer.test_index.driverless'));
+        $this->assertFalse($containerBuilder->hasDefinition('fos_elastica.object_persister.test_index.driverless'));
+    }
 }

--- a/Tests/DependencyInjection/fixtures/driverless_type.yml
+++ b/Tests/DependencyInjection/fixtures/driverless_type.yml
@@ -1,0 +1,16 @@
+fos_elastica:
+    clients:
+        default:
+            url: http://localhost:9200
+    indexes:
+        test_index:
+            client: default
+            types:
+                driverless:
+                    mappings:
+                        text: ~
+                    persistence:
+                        elastica_to_model_transformer:
+                            service: 'custom.transformer.service'
+                        persister:
+                            service: 'custom.persist.service'


### PR DESCRIPTION
This change allows the definition of a type with its own custom persister implementation without needing to define a driver type.