### PR TITLE
Added method check for getFacets for RawPaginatorAdapter to support newer versions of rufin/elastica

### DIFF
--- a/Paginator/RawPaginatorAdapter.php
+++ b/Paginator/RawPaginatorAdapter.php
@@ -88,7 +88,11 @@ class RawPaginatorAdapter implements PaginatorAdapterInterface
 
         $resultSet = $this->searchable->search($query, $this->options);
         $this->totalHits = $resultSet->getTotalHits();
-        $this->facets = $resultSet->getFacets();
+
+        if (method_exists($resultSet, 'getFacets')) {
+            $this->facets = $resultSet->getFacets();
+        }
+        
         $this->aggregations = $resultSet->getAggregations();
 
         return $resultSet;


### PR DESCRIPTION
The current RawPaginatorAdapter uses the getFacets method. This method is not available in newer versions of rufin/elastica.