### PR TITLE
Fix "fos_elastica.paginator.subscriber" service instantiation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ php:
 matrix:
   include:
     - php: 5.6
-      env: SYMFONY_VERSION='2.3.*'
+      env: SYMFONY_VERSION='2.4.*'
     - php: 5.6
       env: SYMFONY_VERSION='2.7.*'
     - php: 5.6

--- a/Resources/config/config.xml
+++ b/Resources/config/config.xml
@@ -27,14 +27,12 @@
         </service>
 
         <service id="fos_elastica.data_collector" class="%fos_elastica.data_collector.class%">
-            <tag name="data_collector" template="FOSElasticaBundle:Collector:elastica" id="elastica" />
             <argument type="service" id="fos_elastica.logger" />
+            <tag name="data_collector" template="FOSElasticaBundle:Collector:elastica" id="elastica" />
         </service>
 
         <service id="fos_elastica.paginator.subscriber" class="FOS\ElasticaBundle\Subscriber\PaginateElasticaQuerySubscriber">
-            <call method="setRequest">
-                <argument type="service" id="request" on-invalid="null" strict="false" />
-            </call>
+            <argument type="service" id="request_stack" />
             <tag name="knp_paginator.subscriber" />
         </service>
 

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "symfony/framework-bundle": "~2.3|~3.0",
+        "symfony/framework-bundle": "~2.4|~3.0",
         "symfony/console": "~2.1|~3.0",
         "symfony/form": "~2.1|~3.0",
         "symfony/property-access": "~2.3|~3.0",


### PR DESCRIPTION
The `PaginateElasticaQuerySubscriber` object is not properly initialized on symfony > v3.0 as it use `request` service which was deprecated in v2.4 and removed in v3.0. 

This PR rises minimal `framework-bundle` version to 2.4 to avoid clutter with checking for existence of both `request` and `request_stack` services.