### PR TITLE
[Bug Fix] Remove PaginatorAdapterInterface from Pagerfanta adapter

### DIFF
--- a/Paginator/FantaPaginatorAdapter.php
+++ b/Paginator/FantaPaginatorAdapter.php
@@ -4,7 +4,7 @@ namespace FOS\ElasticaBundle\Paginator;
 
 use Pagerfanta\Adapter\AdapterInterface;
 
-class FantaPaginatorAdapter implements AdapterInterface, PaginatorAdapterInterface
+class FantaPaginatorAdapter implements AdapterInterface
 {
     private $adapter;
 


### PR DESCRIPTION
As described in issue #1040 the PaginatorAdapterInterface should not be applied to the FantaPaginatorAdapter (which is the adapter for Pagerfanta).