### PR TITLE
Allow serialize_null option for Serializer

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -587,6 +587,9 @@ class Configuration implements ConfigurationInterface
                     ->prototype('scalar')->end()
                 ->end()
                 ->scalarNode('version')->end()
+                ->booleanNode('serialize_null')
+                    ->defaultFalse()
+                ->end()
             ->end();
 
         return $node;

--- a/DependencyInjection/FOSElasticaExtension.php
+++ b/DependencyInjection/FOSElasticaExtension.php
@@ -298,6 +298,11 @@ class FOSElasticaExtension extends Extension
                 if (isset($type['serializer']['groups'])) {
                     $typeSerializerDef->addMethodCall('setGroups', array($type['serializer']['groups']));
                 }
+
+                if (isset($type['serializer']['serialize_null'])) {
+                    $typeSerializerDef->addMethodCall('setSerializeNull', array($type['serializer']['serialize_null']));
+                }
+
                 if (isset($type['serializer']['version'])) {
                     $typeSerializerDef->addMethodCall('setVersion', array($type['serializer']['version']));
                 }

--- a/Resources/doc/serializer.md
+++ b/Resources/doc/serializer.md
@@ -6,7 +6,7 @@ which will be sent directly to the Elasticsearch server. Combined with automatic
 it means types do not have to be mapped.
 
 A) Install and declare the serializer
--------------------------
+-------------------------------------
 
 Follow the installation instructions for [JMSSerializerBundle](http://jmsyst.com/bundles/JMSSerializerBundle).
 
@@ -20,7 +20,15 @@ fos_elastica:
 
 The default configuration that comes with FOSElasticaBundle supports both the JMS Serializer
 and the Symfony Serializer. If JMSSerializerBundle is installed, additional support for
-serialization groups and versions are added to the bundle.
+serialization groups, versions and null value serialization are added to the bundle. Example:
+
+```yaml
+fos_elastica:
+    serializer:
+        groups: [elastica, Default]
+        version: '1.1'
+        serialize_null: true
+```
 
 B) Set up each defined type to support serialization
 ----------------------------------------------------

--- a/Serializer/Callback.php
+++ b/Serializer/Callback.php
@@ -10,6 +10,7 @@ class Callback
     protected $serializer;
     protected $groups = array();
     protected $version;
+    protected $serializeNull;
 
     public function setSerializer($serializer)
     {
@@ -37,6 +38,15 @@ class Callback
         }
     }
 
+    public function setSerializeNull($serializeNull)
+    {
+        $this->serializeNull = $serializeNull;
+
+        if (true === $this->serializeNull && !$this->serializer instanceof SerializerInterface) {
+            throw new \RuntimeException('Setting null value serialization option requires using "JMS\Serializer\Serializer".');
+        }
+    }
+
     public function serialize($object)
     {
         $context = $this->serializer instanceof SerializerInterface ? SerializationContext::create()->enableMaxDepthChecks() : array();
@@ -48,6 +58,8 @@ class Callback
         if ($this->version) {
             $context->setVersion($this->version);
         }
+
+        $context->setSerializeNull($this->serializeNull);
 
         return $this->serializer->serialize($object, 'json', $context);
     }

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -134,6 +134,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
                         'serializer' => array(
                             'groups' => array('Search'),
                             'version' => 1,
+                            'serialize_null' => false,
                         ),
                     ),
                     'types' => array(

--- a/Tests/Functional/SerializerTest.php
+++ b/Tests/Functional/SerializerTest.php
@@ -32,6 +32,35 @@ class SerializerTest extends WebTestCase
         $persister->replaceOne($object);
     }
 
+    /**
+     * Tests that the serialize_null configuration attribute works
+     */
+    public function testWithNullValues()
+    {
+        $client = $this->createClient(array('test_case' => 'Serializer'));
+        $container = $client->getContainer();
+
+        $disabledNullPersister = $container->get('fos_elastica.object_persister.index.type_serialize_null_disabled');
+        $enabledNullPersister = $container->get('fos_elastica.object_persister.index.type_serialize_null_enabled');
+
+        $object = new TypeObj();
+        $object->id = 1;
+        $object->field1 = null;
+        $disabledNullPersister->insertOne($object);
+        $enabledNullPersister->insertOne($object);
+
+        // Tests that attributes with null values are not persisted into an Elasticsearch type without the serialize_null option
+        $disabledNullType = $container->get('fos_elastica.index.index.type_serialize_null_disabled');
+        $documentData = $disabledNullType->getDocument(1)->getData();
+        $this->assertArrayNotHasKey('field1', $documentData);
+
+        // Tests that attributes with null values are persisted into an Elasticsearch type with the serialize_null option
+        $enabledNullType = $container->get('fos_elastica.index.index.type_serialize_null_enabled');
+        $documentData = $enabledNullType->getDocument(1)->getData();
+        $this->assertArrayHasKey('field1', $documentData);
+        $this->assertEquals($documentData['field1'], null);
+    }
+
     public function testUnmappedType()
     {
         $client = $this->createClient(array('test_case' => 'Serializer'));

--- a/Tests/Functional/app/Serializer/config.yml
+++ b/Tests/Functional/app/Serializer/config.yml
@@ -40,6 +40,22 @@ fos_elastica:
                     serializer:
                         groups: ['search', 'Default']
                         version: 1.1
+                type_serialize_null_disabled:
+                    properties:
+                        field1: ~
+                    persistence:
+                        driver: orm
+                        model: FOS\ElasticaBundle\Tests\Functional\TypeObj
+                    serializer:
+                        serialize_null: false
+                type_serialize_null_enabled:
+                    properties:
+                        field1: ~
+                    persistence:
+                        driver: orm
+                        model: FOS\ElasticaBundle\Tests\Functional\TypeObj
+                    serializer:
+                        serialize_null: true
                 unmapped:
                     persistence:
                         driver: orm


### PR DESCRIPTION
It is currently impossible to populate attributes with a `null` value with FOSElasticaBundle, due to to the default behavior of JMS Serializer which doesn't serialize attributes with `null` values.

This PR adds an option to the `serializer` configuration so that the JMS Serializer can be configured with the `serialize_null` option.

There is no specific test for this PR, as it is a configuration for JMS Serializer, and I didn't find any other test concerning its configuration (for the `version` and `groups` options). I just updated the default test configuration (with a `false` value, which is the default value anyway), and added an example to the documentation for better clarity.