### PR TITLE
Removed immediate option in config

### DIFF
--- a/CHANGELOG-3.2.md
+++ b/CHANGELOG-3.2.md
@@ -16,3 +16,4 @@ CHANGELOG for 3.2.x
  * Resolved Propel configuration
  * Add Elastica compression option
  * Add support for `defaultSortFieldName` and `defaultSortDirection` pagination options
+ * Removed `immediate` option on type persistence configuration

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -533,7 +533,6 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('update')->defaultTrue()->end()
                         ->scalarNode('delete')->defaultTrue()->end()
                         ->scalarNode('flush')->defaultTrue()->end()
-                        ->booleanNode('immediate')->defaultFalse()->end()
                         ->scalarNode('logger')
                             ->defaultFalse()
                             ->treatNullLike('fos_elastica.logger')

--- a/DependencyInjection/FOSElasticaExtension.php
+++ b/DependencyInjection/FOSElasticaExtension.php
@@ -576,7 +576,7 @@ class FOSElasticaExtension extends Extension
             'insert' => array(constant($eventsClass.'::postPersist')),
             'update' => array(constant($eventsClass.'::postUpdate')),
             'delete' => array(constant($eventsClass.'::preRemove')),
-            'flush' => array($typeConfig['listener']['immediate'] ? constant($eventsClass.'::preFlush') : constant($eventsClass.'::postFlush')),
+            'flush' => array(constant($eventsClass.'::postFlush')),
         );
 
         foreach ($eventMapping as $event => $doctrineEvents) {

--- a/Resources/doc/setup.md
+++ b/Resources/doc/setup.md
@@ -127,8 +127,7 @@ Below is an example for the Doctrine ORM.
                         driver: orm
                         model: Acme\ApplicationBundle\Entity\User
                         provider: ~
-                        listener:
-                            immediate: ~
+                        listener: ~
                         finder: ~
 ```
 

--- a/Resources/doc/types.md
+++ b/Resources/doc/types.md
@@ -325,21 +325,6 @@ You can also choose to only listen for some of the events:
 
 > **Propel** doesn't support this feature yet.
 
-Flushing Method
----------------
-
-FOSElasticaBundle, since 3.0.0 performs its indexing in the postFlush Doctrine event
-instead of prePersist and preUpdate which means that indexing will only occur when there
-has been a successful flush. This new default makes more sense but in the instance where
-you want to perform indexing before the flush is confirmed you may set the `immediate`
-option on a type persistence configuration to `true`.
-
-```yaml
-                    persistence:
-                        listener:
-                            immediate: true
-```
-
 Logging Errors
 --------------
 


### PR DESCRIPTION
I've removed this option **immediate: true** from options of **listener**.

This option calls postFlush before any other doctrine event and avoids every update or insert of entity related to type of index.

i.e. If I declare that options such as

```
listener:
  immediate: true
 ```
on my index this will not be synchronized with entities persisted on my database

P.S. I've removed it also from documentation.