### PR TITLE
Add dynamic option in mapping at the type and field level

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -5,3 +5,4 @@ CHANGELOG for 3.2.x
 
  * Allow driverless type definitions #953
  * Change Elastica constraints to allow ~2.1 as Elastica now follows semver
+ * Add support for the [dynamic](https://www.elastic.co/guide/en/elasticsearch/reference/current/dynamic.html) setting in mapping

--- a/Configuration/TypeConfig.php
+++ b/Configuration/TypeConfig.php
@@ -102,7 +102,16 @@ class TypeConfig
     }
 
     /**
+     * @return string|null
+     */
+    public function getDynamic()
+    {
+        return $this->getConfig('dynamic');
+    }
+
+    /**
      * @param string $key
+     * @return null|string
      */
     private function getConfig($key)
     {

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -255,6 +255,7 @@ class Configuration implements ConfigurationInterface
                     ->scalarNode('index_analyzer')->end()
                     ->booleanNode('numeric_detection')->end()
                     ->scalarNode('search_analyzer')->end()
+                    ->scalarNode('dynamic')->end()
                     ->variableNode('indexable_callback')->end()
                     ->append($this->getPersistenceNode())
                     ->append($this->getSerializerNode())

--- a/DependencyInjection/FOSElasticaExtension.php
+++ b/DependencyInjection/FOSElasticaExtension.php
@@ -269,6 +269,7 @@ class FOSElasticaExtension extends Extension
                 'serializer',
                 'index_analyzer',
                 'search_analyzer',
+                'dynamic',
                 'date_detection',
                 'dynamic_date_formats',
                 'numeric_detection',

--- a/Index/MappingBuilder.php
+++ b/Index/MappingBuilder.php
@@ -82,6 +82,10 @@ class MappingBuilder
             $mapping['search_analyzer'] = $typeConfig->getSearchAnalyzer();
         }
 
+        if ($typeConfig->getDynamic()) {
+            $mapping['dynamic'] = $typeConfig->getDynamic();
+        }
+
         if (isset($mapping['dynamic_templates']) and empty($mapping['dynamic_templates'])) {
             unset($mapping['dynamic_templates']);
         }

--- a/Index/MappingBuilder.php
+++ b/Index/MappingBuilder.php
@@ -82,7 +82,7 @@ class MappingBuilder
             $mapping['search_analyzer'] = $typeConfig->getSearchAnalyzer();
         }
 
-        if ($typeConfig->getDynamic()) {
+        if ($typeConfig->getDynamic() !== null) {
             $mapping['dynamic'] = $typeConfig->getDynamic();
         }
 

--- a/Resources/doc/types.md
+++ b/Resources/doc/types.md
@@ -149,6 +149,23 @@ If you want to specify a [date format](http://www.elasticsearch.org/guide/en/ela
                         birthday: { type: date, format: "yyyy-MM-dd" }
 ```
 
+
+Disable dynamic mapping example
+-------------------
+
+If you want to specify manually the dynamic capabilities of Elasticsearch mapping, you can use 
+the [dynamic](https://www.elastic.co/guide/en/elasticsearch/reference/current/dynamic.html) option:
+
+```yaml
+                user:
+                    dynamic: strict
+                    mappings:
+                        username: { type: string }
+                        addresses: { type: object, dynamic: true }
+```
+
+With this example, Elasticsearch is going to throw exceptions if you try to index a not mapped field, except in `addresses`.
+
 Custom settings
 ---------------
 

--- a/Tests/Functional/MappingToElasticaTest.php
+++ b/Tests/Functional/MappingToElasticaTest.php
@@ -36,6 +36,10 @@ class MappingToElasticaTest extends WebTestCase
         $mapping = $type->getMapping();
         $this->assertEquals('parent', $mapping['type']['_parent']['type']);
 
+        $this->assertEquals('strict', $mapping['type']['dynamic']);
+        $this->assertArrayHasKey('dynamic', $mapping['type']['properties']['dynamic_allowed']);
+        $this->assertEquals('true', $mapping['type']['properties']['dynamic_allowed']['dynamic']);
+
         $parent = $this->getType($client, 'parent');
         $mapping = $parent->getMapping();
 

--- a/Tests/Functional/app/Basic/config.yml
+++ b/Tests/Functional/app/Basic/config.yml
@@ -39,6 +39,7 @@ fos_elastica:
                             max_gram: 5
             types:
                 parent:
+                    dynamic: false
                     dynamic_templates:
                         dates:
                             match: "date_*"
@@ -50,6 +51,7 @@ fos_elastica:
                     search_analyzer: whitespace
                     index_analyzer: my_analyzer
                 type:
+                    dynamic: strict
                     search_analyzer: my_analyzer
                     date_detection: false
                     dynamic_date_formats: [ 'yyyy-MM-dd' ]
@@ -94,6 +96,7 @@ fos_elastica:
                             type: "attachment"
                         lastlogin: { type: date, format: basic_date_time }
                         birthday: { type: date, format: "yyyy-MM-dd" }
+                        dynamic_allowed: { type: object, dynamic: true }
                     _parent:
                         type: "parent"
                         property: "parent"


### PR DESCRIPTION
This PR add support for the `dynamic` option in mapping.

https://www.elastic.co/guide/en/elasticsearch/reference/current/dynamic.html

This option allow to control when Elasticsearch is allowed to dynamically map an unknown field. I added as an example what is known to be a good practice, which is disabling the dynamic mapping completely, and then allowing it for some particular fields.