### PR TITLE
Add More Debugging Output

### DIFF
--- a/Doctrine/AbstractElasticaToModelTransformer.php
+++ b/Doctrine/AbstractElasticaToModelTransformer.php
@@ -87,7 +87,7 @@ abstract class AbstractElasticaToModelTransformer extends BaseTransformer
         $objectsCnt = count($objects);
         $elasticaObjectsCnt = count($elasticaObjects);
         if (!$this->options['ignore_missing'] && $objectsCnt < $elasticaObjectsCnt) {
-            throw new \RuntimeException(sprintf('Cannot find corresponding Doctrine objects (%d) for all Elastica results (%s). IDs: %s', $objectsCnt, $elasticaObjectsCnt, join(', ', $ids)));
+            throw new \RuntimeException(sprintf('Cannot find corresponding Doctrine objects (%d) for all Elastica results (%d). IDs: %s', $objectsCnt, $elasticaObjectsCnt, join(', ', $ids)));
         };
 
         foreach ($objects as $object) {

--- a/Doctrine/AbstractElasticaToModelTransformer.php
+++ b/Doctrine/AbstractElasticaToModelTransformer.php
@@ -84,8 +84,10 @@ abstract class AbstractElasticaToModelTransformer extends BaseTransformer
         }
 
         $objects = $this->findByIdentifiers($ids, $this->options['hydrate']);
-        if (!$this->options['ignore_missing'] && count($objects) < count($elasticaObjects)) {
-            throw new \RuntimeException('Cannot find corresponding Doctrine objects for all Elastica results.');
+        $objectsCnt = count($objects);
+        $elasticaObjectsCnt = count($elasticaObjects);
+        if (!$this->options['ignore_missing'] && $objectsCnt < $elasticaObjectsCnt) {
+            throw new \RuntimeException('Cannot find corresponding Doctrine objects ('.$objectsCnt.') for all Elastica results ('.$elasticaObjectsCnt.'). IDs: '.join(', ', $ids));
         };
 
         foreach ($objects as $object) {

--- a/Doctrine/AbstractElasticaToModelTransformer.php
+++ b/Doctrine/AbstractElasticaToModelTransformer.php
@@ -87,7 +87,7 @@ abstract class AbstractElasticaToModelTransformer extends BaseTransformer
         $objectsCnt = count($objects);
         $elasticaObjectsCnt = count($elasticaObjects);
         if (!$this->options['ignore_missing'] && $objectsCnt < $elasticaObjectsCnt) {
-            throw new \RuntimeException('Cannot find corresponding Doctrine objects ('.$objectsCnt.') for all Elastica results ('.$elasticaObjectsCnt.'). IDs: '.join(', ', $ids));
+            throw new \RuntimeException(sprintf('Cannot find corresponding Doctrine objects (%d) for all Elastica results (%s). IDs: %s', $objectsCnt, $elasticaObjectsCnt, join(', ', $ids)));
         };
 
         foreach ($objects as $object) {


### PR DESCRIPTION
The original message doesn't actually help anybody. If this exception pops up provide the count of the Doctrine objects and the count of the Elastica results. Also print the IDs found by Elastica for further
investigation about the out-of-sync state.