### PR TITLE
Show query backtrace in profiler

### DIFF
--- a/Logger/ElasticaLogger.php
+++ b/Logger/ElasticaLogger.php
@@ -54,6 +54,8 @@ class ElasticaLogger implements LoggerInterface
     public function logQuery($path, $method, $data, $time, $connection = array(), $query = array(), $engineTime = 0, $itemCount = 0)
     {
         if ($this->debug) {
+            $e = new \Exception();
+
             $this->queries[] = array(
                 'path' => $path,
                 'method' => $method,
@@ -63,6 +65,7 @@ class ElasticaLogger implements LoggerInterface
                 'connection' => $connection,
                 'queryString' => $query,
                 'itemCount' => $itemCount,
+                'backtrace' => $e->getTraceAsString()
             );
         }
 

--- a/Resources/views/Collector/elastica.html.twig
+++ b/Resources/views/Collector/elastica.html.twig
@@ -58,16 +58,29 @@
                     <small>
                         <strong>Time</strong>: {{ '%0.2f'|format(query.executionMS * 1000) }} ms
                     </small>
-
                     {% if query.connection.transport in ['Http', 'Https'] %}{# cURL support only HTTP #}
-                        <a href="#elastica_curl_query_{{ key }}" onclick="return curl_version(this);" style="text-decoration: none;" title="Get the cURL repeatable query">
+                        <a href="#elastica_curl_query_{{ key }}" onclick="return toggle_details(this);" style="text-decoration: none;" title="Get the cURL repeatable query">
                             <img alt="+" src="{{ asset('bundles/framework/images/blue_picto_more.gif') }}" style="display: inline; width: 12px; height: 12px; vertical-align: bottom;" />
                             <img alt="-" src="{{ asset('bundles/framework/images/blue_picto_less.gif') }}" style="display: none; width: 12px; height: 12px; vertical-align: bottom;" />
                             <small>Display cURL query</small>
                         </a>
+                    {% endif %}
+                    {% if query.backtrace is defined %}
+                        <a href="#elastica_query_backtrace_{{ key }}" onclick="return toggle_details(this);" style="text-decoration: none;" title="Display backtrace of query execution">
+                            <img alt="+" src="{{ asset('bundles/framework/images/blue_picto_more.gif') }}" style="display: inline; width: 12px; height: 12px; vertical-align: bottom;" />
+                            <img alt="-" src="{{ asset('bundles/framework/images/blue_picto_less.gif') }}" style="display: none; width: 12px; height: 12px; vertical-align: bottom;" />
+                            <small>Display query backtrace</small>
+                        </a>
+                    {% endif %}
 
+                    {% if query.connection.transport in ['Http', 'Https'] %}{# cURL support only HTTP #}
                         <div style="display: none;" id="elastica_curl_query_{{ key }}">
                             <code>curl -X{{ query.method }} '{{ query.connection.transport|lower }}://{{ query.connection.host }}:{{ query.connection.port }}/{{ query.path }}{% if query.queryString|length %}?{{ query.queryString|url_encode }}{% endif %}' -d '{{ query.data|json_encode }}'</code>
+                        </div>
+                    {% endif %}
+                    {% if query.backtrace is defined %}
+                        <div style="display: none;" id="elastica_query_backtrace_{{ key }}">
+                            <code><pre>{{ query.backtrace }}</pre></code>
                         </div>
                     {% endif %}
                 </li>
@@ -75,7 +88,7 @@
         </ul>
 
         <script type="text/javascript">//<![CDATA[
-            function curl_version(link) {
+            function toggle_details(link) {
                 "use strict";
 
                 var sections = link.children;

--- a/Tests/Logger/ElasticaLoggerTest.php
+++ b/Tests/Logger/ElasticaLoggerTest.php
@@ -86,6 +86,9 @@ class ElasticaLoggerTest extends \PHPUnit_Framework_TestCase
 
         $elasticaLogger->logQuery($path, $method, $data, $time, $connection, $query);
         $returnedQueries = $elasticaLogger->getQueries();
+        $this->assertArrayHasKey('backtrace', $returnedQueries[0]);
+        $this->assertIsNotEmpty($returnedQueries[0]['backtrace']);
+        unset($returnedQueries[0]['backtrace']);
         $this->assertEquals($expected, $returnedQueries[0]);
     }
 

--- a/Tests/Logger/ElasticaLoggerTest.php
+++ b/Tests/Logger/ElasticaLoggerTest.php
@@ -87,7 +87,7 @@ class ElasticaLoggerTest extends \PHPUnit_Framework_TestCase
         $elasticaLogger->logQuery($path, $method, $data, $time, $connection, $query);
         $returnedQueries = $elasticaLogger->getQueries();
         $this->assertArrayHasKey('backtrace', $returnedQueries[0]);
-        $this->assertIsNotEmpty($returnedQueries[0]['backtrace']);
+        $this->assertNotEmpty($returnedQueries[0]['backtrace']);
         unset($returnedQueries[0]['backtrace']);
         $this->assertEquals($expected, $returnedQueries[0]);
     }


### PR DESCRIPTION
Often there is needed to understand where ES query come from. This PR add backtrace information and show it in profiler. It is easy to find line, that raise query call:

![profiler-query-backtrace](https://cloud.githubusercontent.com/assets/735804/12275341/e461c28c-b96f-11e5-9ca5-f8507c83320f.png)
