### PR TITLE
Allow to access to the Type in transformers and events

### DIFF
--- a/Event/TransformEvent.php
+++ b/Event/TransformEvent.php
@@ -12,6 +12,7 @@
 namespace FOS\ElasticaBundle\Event;
 
 use Symfony\Component\EventDispatcher\Event;
+use Elastica\Type;
 
 class TransformEvent extends Event
 {
@@ -34,15 +35,22 @@ class TransformEvent extends Event
     private $object;
 
     /**
-     * @param mixed $document
-     * @param array $fields
-     * @param mixed $object
+     * @var Type|null
      */
-    public function __construct($document, array $fields, $object)
+    private $type;
+
+    /**
+     * @param mixed     $document
+     * @param array     $fields
+     * @param mixed     $object
+     * @param Type|null $type
+     */
+    public function __construct($document, array $fields, $object, Type $type = null)
     {
         $this->document = $document;
         $this->fields = $fields;
         $this->object = $object;
+        $this->type = $type;
     }
 
     /**
@@ -67,6 +75,14 @@ class TransformEvent extends Event
     public function getObject()
     {
         return $this->object;
+    }
+
+    /**
+     * @return Type
+     */
+    public function getType()
+    {
+        return $this->type;
     }
 
     /**

--- a/Persister/ObjectPersister.php
+++ b/Persister/ObjectPersister.php
@@ -188,6 +188,6 @@ class ObjectPersister implements ObjectPersisterInterface
      */
     public function transformToElasticaDocument($object)
     {
-        return $this->transformer->transform($object, $this->fields);
+        return $this->transformer->transform($object, $this->fields, $this->type);
     }
 }

--- a/Persister/ObjectSerializerPersister.php
+++ b/Persister/ObjectSerializerPersister.php
@@ -40,7 +40,7 @@ class ObjectSerializerPersister extends ObjectPersister
      */
     public function transformToElasticaDocument($object)
     {
-        $document = $this->transformer->transform($object, array());
+        $document = $this->transformer->transform($object, array(), $this->type);
 
         $data = call_user_func($this->serializer, $object);
         $document->setData($data);

--- a/Transformer/ModelToElasticaIdentifierTransformer.php
+++ b/Transformer/ModelToElasticaIdentifierTransformer.php
@@ -3,6 +3,7 @@
 namespace FOS\ElasticaBundle\Transformer;
 
 use Elastica\Document;
+use Elastica\Type;
 
 /**
  * Creates an Elastica document with the ID of
@@ -13,15 +14,16 @@ class ModelToElasticaIdentifierTransformer extends ModelToElasticaAutoTransforme
     /**
      * Creates an elastica document with the id of the doctrine object as id.
      *
-     * @param object $object the object to convert
-     * @param array  $fields the keys we want to have in the returned array
+     * @param object    $object the object to convert
+     * @param array     $fields the keys we want to have in the returned array
+     * @param Type|null $type   the current type
      *
      * @return Document
      **/
-    public function transform($object, array $fields)
+    public function transform($object, array $fields, Type $type = null)
     {
         $identifier = $this->propertyAccessor->getValue($object, $this->options['identifier']);
 
-        return new Document($identifier);
+        return new Document($identifier, array(), $type ? $type->getName() : '');
     }
 }

--- a/Transformer/ModelToElasticaTransformerInterface.php
+++ b/Transformer/ModelToElasticaTransformerInterface.php
@@ -2,6 +2,8 @@
 
 namespace FOS\ElasticaBundle\Transformer;
 
+use Elastica\Type;
+
 /**
  * Maps Elastica documents with model objects.
  */
@@ -10,10 +12,11 @@ interface ModelToElasticaTransformerInterface
     /**
      * Transforms an object into an elastica object having the required keys.
      *
-     * @param object $object the object to convert
-     * @param array  $fields the keys we want to have in the returned array
+     * @param object    $object the object to convert
+     * @param array     $fields the keys we want to have in the returned array
+     * @param Type|null $type   the current type
      *
      * @return \Elastica\Document
      **/
-    public function transform($object, array $fields);
+    public function transform($object, array $fields, Type $type = null);
 }


### PR DESCRIPTION
Close #908.

Propagates the current type to transformers and events. This is useful when you need to know on which index you are working on.

My use case: I store translations in a different index for each lang. I want to set some custom properties on a given lang, I need to know the name of the current index.
