### PR TITLE
Allow to specify custom connection settings for functional tests

### DIFF
--- a/Tests/Functional/ClientTest.php
+++ b/Tests/Functional/ClientTest.php
@@ -11,8 +11,6 @@
 
 namespace FOS\ElasticaBundle\Tests\Functional;
 
-use Symfony\Bundle\FrameworkBundle\Client;
-
 /**
  * @group functional
  */

--- a/Tests/Functional/app/Basic/config.yml
+++ b/Tests/Functional/app/Basic/config.yml
@@ -12,16 +12,16 @@ fos_elastica:
     clients:
         default:
             connections:
-                - url: http://localhost:9200
-                - host: localhost
-                  port: 9200
+                - url: http://%fos_elastica.host%:%fos_elastica.port%
+                - host: %fos_elastica.host%
+                  port: %fos_elastica.port%
             connectionStrategy: RoundRobin
         second_server:
             connections:
-                - url: http://localhost:9200
+                - url: http://%fos_elastica.host%:%fos_elastica.port%
             connection_strategy: RoundRobin
         third:
-            url: http://localhost:9200
+            url: http://%fos_elastica.host%:%fos_elastica.port%
     indexes:
         index:
             index_name: foselastica_basic_test_%kernel.environment%

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <phpunit bootstrap="./vendor/autoload.php" colors="true">
+    <php>
+        <server name="SYMFONY__FOS_ELASTICA__HOST" value="localhost" />
+        <server name="SYMFONY__FOS_ELASTICA__PORT" value="9200" />
+    </php>
+
     <testsuites>
         <testsuite name="FOSElasticaBundle Test Suite">
             <directory>./Tests</directory>


### PR DESCRIPTION
This PR adds ability to overwrite default connection settings by customising `phpinit.xml` or by providing env variables, e.g.: 

```
$ export SYMFONY__FOS_ELASTICA__HOST=192.168.33.1
$ export SYMFONY__FOS_ELASTICA__PORT=19200
$ phpunit Tests/Functional/ClientTest.php
```