### PR TITLE
[ElasticSearch 2.0] No store parameters for nested type

### DIFF
--- a/Index/MappingBuilder.php
+++ b/Index/MappingBuilder.php
@@ -21,7 +21,7 @@ class MappingBuilder
      *
      * @var array
      */
-    private $skipTypes = array('completion');
+    private $skipTypes = array('completion', 'nested');
 
     /**
      * Builds mappings for an entire index.


### PR DESCRIPTION
ElasticSearch 2.0+ returns **mapper_parsing_exception**: Mapping definition has unsupported parameters:  [store : true]