### PR TITLE
Skip array, object and nested file in MappingBuilder

### DIFF
--- a/Index/MappingBuilder.php
+++ b/Index/MappingBuilder.php
@@ -21,7 +21,7 @@ class MappingBuilder
      *
      * @var array
      */
-    private $skipTypes = array('completion', 'array', 'object');
+    private $skipTypes = array('completion', 'array', 'object', 'nested');
 
     /**
      * Builds mappings for an entire index.

--- a/Index/MappingBuilder.php
+++ b/Index/MappingBuilder.php
@@ -21,7 +21,7 @@ class MappingBuilder
      *
      * @var array
      */
-    private $skipTypes = array('completion');
+    private $skipTypes = array('completion', 'array', 'object');
 
     /**
      * Builds mappings for an entire index.


### PR DESCRIPTION
I added the following types: array, object and nested to the skipTypes array. I've seen the pull reject from a month ago: https://github.com/FriendsOfSymfony/FOSElasticaBundle/pull/987. 
I have been waiting since that day for a fix, but this is still a issue in the current version, so thats the reason why i added them and made a new pull request.