### PR TITLE
Made default sort options from pagination config to work as expected

### DIFF
--- a/Subscriber/PaginateElasticaQuerySubscriber.php
+++ b/Subscriber/PaginateElasticaQuerySubscriber.php
@@ -49,12 +49,12 @@ class PaginateElasticaQuerySubscriber implements EventSubscriberInterface
     protected function setSorting(ItemsEvent $event)
     {
         $options = $event->options;
-        $sortField = $this->request->get($options['sortFieldParameterName']);
+        $sortField = $this->request->get($options['sortFieldParameterName'], $options['defaultSortFieldName']);
 
         if (!empty($sortField)) {
             // determine sort direction
             $dir = 'asc';
-            $sortDirection = $this->request->get($options['sortDirectionParameterName']);
+            $sortDirection = $this->request->get($options['sortDirectionParameterName'], $options['defaultSortDirection']);
             if ('desc' === strtolower($sortDirection)) {
                 $dir = 'desc';
             }


### PR DESCRIPTION
Fallback to defaultSortFieldName and defaultSortDirection pagination options instead of ignoring then.