### PR TITLE
Update Provider.php

### DIFF
--- a/Doctrine/ORM/Provider.php
+++ b/Doctrine/ORM/Provider.php
@@ -64,6 +64,7 @@ class Provider extends AbstractProvider
             ->select($qb->expr()->count($rootAliases[0]))
             // Remove ordering for efficiency; it doesn't affect the count
             ->resetDQLPart('orderBy')
+            ->resetDQLPart('groupBy')
             ->getQuery()
             ->getSingleScalarResult();
     }


### PR DESCRIPTION
removed the optional groupBy clause from the count query

if it is provided a custom query builder method with a groupBy clause the count method will fail.