### PR TITLE
Fixed bug where sort field was requested from a Request object that m…

### DIFF
--- a/Resources/config/config.xml
+++ b/Resources/config/config.xml
@@ -35,6 +35,9 @@
             <call method="setRequest">
                 <argument type="service" id="request" on-invalid="null" strict="false" />
             </call>
+            <call method="setRequestStack">
+                <argument type="service" id="request_stack" on-invalid="null" strict="false" />
+            </call>
             <tag name="knp_paginator.subscriber" />
         </service>
 


### PR DESCRIPTION
…ight not have been set

Resulting in the error:

```json
{
  "error": {
    "code": 500,
    "message": "Internal Server Error",
    "exception": [
      {
        "message": "Error: Call to a member function get() on null",
        "class": "Symfony\\Component\\Debug\\Exception\\FatalErrorException",
        "trace": [
          {
            "namespace": "",
            "short_class": "",
            "class": "",
            "type": "",
            "function": "",
            "file": "/projects/freshheads-rapportage/vendor/friendsofsymfony/elastica-bundle/Subscriber/PaginateElasticaQuerySubscriber.php",
            "line": 52,
            "args": []
          },

...

```