### PR TITLE
Allow passing extra parameters to queryBuilder factory

### DIFF
--- a/Doctrine/AbstractProvider.php
+++ b/Doctrine/AbstractProvider.php
@@ -58,10 +58,11 @@ abstract class AbstractProvider extends BaseAbstractProvider
      * Creates the query builder, which will be used to fetch objects to index.
      *
      * @param string $method
+     * @param array $arguments
      *
      * @return object
      */
-    abstract protected function createQueryBuilder($method);
+    abstract protected function createQueryBuilder($method, array $arguments = array());
 
     /**
      * Fetches a slice of objects using the query builder.

--- a/Doctrine/ORM/Provider.php
+++ b/Doctrine/ORM/Provider.php
@@ -107,12 +107,14 @@ class Provider extends AbstractProvider
     /**
      * {@inheritDoc}
      */
-    protected function createQueryBuilder($method)
+    protected function createQueryBuilder($method, array $arguments = array())
     {
-        return $this->managerRegistry
+        $repository = $this->managerRegistry
             ->getManagerForClass($this->objectClass)
-            ->getRepository($this->objectClass)
-            // ORM query builders require an alias argument
-            ->{$method}(static::ENTITY_ALIAS);
+            ->getRepository($this->objectClass);
+        // ORM query builders require an alias argument
+        $arguments = [static::ENTITY_ALIAS] + $arguments;
+
+        return call_user_func_array([$repository, $method], $arguments);
     }
 }


### PR DESCRIPTION
This adds a possibility to not only specify a method that creates a query builder, but also to supply extra parameters for the method call.

The previous implementation didn't really allow much flexibility when creating a query builder; just having a single method called at all times for a given type is a constraint that has limited several use cases for me, and I think I might be not the only one having this kind of trouble.

Note: this is in an un-tested state, I should fix this.