### PR TITLE
Search Elastic Search Results from a Repository

### DIFF
--- a/Finder/PaginatedFinderInterface.php
+++ b/Finder/PaginatedFinderInterface.php
@@ -27,4 +27,35 @@ interface PaginatedFinderInterface extends FinderInterface
      * @return PaginatorAdapterInterface
      */
     public function createPaginatorAdapter($query, $options = array());
+    
+    /**
+     * Searches for query results and returns them wrapped in a paginator.
+     *
+     * @param mixed $query   Can be a string, an array or an \Elastica\Query object
+     * @param array $options
+     *
+     * @return Pagerfanta paginated results
+     */
+    public function findRawPaginated($query, $options = array());
+    
+    /**
+     * Creates a paginator adapter for this query.
+     *
+     * @param mixed $query
+     * @param array $options
+     *
+     * @return PaginatorAdapterInterface
+     */
+    public function createRawPaginatorAdapter($query, $options = array());
+    
+    /**
+     * Searches for query results within a given limit.
+     *
+     * @param mixed $query   Can be a string, an array or an \Elastica\Query object
+     * @param int   $limit   How many results to get
+     * @param array $options
+     *
+     * @return array results
+     */
+    public function findRawResult($query, $limit = null, $options = array());
 }

--- a/Finder/TransformedFinder.php
+++ b/Finder/TransformedFinder.php
@@ -6,6 +6,7 @@ use Elastica\Document;
 use FOS\ElasticaBundle\Transformer\ElasticaToModelTransformerInterface;
 use FOS\ElasticaBundle\Paginator\TransformedPaginatorAdapter;
 use FOS\ElasticaBundle\Paginator\FantaPaginatorAdapter;
+use FOS\ElasticaBundle\Paginator\RawPaginatorAdapter;
 use Pagerfanta\Pagerfanta;
 use Elastica\SearchableInterface;
 use Elastica\Query;
@@ -46,7 +47,13 @@ class TransformedFinder implements PaginatedFinderInterface
 
         return $this->transformer->hybridTransform($results);
     }
+    
+    public function findRawResult($query, $limit = null, $options = array())
+    {
+        $results = $this->search($query, $limit, $options);
 
+        return $results;
+    }
     /**
      * Find documents similar to one with passed id.
      *
@@ -97,6 +104,17 @@ class TransformedFinder implements PaginatedFinderInterface
 
         return new Pagerfanta(new FantaPaginatorAdapter($paginatorAdapter));
     }
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function findRawPaginated($query, $options = array())
+    {
+        $queryObject = Query::create($query);
+        $paginatorAdapter = $this->createRawPaginatorAdapter($queryObject, $options);
+
+        return new Pagerfanta(new FantaPaginatorAdapter($paginatorAdapter));
+    }
 
     /**
      * {@inheritdoc}
@@ -106,5 +124,14 @@ class TransformedFinder implements PaginatedFinderInterface
         $query = Query::create($query);
 
         return new TransformedPaginatorAdapter($this->searchable, $query, $options, $this->transformer);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function createRawPaginatorAdapter($query, $options = array())
+    {
+        $query = Query::create($query);
+        return new RawPaginatorAdapter($this->searchable, $query, $options);
     }
 }

--- a/Repository.php
+++ b/Repository.php
@@ -44,6 +44,18 @@ class Repository
     }
 
     /**
+     * @param mixed   $query
+     * @param integer $limit
+     * @param array   $options
+     *
+     * @return mixed
+     */
+    public function findRawResult($query, $limit = null, $options = array())
+    {
+        return $this->finder->findRawResult($query, $limit, $options);
+    }
+
+    /**
      * @param mixed $query
      * @param array $options
      *
@@ -63,5 +75,27 @@ class Repository
     public function createPaginatorAdapter($query, $options = array())
     {
         return $this->finder->createPaginatorAdapter($query, $options);
+    }
+
+    /**
+     * @param mixed $query
+     * @param array $options
+     *
+     * @return \Pagerfanta\Pagerfanta
+     */
+    public function findRawPaginated($query, $options = array())
+    {
+        return $this->finder->findRawPaginated($query, $options);
+    }
+
+    /**
+     * @param string $query
+     * @param array  $options
+     *
+     * @return Paginator\PaginatorAdapterInterface
+     */
+    public function createRawPaginatorAdapter($query, $options = array())
+    {
+        return $this->finder->createRawPaginatorAdapter($query, $options);
     }
 }

--- a/Tests/RepositoryTest.php
+++ b/Tests/RepositoryTest.php
@@ -55,6 +55,33 @@ class RepositoryTest extends \PHPUnit_Framework_TestCase
         $repository->findHybrid($testQuery);
     }
 
+    public function testThatFindRawResultCallsFindRawResultOnFinder()
+    {
+        $testQuery = 'Test Query';
+
+        $finderMock = $this->getFinderMock($testQuery, null, 'findRawResult');
+        $repository = new Repository($finderMock);
+        $repository->findRawResult($testQuery);
+    }
+    
+    public function testThatFindRawPaginatedCallsFindRawPaginatedOnFinder()
+    {
+        $testQuery = 'Test Query';
+
+        $finderMock = $this->getFinderMock($testQuery, array(), 'findRawPaginated');
+        $repository = new Repository($finderMock);
+        $repository->findRawPaginated($testQuery);
+    }
+
+    public function testThatCreateRawPaginatorCreatesAPaginatorViaFinder()
+    {
+        $testQuery = 'Test Query';
+
+        $finderMock = $this->getFinderMock($testQuery, array(), 'createRawPaginatorAdapter');
+        $repository = new Repository($finderMock);
+        $repository->createRawPaginatorAdapter($testQuery);
+    }
+
     /**
      * @param string $testQuery
      * @param mixed $testLimit

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,7 +2,7 @@
 
 <phpunit bootstrap="./vendor/autoload.php" colors="true">
     <php>
-        <server name="SYMFONY__FOS_ELASTICA__HOST" value="localhost" />
+        <server name="SYMFONY__FOS_ELASTICA__HOST" value="127.0.0.1" />
         <server name="SYMFONY__FOS_ELASTICA__PORT" value="9200" />
     </php>
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,7 +2,7 @@
 
 <phpunit bootstrap="./vendor/autoload.php" colors="true">
     <php>
-        <server name="SYMFONY__FOS_ELASTICA__HOST" value="127.0.0.1" />
+        <server name="SYMFONY__FOS_ELASTICA__HOST" value="localhost" />
         <server name="SYMFONY__FOS_ELASTICA__PORT" value="9200" />
     </php>
 


### PR DESCRIPTION
Hello,

It's been some time I'm wondering why getting hybrid or Doctrine Result would be done a way, and getting Elastic Search Result another way.
For performance reason, I decided to not use Doctrine Result neither the Hybrid one.

As I needed Pagination, I created all methods that will allow user to retrieve Raw Result, meaning an Array containing all Elastic search data.

Example of usage : 
In the repository

```
        $query =  new \Elastica\Query\MatchAll();
        return $this->findRawResult($query);
```

And with pagination

```
        $repositoryManager = $this->get('fos_elastica.manager.orm');
        $repository = $repositoryManager->getRepository('MyBundle:Entity');
        $pagerfanta = $repository->findRawPaginated($myQuery);
```

This change is only adding new functionalities, not affecting any other.

Some improvement could be done. For example, ElasticAdapter from PagerFanta Bundle, return Object you can use like that : 

```
foreach($results as $result){
    echo $result->getId();
}
```

The FantaPaginatorAdapter prevent that by forcing array to be returned in place of object. Could maybe be a good point to allow both.
