### PR TITLE
Symfony3 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,13 +15,13 @@ php:
 matrix:
   include:
     - php: 5.6
-      env: SYMFONY_VERSION='2.3.*'
+      env: SYMFONY_VERSION='2.6.*'
     - php: 5.6
       env: SYMFONY_VERSION='2.7.*'
     - php: 5.6
-      env: SYMFONY_VERSION='2.8.*@dev'
+      env: SYMFONY_VERSION='2.8.*'
     - php: 5.6
-      env: DEPENDENCIES='dev' SYMFONY_VERSION='3.0.*@dev'
+      env: SYMFONY_VERSION='3.0.*'
   allow_failures:
     - php: hhvm
   fast_finish: true

--- a/Provider/AbstractProvider.php
+++ b/Provider/AbstractProvider.php
@@ -108,9 +108,7 @@ abstract class AbstractProvider implements ProviderInterface
             'batch_size' => 100,
             'skip_indexable_check' => false,
         ));
-        $this->resolver->setAllowedTypes(array(
-            'batch_size' => 'int'
-        ));
+        $this->resolver->setAllowedTypes('batch_size', 'int');
 
         $this->resolver->setRequired(array(
             'indexName',

--- a/Tests/Functional/app/ORM/config.yml
+++ b/Tests/Functional/app/ORM/config.yml
@@ -3,7 +3,7 @@ imports:
 
 doctrine:
     dbal:
-        path: %kernel.cache_dir%/db.sqlite
+        path: "%kernel.cache_dir%/db.sqlite"
         charset:  UTF8
     orm:
         auto_generate_proxy_classes: false
@@ -44,7 +44,7 @@ fos_elastica:
                         driver: orm
                         model: FOS\ElasticaBundle\Tests\Functional\TypeObj
                         listener:
-                            is_indexable_callback: [ @indexableService, 'isIndexable' ]
+                            is_indexable_callback: [ "@indexableService", 'isIndexable' ]
                 type3:
                     mappings:
                         field1: ~

--- a/Tests/Logger/ElasticaLoggerTest.php
+++ b/Tests/Logger/ElasticaLoggerTest.php
@@ -10,11 +10,11 @@ use FOS\ElasticaBundle\Logger\ElasticaLogger;
 class ElasticaLoggerTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @return \PHPUnit_Framework_MockObject_MockObject|\Symfony\Component\HttpKernel\Log\LoggerInterface
+     * @return \PHPUnit_Framework_MockObject_MockObject|\Psr\Log\LoggerInterface
      */
     private function getMockLogger()
     {
-        return $this->getMockBuilder('Symfony\Component\HttpKernel\Log\LoggerInterface')
+        return $this->getMockBuilder('Psr\Log\LoggerInterface')
             ->disableOriginalConstructor()
             ->getMock();
     }
@@ -28,7 +28,7 @@ class ElasticaLoggerTest extends \PHPUnit_Framework_TestCase
      */
     private function getMockLoggerForLevelMessageAndContext($level, $message, $context)
     {
-        $loggerMock = $this->getMockBuilder('Symfony\Component\HttpKernel\Log\LoggerInterface')
+        $loggerMock = $this->getMockBuilder('Psr\Log\LoggerInterface')
             ->disableOriginalConstructor()
             ->getMock();
 

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "symfony/framework-bundle": "~2.3|~3.0",
+        "symfony/framework-bundle": "~2.6|~3.0",
         "symfony/console": "~2.1|~3.0",
         "symfony/form": "~2.1|~3.0",
         "symfony/property-access": "~2.3|~3.0",


### PR DESCRIPTION
Fixed code and tests to get full 2.8/3.0 compatibility (as far as the current test coverage goes). This results in loss of Symfony 2.3 support - the minimum version is now 2.6.

I don't know if this is desired at the moment, but on the long run it will be necessary anyway.