### PR TITLE
Revert "Made default sort options from pagination config to work as expected"

### DIFF
--- a/Subscriber/PaginateElasticaQuerySubscriber.php
+++ b/Subscriber/PaginateElasticaQuerySubscriber.php
@@ -60,12 +60,12 @@ class PaginateElasticaQuerySubscriber implements EventSubscriberInterface
     protected function setSorting(ItemsEvent $event)
     {
         $options = $event->options;
-        $sortField = $this->request->get($options['sortFieldParameterName'], $options['defaultSortFieldName']);
+        $sortField = $this->request->get($options['sortFieldParameterName']);
 
         if (!empty($sortField)) {
             // determine sort direction
             $dir = 'asc';
-            $sortDirection = $this->request->get($options['sortDirectionParameterName'], $options['defaultSortDirection']);
+            $sortDirection = $this->request->get($options['sortDirectionParameterName']);
             if ('desc' === strtolower($sortDirection)) {
                 $dir = 'desc';
             }


### PR DESCRIPTION
Reverts FriendsOfSymfony/FOSElasticaBundle#1032 due to broken compatability with KnpPaginatorBundle