### PR TITLE
Added methods to get suggests out of a paginated result

### DIFF
--- a/Paginator/FantaPaginatorAdapter.php
+++ b/Paginator/FantaPaginatorAdapter.php
@@ -49,6 +49,18 @@ class FantaPaginatorAdapter implements AdapterInterface
     }
 
     /**
+     * Returns Suggestions.
+     *
+     * @return mixed
+     *
+     * @api
+     */
+    public function getSuggests()
+    {
+        return $this->adapter->getSuggests();
+    }
+
+    /**
      * Returns a slice of the results.
      *
      * @param integer $offset The offset.

--- a/Paginator/PaginatorAdapterInterface.php
+++ b/Paginator/PaginatorAdapterInterface.php
@@ -34,4 +34,11 @@ interface PaginatorAdapterInterface
      * @return mixed
      */
     public function getAggregations();
+
+    /**
+     * Returns Suggests.
+     *
+     * @return mixed
+     */
+    public function getSuggests();
 }

--- a/Paginator/RawPaginatorAdapter.php
+++ b/Paginator/RawPaginatorAdapter.php
@@ -43,6 +43,11 @@ class RawPaginatorAdapter implements PaginatorAdapterInterface
     private $aggregations;
 
     /**
+     * @var array for the suggests
+     */
+    private $suggests;
+
+    /**
      * @see PaginatorAdapterInterface::__construct
      *
      * @param SearchableInterface $searchable the object to search in
@@ -90,6 +95,7 @@ class RawPaginatorAdapter implements PaginatorAdapterInterface
         $this->totalHits = $resultSet->getTotalHits();
         $this->facets = $resultSet->getFacets();
         $this->aggregations = $resultSet->getAggregations();
+        $this->suggests = $resultSet->getSuggests();
 
         return $resultSet;
     }
@@ -155,6 +161,20 @@ class RawPaginatorAdapter implements PaginatorAdapterInterface
         }
 
         return $this->aggregations;
+    }
+
+    /**
+     * Returns Suggests.
+     *
+     * @return mixed
+     */
+    public function getSuggests()
+    {
+        if (!isset($this->suggests)) {
+            $this->suggests = $this->searchable->search($this->query)->getSuggests();
+        }
+
+        return $this->suggests;
     }
 
     /**

--- a/Paginator/RawPartialResults.php
+++ b/Paginator/RawPartialResults.php
@@ -61,4 +61,16 @@ class RawPartialResults implements PartialResultsInterface
 
         return;
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getSuggests()
+    {
+        if ($this->resultSet->hasSuggests()) {
+            return $this->resultSet->getSuggests();
+        }
+
+        return;
+    }
 }


### PR DESCRIPTION
It seems like these methods would come real handy when using KnpPaginator together with FOSElastica. When the search query includes suggests, it is otherwise impossible to get them from the processed query. If this should go somewhere else, please let me know.