### PR TITLE
Differentiate query time from execution time

### DIFF
--- a/DataCollector/ElasticaDataCollector.php
+++ b/DataCollector/ElasticaDataCollector.php
@@ -44,7 +44,7 @@ class ElasticaDataCollector extends DataCollector
     {
         $time = 0;
         foreach ($this->data['queries'] as $query) {
-            $time += $query['executionMS'];
+            $time += $query['engineMS'];
         }
 
         return $time;

--- a/Elastica/Client.php
+++ b/Elastica/Client.php
@@ -46,7 +46,11 @@ class Client extends BaseClient
         $start = microtime(true);
         $response = parent::request($path, $method, $data, $query);
 
-        $this->logQuery($path, $method, $data, $query, $start);
+        if (isset($response->getData()['took'])) {
+            $this->logQuery($path, $method, $data, $query, $start, $response->getEngineTime(), $response->getData()['hits']['total']);
+        } else {
+            $this->logQuery($path, $method, $data, $query, $start, 0, 0);
+        }
 
         if ($this->stopwatch) {
             $this->stopwatch->stop('es_request');
@@ -83,7 +87,7 @@ class Client extends BaseClient
      * @param array  $query
      * @param int    $start
      */
-    private function logQuery($path, $method, $data, array $query, $start)
+    private function logQuery($path, $method, $data, array $query, $start, $engineMS = 0, $itemCount = 0)
     {
         if (!$this->_logger or !$this->_logger instanceof ElasticaLogger) {
             return;
@@ -99,6 +103,6 @@ class Client extends BaseClient
             'headers' => $connection->hasConfig('headers') ? $connection->getConfig('headers') : array(),
         );
 
-        $this->_logger->logQuery($path, $method, $data, $time, $connection_array, $query);
+        $this->_logger->logQuery($path, $method, $data, $time, $connection_array, $query, $engineMS, $itemCount);
     }
 }

--- a/Logger/ElasticaLogger.php
+++ b/Logger/ElasticaLogger.php
@@ -51,7 +51,7 @@ class ElasticaLogger implements LoggerInterface
      * @param array  $connection Host, port, transport, and headers of the query
      * @param array  $query      Arguments
      */
-    public function logQuery($path, $method, $data, $time, $connection = array(), $query = array())
+    public function logQuery($path, $method, $data, $time, $connection = array(), $query = array(), $engineTime = 0, $itemCount = 0)
     {
         if ($this->debug) {
             $this->queries[] = array(
@@ -59,8 +59,10 @@ class ElasticaLogger implements LoggerInterface
                 'method' => $method,
                 'data' => $data,
                 'executionMS' => $time,
+                'engineMS' => $engineTime,
                 'connection' => $connection,
                 'queryString' => $query,
+                'itemCount' => $itemCount,
             );
         }
 

--- a/Resources/views/Collector/elastica.html.twig
+++ b/Resources/views/Collector/elastica.html.twig
@@ -5,7 +5,7 @@
         <img alt="elastica" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABYAAAAcCAYAAABlL09dAAAABGdBTUEAALGPC/xhBQAAA/BpQ0NQSUNDIFByb2ZpbGUAACiRjVXdb9tUFD+Jb1ykFj+gsY4OFYuvVVNbuRsarcYGSZOl6UIauc3YKqTJdW4aU9c2ttNtVZ/2Am8M+AOAsgcekHhCGgzE9rLtAbRJU0EV1SSkPXTaQGiT9oKqcK6vU7tdxriRr38553c+79E1QMdXmuOYSRlg3vJdNZ+Rj5+YljtWIQnPQSf0QKeme066XC4CLsaFR9bDXyHB3jcH2uv/c3VWqacDJJ5CbFc9fR7xaYCUqTuuDyDeRvnwKd9B3PE84h0uJohYYXiW4yzDMxwfDzhT6ihilouk17Uq4iXE/TMx+WwM8xyCtSNPLeoausx6UXbtmmHSWLpPUP/PNW82WvF68eny5iaP4ruP1V53x9QQf65ruUnELyO+5vgZJn8V8b3GXCWNeC9A8pmae6TC+ck3FutT7yDeibhq+IWpUL5ozZQmuG1yec4+qoaca7o3ij2DFxHfqtNCkecjQJVmc6xfiHvrjbHQvzDuLUzmWn4W66Ml7kdw39PGy4h7EH/o2uoEz1lYpmZe5f6FK45fDnMQ1i2zVOQ+iUS9oMZA7tenxrgtOeDjIXJbMl0zjhRC/pJjBrOIuZHzbkOthJwbmpvLcz/kPrUqoc/UrqqWZb0dRHwYjiU0oGDDDO46WLABMqiQhwy+HXBRUwMDTJRQ1FKUGImnYQ5l7XnlgMNxxJgNrNeZNUZpz+ER7oQcm3QThezH5yApkkNkmIyATN4kb5HDJIvSEXJw07Yci89i3dn08z400CvjHYPMuZ5GXxTvrHvS0K9/9PcWa/uRnGkrn3gHwMMOtJgD8fqvLv2wK/KxQi68e7Pr6hJMPKm/qdup9dQK7quptYiR+j21hr9VSGNuZpDRPD5GkIcXyyBew2V8fNBw/wN5doy3JWLNOtcTaVgn6AelhyU42x9Jld+UP5UV5QvlvHJ3W5fbdkn4VPhW+FH4Tvhe+Blk4ZJwWfhJuCJ8I1yMndXj52Pz7IN6W9UyTbteUzCljLRbeknKSi9Ir0jFyJ/ULQ1JY9Ie1OzePLd4vHgtBpzAvdXV9rE4r4JaA04FFXhBhy04s23+Q2vSS4ZIYdvUDrNZbjHEnJgV0yCLe8URcUgcZ7iVn7gHdSO457ZMnf6YCmiMFa9zIJg6NqvMeiHQeUB9etpnF+2o7Zxxjdm6L+9TlNflNH6qqFyw9MF+WTNNOVB5sks96i7Q6iCw7yC/oh+owfctsfN6JPPfBjj0F95ZNyLZdAPgaw+g+7VI1od34rOfAVw4oDfchfDOTyR+AfBq+/fxf10ZvJtuNZsP8L7q+ARg4+Nm85/lZnPjS/S/BnDJ/BdZAHF4xCjCQAAAAAlwSFlzAAALEwAACxMBAJqcGAAABWZJREFUSIm1lU9sXFcVxr9773tv/o8n5sWeGQejTIwpoXYlUCQCUiBSRTdRpS5ihLKxiJBASBFVkViwiOpNxCYREixSdimoi0pATAQJEkJIDlWUtK5K4iKc1HatYtfO+N+8PzPvvnMOCzyWxy2BBT2bK7177u9+99N331Uigk+i9CdCBeD8L00TExOmr6/PN8Z83RjzLaXUF40xeQBzxpjfWGt/6/v+BxcvXky6a9R/s+LChQuZKIqe1Vr/SGv9FaVUopRKjTGitTZa64zW+j2l1BXP816/dOnShojIExVPTEyYUqn0nIhcBjDkuu7Dcrm8UC6XN7XWAuBQq9UaDsNwGMDLcRwXJycnfwag/URwqVT6DIApAJ/O5XKzjUbjzVqttt3f30+FQqFQ7is7YRAuz87OBvPz858noheLxeIbAG7vgZVS6sSJE4Ou646naZoS0ZtjY2PnAIx7nvePkZGRuyMjI9uFQgHZbFZXKpXC4ODgEc/z6gMDA+udTuf9hYWFUQAvAbi9l4qTJ09mtdaTzHwFwA8ymcxRpdQLRESVSuXdI0eObBeLReV5nvI8T4hoKwzDOcdxglqtdvj48eM7xpiAmZ8D9sWNiPIATouIEpE/VKtVF8CA1jqsVCrNUqkkruvC8zxorZVSKu10Oh9GUfQ2gG3f97czmUyLiHIHwUpEHBGZ1Vr/rlgspsYY7bqudV03dRwHWmtoreE4DjzPg+M4ipmb1tp3rbUrImKJCD3gbjFzGoahFZEPRMSKSCZN0ywRGWOM6kK76gFEYRgubG5u2iRJvI+AjTEiIujm+tq1a2tJkiwxcyGKouFsNlvNZDL5/aodxwEAabfbvLS0NBAEwSHP8zZ6wMxcIyKfiGg3o4jj+GqSJMna2trxxcXFwU6nUxCR/WtkZ2cHc3Nz/qNHj55SSmWLxeIvgH1XmpmnRMRn5ncAhLvg3wO4wczP37lz5wsbGxtJo9EIqtVqEIYhOp2ONz8/X7t///4zGxsbjVKp9FYul3vlILifiDqppK04iAkAbty4sXnmzJmXHccZbTabY3Ecl5eXl4/29/dvGWMkCILC2tracBzHh/L5/N9c150aHx9/vwdsrf2xiPwcgi87jjMNoA0Ap06dsq1WC4uLi6rVapWTJPlss9l0RUSladoGsGqM+SOAV9M0nTl79iz1gIno70qpx0TkEZEGgNOnTzvHjh37dqFQeMpxHCRJ8ra1dpqEjFHGYebtlZUVLwiCpa2trfcePnyYXL58GQetUAAUM+9Fr16vP9PpdL63tbXlRVG0w8yvlcvlq5wwcqWcevDgQd/CwsJPiei7InKrUqlMAVjqAQdBgFwuh/1gAD9JkqQUxzGCIHij3W7/6ubNm0F3slqtMhH9GcBRpdRXd8dlEeGeC9LNsO/76ty5c5NKqS/FcSxRFK1aa1+9e/fuh/v7V1dXw2azeVVEfikiqYiY7lwPmIhARHz+/PmjtVrtO9baviiK0G63b1trb8nHvwqamYmZsyIy1HXhoGIhIp3L5b4xOjr6ucP+YeW67rq19pV79+49/hgoAKQiMiciLWZ+qVAo9Pd4vKtYMTNmZmbeqdfrfzKOebbRaPzadd2Z/wD9NzlNZXcD0lrzR8Ddf8X169f/Wq/X79dqtemxsbG3pqenoydwDTM/LSKfAjAVRdEWsO8xHRoa8kXkdRF5rJT64crKyj8BqCcp3a2s53kvisg3ReT7aZr+RUR4T3Gr1ZJ8Pp+IyEkRueL7figiB+OH7jdrLUQEROQw89NEJCKSdvv2wMPDw6319fVbAL4G4PnuSbTWezHsWsXMXSiYGUTEAF4D8EhEuMeK/3f9C5VtKG2arhqTAAAAAElFTkSuQmCC" />
         <span class="sf-toolbar-status">{{ collector.querycount }}</span>
     {% if collector.querycount > 0 %}
-        <span class="sf-toolbar-info-piece-additional-detail">in {{ '%0.2f'|format(collector.time * 1000) }} ms</span>
+        <span class="sf-toolbar-info-piece-additional-detail">in {{ '%0.2f'|format(collector.time) }} ms</span>
     {% endif %}
     {% endset %}
     {% set text %}
@@ -15,7 +15,7 @@
         </div>
         <div class="sf-toolbar-info-piece">
             <b>Query Time</b>
-            <span>{{ '%0.2f'|format(collector.time * 1000) }} ms</span>
+            <span>{{ '%0.2f'|format(collector.time) }} ms</span>
         </div>
     {% endset %}
     {% include 'WebProfilerBundle:Profiler:toolbar_item.html.twig' with { 'link': profiler_url } %}
@@ -27,7 +27,7 @@
         <strong>Elastica</strong>
         <span class="count">
             <span>{{ collector.querycount }}</span>
-            <span>{{ '%0.0f'|format(collector.time * 1000) }} ms</span>
+            <span>{{ '%0.0f'|format(collector.time) }} ms</span>
         </span>
     </span>
 {% endblock %}
@@ -53,6 +53,8 @@
                     <div>
                         <code>{{ query.data|json_encode }}</code>
                     </div>
+                    <div>Query time : {{ '%0.2f'|format(query.engineMS) }} ms</div>
+                    <div>Item count : {{ query.itemCount }}</div>
                     <small>
                         <strong>Time</strong>: {{ '%0.2f'|format(query.executionMS * 1000) }} ms
                     </small>


### PR DESCRIPTION
The only time showed by this bundle is the whole time taken by the request : latency + query + fetch. So a fast query but a long fetch is marked as slow in the debug toolbar. 

With this patch I want to address this case : 
- query 1: 100ms executionTime 
- query 2 : 20ms executionTime

Naturally I want to optimize query 1, but with more analysis, what happened is that : 
- query 1: 100ms executionTime, 1ms queryTime
- query 2 : 20ms executionTime, 15ms queryTime

So the fix is different : I need to work on the query itself on query 2 and on the data retrieved on query 1.

I also return the number of result given by the query, as it can give a useful info about the query (hello the sort on 1000000 results, better shrink the resultset).

This is a very naive approach and we sure can add more time information (latency?) to have some useful time given. 

What do you think?