### PR TITLE
Fixed ability to use an object as unique identifier

### DIFF
--- a/Doctrine/AbstractElasticaToModelTransformer.php
+++ b/Doctrine/AbstractElasticaToModelTransformer.php
@@ -106,7 +106,7 @@ abstract class AbstractElasticaToModelTransformer extends BaseTransformer
     {
         $indexedElasticaResults = array();
         foreach ($elasticaObjects as $elasticaObject) {
-            $indexedElasticaResults[$elasticaObject->getId()] = $elasticaObject;
+            $indexedElasticaResults[(string) $elasticaObject->getId()] = $elasticaObject;
         }
 
         $objects = $this->transform($elasticaObjects);

--- a/Tests/Transformer/ElasticaToModelTransformerCollectionTest.php
+++ b/Tests/Transformer/ElasticaToModelTransformerCollectionTest.php
@@ -100,6 +100,32 @@ class ElasticaToModelTransformerCollectionTest extends \PHPUnit_Framework_TestCa
         ), $results);
     }
 
+    public function testTransformOrderWithIdAsObject()
+    {
+        $this->collectionSetup();
+
+        $id1 = 'yo';
+        $id2 = 'lo';
+        $idObject1 = new IDObject($id1);
+        $idObject2 = new IDObject($id2);
+        $document1 = new Document($idObject1, array('data' => 'lots of data'), 'type1');
+        $document2 = new Document($idObject2, array('data' => 'not so much data'), 'type1');
+        $result1 = new POPO($idObject1, 'lots of data');
+        $result2 = new POPO2($idObject2, 'not so much data');
+
+        $this->transformers['type1']->expects($this->once())
+         ->method('transform')
+         ->with(array($document1, $document2))
+         ->will($this->returnValue(array($result1, $result2)));
+
+        $results = $this->collection->transform(array($document1, $document2));
+
+        $this->assertEquals(array(
+            $result1,
+            $result2,
+        ), $results);
+    }
+
     public function testGetIdentifierFieldReturnsAMapOfIdentifiers()
     {
         $collection = new ElasticaToModelTransformerCollection(array());
@@ -158,7 +184,7 @@ class POPO
     public $data;
 
     /**
-     * @param integer $id
+     * @param mixed $id
      */
     public function __construct($id, $data)
     {
@@ -174,4 +200,22 @@ class POPO
 
 class POPO2 extends POPO
 {
+}
+
+class IDObject
+{
+    protected $id;
+
+    /**
+     * @param int|string $id
+     */
+    public function __construct($id)
+    {
+        $this->id = $id;
+    }
+
+    public function __toString()
+    {
+        return (string) $this->id;
+    }
 }

--- a/Transformer/AbstractElasticaToModelTransformer.php
+++ b/Transformer/AbstractElasticaToModelTransformer.php
@@ -45,7 +45,7 @@ abstract class AbstractElasticaToModelTransformer implements ElasticaToModelTran
         $propertyAccessor = $this->propertyAccessor;
 
         return function ($a, $b) use ($idPos, $identifierPath, $propertyAccessor) {
-            return $idPos[$propertyAccessor->getValue($a, $identifierPath)] > $idPos[$propertyAccessor->getValue($b, $identifierPath)];
+            return $idPos[(string) $propertyAccessor->getValue($a, $identifierPath)] > $idPos[(string) $propertyAccessor->getValue($b, $identifierPath)];
         };
     }
 }

--- a/Transformer/ElasticaToModelTransformerCollection.php
+++ b/Transformer/ElasticaToModelTransformerCollection.php
@@ -68,8 +68,8 @@ class ElasticaToModelTransformerCollection implements ElasticaToModelTransformer
 
         $result = array();
         foreach ($elasticaObjects as $object) {
-            if (array_key_exists($object->getId(), $transformed[$object->getType()])) {
-                $result[] = $transformed[$object->getType()][$object->getId()];
+            if (array_key_exists((string) $object->getId(), $transformed[$object->getType()])) {
+                $result[] = $transformed[$object->getType()][(string) $object->getId()];
             }
         }
 


### PR DESCRIPTION
When using a lib such as `ramsey/uuid-doctrine` to handle object IDs, the cast is not performed blocking transformation.