### PR TITLE
array hydration fails to get the id property

### DIFF
--- a/Doctrine/AbstractElasticaToModelTransformer.php
+++ b/Doctrine/AbstractElasticaToModelTransformer.php
@@ -96,7 +96,11 @@ abstract class AbstractElasticaToModelTransformer extends BaseTransformer
 
         // sort objects in the order of ids
         $idPos = array_flip($ids);
-        $identifier = $this->options['identifier'];
+        if ($this->options['hydrate']) {
+            $identifier = $this->options['identifier'];
+        } else {
+            $identifier = '[' . $this->options['identifier'] . ']';
+        }
         usort($objects, $this->getSortingClosure($idPos, $identifier));
 
         return $objects;


### PR DESCRIPTION
**Error: Cannot read property "id" from an array. Maybe you intended to write the property path as "[id]" instead.**

If I set the hydration option to false on the ElasticaToModelTransformer, the transform function complains that it cannot get the property id, because it does not detect "id" as an index inside the Symfony Component PropertyPathAccessor (or more correctly during the PropertyPath construction). I found issue #568, but the solution with the brackets throws the error:

**QueryException: SELECT o FROM XXX o WHERE o.[id] IN(:values)**

because of the line

`$qb->andWhere($qb->expr()->in(static::ENTITY_ALIAS . '.' . $this->options['identifier'], ':values'))`

inside the ElasticaToModelTransformer.