### PR TITLE
Fix defaultSortFieldName and defaultSortDirection pagination option from KNP

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -13,3 +13,4 @@ CHANGELOG for 3.2.x
  * Introduce `serialize_null` option for Serializer
  * Ability to specify custom connection settings for functional tests
  * Doctrine: possible to use hints when hydrating objects
+ * Resolved Propel configuration

--- a/Propel/ElasticaToModelTransformer.php
+++ b/Propel/ElasticaToModelTransformer.php
@@ -5,6 +5,7 @@ namespace FOS\ElasticaBundle\Propel;
 use FOS\ElasticaBundle\HybridResult;
 use FOS\ElasticaBundle\Transformer\AbstractElasticaToModelTransformer;
 use FOS\ElasticaBundle\Transformer\ElasticaToModelTransformerInterface;
+use FOS\ElasticaBundle\Transformer\HighlightableModelInterface;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 
 /**
@@ -56,25 +57,36 @@ class ElasticaToModelTransformer extends AbstractElasticaToModelTransformer
      */
     public function transform(array $elasticaObjects)
     {
-        $ids = array();
+        $ids = $highlights = array();
         foreach ($elasticaObjects as $elasticaObject) {
             $ids[] = $elasticaObject->getId();
+            $highlights[$elasticaObject->getId()] = $elasticaObject->getHighlights();
         }
 
         $objects = $this->findByIdentifiers($ids, $this->options['hydrate']);
 
-        // Sort objects in the order of their IDs
-        $idPos = array_flip($ids);
-        $identifier = $this->options['identifier'];
-        $sortCallback = $this->getSortingClosure($idPos, $identifier);
-
-        if (is_object($objects)) {
-            $objects->uasort($sortCallback);
-        } else {
-            usort($objects, $sortCallback);
+        if (!$this->options['ignore_missing'] && count($objects) < count($elasticaObjects)) {
+            throw new \RuntimeException('Cannot find corresponding Propel objects for all Elastica results.');
         }
 
-        return $objects;
+        $_objects = [];
+        foreach ($objects as $object) {
+            if ($objects instanceof HighlightableModelInterface) {
+                $object->setElasticHighlights($highlights[$object->getId()]);
+            }
+
+            $_objects[] = $object;
+        }
+
+
+//        $objects = $objects->toArray();
+//
+//        // Sort objects in the order of their IDs
+//        $idPos = array_flip($ids);
+//        $identifier = $this->options['identifier'];
+//        usort($objects, $this->getSortingClosure($idPos, $identifier));
+
+        return $_objects;
     }
 
     /**

--- a/Propel/Provider.php
+++ b/Propel/Provider.php
@@ -54,4 +54,21 @@ class Provider extends AbstractProvider
     protected function enableLogging($logger)
     {
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function configureOptions()
+    {
+        parent::configureOptions();
+
+        $this->resolver->setDefaults(array(
+            'clear_object_manager' => true,
+            'debug_logging'        => false,
+            'ignore_errors'        => false,
+            'offset'               => 0,
+            'query_builder_method' => 'createQueryBuilder',
+            'sleep'                => 0
+        ));
+    }
 }

--- a/Serializer/Callback.php
+++ b/Serializer/Callback.php
@@ -59,7 +59,9 @@ class Callback
             $context->setVersion($this->version);
         }
 
-        $context->setSerializeNull($this->serializeNull);
+        if (!is_array($context)) {
+          $context->setSerializeNull($this->serializeNull);
+        }
 
         return $this->serializer->serialize($object, 'json', $context);
     }

--- a/Subscriber/PaginateElasticaQuerySubscriber.php
+++ b/Subscriber/PaginateElasticaQuerySubscriber.php
@@ -60,12 +60,21 @@ class PaginateElasticaQuerySubscriber implements EventSubscriberInterface
     protected function setSorting(ItemsEvent $event)
     {
         $options = $event->options;
-        $sortField = $this->request->get($options['sortFieldParameterName'], $options['defaultSortFieldName']);
+        $sortField = $this->request->get($options['sortFieldParameterName']);
+
+        if(!$sortField && isset($options['defaultSortFieldName'])) {
+            $sortField = $options['defaultSortFieldName'];
+        }
 
         if (!empty($sortField)) {
             // determine sort direction
             $dir = 'asc';
-            $sortDirection = $this->request->get($options['sortDirectionParameterName'], $options['defaultSortDirection']);
+            $sortDirection = $this->request->get($options['sortDirectionParameterName']);
+            
+            if(!$sortDirection && isset($options['defaultSortDirection'])) {
+                $sortDirection = $options['defaultSortDirection'];
+            }
+            
             if ('desc' === strtolower($sortDirection)) {
                 $dir = 'desc';
             }

--- a/Subscriber/PaginateElasticaQuerySubscriber.php
+++ b/Subscriber/PaginateElasticaQuerySubscriber.php
@@ -70,11 +70,11 @@ class PaginateElasticaQuerySubscriber implements EventSubscriberInterface
             // determine sort direction
             $dir = 'asc';
             $sortDirection = $this->request->get($options['sortDirectionParameterName']);
-            
+
             if (!$sortDirection && isset($options['defaultSortDirection'])) {
                 $sortDirection = $options['defaultSortDirection'];
             }
-            
+
             if ('desc' === strtolower($sortDirection)) {
                 $dir = 'desc';
             }

--- a/Subscriber/PaginateElasticaQuerySubscriber.php
+++ b/Subscriber/PaginateElasticaQuerySubscriber.php
@@ -62,7 +62,7 @@ class PaginateElasticaQuerySubscriber implements EventSubscriberInterface
         $options = $event->options;
         $sortField = $this->request->get($options['sortFieldParameterName']);
 
-        if (!$sortField && isset($options['defaultSortFieldName'])) {
+        if(!$sortField && isset($options['defaultSortFieldName'])) {
             $sortField = $options['defaultSortFieldName'];
         }
 
@@ -70,11 +70,11 @@ class PaginateElasticaQuerySubscriber implements EventSubscriberInterface
             // determine sort direction
             $dir = 'asc';
             $sortDirection = $this->request->get($options['sortDirectionParameterName']);
-
-            if (!$sortDirection && isset($options['defaultSortDirection'])) {
+            
+            if(!$sortDirection && isset($options['defaultSortDirection'])) {
                 $sortDirection = $options['defaultSortDirection'];
             }
-
+            
             if ('desc' === strtolower($sortDirection)) {
                 $dir = 'desc';
             }

--- a/Subscriber/PaginateElasticaQuerySubscriber.php
+++ b/Subscriber/PaginateElasticaQuerySubscriber.php
@@ -62,7 +62,7 @@ class PaginateElasticaQuerySubscriber implements EventSubscriberInterface
         $options = $event->options;
         $sortField = $this->request->get($options['sortFieldParameterName']);
 
-        if(!$sortField && isset($options['defaultSortFieldName'])) {
+        if (!$sortField && isset($options['defaultSortFieldName'])) {
             $sortField = $options['defaultSortFieldName'];
         }
 
@@ -71,7 +71,7 @@ class PaginateElasticaQuerySubscriber implements EventSubscriberInterface
             $dir = 'asc';
             $sortDirection = $this->request->get($options['sortDirectionParameterName']);
             
-            if(!$sortDirection && isset($options['defaultSortDirection'])) {
+            if (!$sortDirection && isset($options['defaultSortDirection'])) {
                 $sortDirection = $options['defaultSortDirection'];
             }
             


### PR DESCRIPTION
Apply defaultSortFieldName and defaultSortDirection pagination options if they are defined. Fix for previous PR.

https://github.com/FriendsOfSymfony/FOSElasticaBundle/pull/1032#issuecomment-191746589