### PR TITLE
Fixed PropelCollection to array casting error

### DIFF
--- a/Propel/ElasticaToModelTransformer.php
+++ b/Propel/ElasticaToModelTransformer.php
@@ -131,7 +131,7 @@ class ElasticaToModelTransformer extends AbstractElasticaToModelTransformer
             return $query->toArray();
         }
 
-        return $query->find();
+        return $query->find()->getArrayCopy();
     }
 
     /**


### PR DESCRIPTION
The ElasticaToModelTransformer failed when fetching propel results. This is solved by converting the PropelCollection returned by `->find()` into an array.