### PR TITLE
Add ability to use an object as unique identifier

### DIFF
--- a/PropertyAccessor/CastToStringPropertyAccessor.php
+++ b/PropertyAccessor/CastToStringPropertyAccessor.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace FOS\ElasticaBundle\PropertyAccessor;
+
+use Symfony\Component\PropertyAccess\PropertyAccessor;
+
+/**
+ * Allow to access a property value and directly call it's __toString() method
+ * Very useful for objects used as id (like UUID)
+ */
+class CastToStringPropertyAccessor extends PropertyAccessor
+{
+    /**
+     * @inheritDoc
+     */
+    public function getValue($objectOrArray, $propertyPath)
+    {
+        $value = parent::getValue($objectOrArray, $propertyPath);
+
+        return $this->cleanValue($value);
+    }
+
+    /**
+     * @param mixed $value
+     *
+     * @return string
+     */
+    private function cleanValue($value)
+    {
+        if (true === is_object($value) && method_exists($value, '__toString')) {
+            $value = (string) $value;
+        }
+
+        return $value;
+    }
+}

--- a/Resources/config/config.xml
+++ b/Resources/config/config.xml
@@ -9,7 +9,7 @@
         <parameter key="fos_elastica.logger.class">FOS\ElasticaBundle\Logger\ElasticaLogger</parameter>
         <parameter key="fos_elastica.data_collector.class">FOS\ElasticaBundle\DataCollector\ElasticaDataCollector</parameter>
         <parameter key="fos_elastica.mapping_builder.class">FOS\ElasticaBundle\Index\MappingBuilder</parameter>
-        <parameter key="fos_elastica.property_accessor.class">Symfony\Component\PropertyAccess\PropertyAccessor</parameter>
+        <parameter key="fos_elastica.property_accessor.class">FOS\ElasticaBundle\PropertyAccessor\CastToStringPropertyAccessor</parameter>
         <parameter key="fos_elastica.property_accessor.magicCall">false</parameter>
         <parameter key="fos_elastica.property_accessor.throwExceptionOnInvalidIndex">false</parameter>
     </parameters>

--- a/Tests/PropertyAccessor/CastToStringPropertyAccessorTest.php
+++ b/Tests/PropertyAccessor/CastToStringPropertyAccessorTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace FOS\ElasticaBundle\Tests\PropertyAccessor;
+
+use FOS\ElasticaBundle\PropertyAccessor\CastToStringPropertyAccessor;
+
+class IdentifierWithoutToString
+{
+    protected $id;
+
+    public function __construct($id)
+    {
+        $this->id = $id;
+    }
+}
+
+class IdentifierWithToString extends IdentifierWithoutToString
+{
+    public function __toString()
+    {
+        return (string) $this->id;
+    }
+}
+
+class CastToStringPropertyAccessorTest extends \PHPUnit_Framework_TestCase
+{
+    public function testThatCanCastObjectToString()
+    {
+        $id = new IdentifierWithToString('id');
+        $array = array(
+            'a' => $id
+        );
+        $propertyAccessor = new CastToStringPropertyAccessor();
+
+        $this->assertEquals('id', $propertyAccessor->getValue($array, '[a]'));
+    }
+
+    public function testThatWontCastObjectWithoutToString()
+    {
+        $id = new IdentifierWithoutToString('id');
+        $array = array(
+            'a' => $id
+        );
+        $propertyAccessor = new CastToStringPropertyAccessor();
+
+        $this->assertEquals($id, $propertyAccessor->getValue($array, '[a]'));
+    }
+
+    public function testThatWontCastIntToString()
+    {
+        $array = array(
+            'a' => 1
+        );
+        $propertyAccessor = new CastToStringPropertyAccessor();
+
+        $this->assertEquals(1, $propertyAccessor->getValue($array, '[a]'));
+    }
+}


### PR DESCRIPTION
Rebound of #1067

Here is another proposal based on @xavismeh custom `PropertyAccessor` idea. Not sure if it is the best one though.

This implementation
- Cast to string only object having `__toString()` method
- Ignore objects not implementing `__toString()` method
- Ignore scalars (int, float, etc..)
- But performs a `is_object()` check on every `PropertyAccessor::getValue()` call.


----------------------

I tried implementing the `id.toString` concept without success: too messy .

----------------------

@merk I let you tell us in which direction you wish to go. 
Whatever you decide. I can give a hand implementing it.

@xavismeh Sorry for hijacking your Pull Request.

Keep up the good work !