### PR TITLE
Ability to close index instead of delete

### DIFF
--- a/Command/PopulateCommand.php
+++ b/Command/PopulateCommand.php
@@ -54,6 +54,7 @@ class PopulateCommand extends ContainerAwareCommand
             ->addOption('index', null, InputOption::VALUE_OPTIONAL, 'The index to repopulate')
             ->addOption('type', null, InputOption::VALUE_OPTIONAL, 'The type to repopulate')
             ->addOption('no-reset', null, InputOption::VALUE_NONE, 'Do not reset index before populating')
+            ->addOption('no-delete', null, InputOption::VALUE_NONE, 'Do not delete index after populate')
             ->addOption('offset', null, InputOption::VALUE_REQUIRED, 'Start indexing at offset', 0)
             ->addOption('sleep', null, InputOption::VALUE_REQUIRED, 'Sleep time between persisting iterations (microseconds)', 0)
             ->addOption('batch-size', null, InputOption::VALUE_REQUIRED, 'Index packet size (overrides provider config option)')
@@ -90,11 +91,16 @@ class PopulateCommand extends ContainerAwareCommand
         $index = $input->getOption('index');
         $type = $input->getOption('type');
         $reset = !$input->getOption('no-reset');
+        $delete = !$input->getOption('no-delete');
+
         $options = array(
+            'delete'        => $delete,
+            'reset'         => $reset,
             'ignore_errors' => $input->getOption('ignore-errors'),
-            'offset' => $input->getOption('offset'),
-            'sleep' => $input->getOption('sleep')
+            'offset'        => $input->getOption('offset'),
+            'sleep'         => $input->getOption('sleep')
         );
+
         if ($input->getOption('batch-size')) {
             $options['batch_size'] = (int) $input->getOption('batch-size');
         }
@@ -179,7 +185,7 @@ class PopulateCommand extends ContainerAwareCommand
 
         $this->dispatcher->dispatch(TypePopulateEvent::POST_TYPE_POPULATE, $event);
 
-        $this->refreshIndex($output, $index, false);
+        $this->refreshIndex($output, $index);
     }
 
     /**
@@ -187,14 +193,9 @@ class PopulateCommand extends ContainerAwareCommand
      *
      * @param OutputInterface $output
      * @param string          $index
-     * @param bool            $postPopulate
      */
-    private function refreshIndex(OutputInterface $output, $index, $postPopulate = true)
+    private function refreshIndex(OutputInterface $output, $index)
     {
-        if ($postPopulate) {
-            $this->resetter->postPopulate($index);
-        }
-
         $output->writeln(sprintf('<info>Refreshing</info> <comment>%s</comment>', $index));
         $this->indexManager->getIndex($index)->refresh();
     }

--- a/DependencyInjection/FOSElasticaExtension.php
+++ b/DependencyInjection/FOSElasticaExtension.php
@@ -46,7 +46,7 @@ class FOSElasticaExtension extends Extension
             return;
         }
 
-        foreach (array('config', 'index', 'persister', 'provider', 'source', 'transformer') as $basename) {
+        foreach (array('config', 'index', 'persister', 'provider', 'source', 'transformer', 'event_listener') as $basename) {
             $loader->load(sprintf('%s.xml', $basename));
         }
 

--- a/Event/IndexPopulateEvent.php
+++ b/Event/IndexPopulateEvent.php
@@ -74,4 +74,29 @@ class IndexPopulateEvent extends IndexEvent
     {
         $this->reset = $reset;
     }
+
+    /**
+     * @param string $name
+     *
+     * @return mixed
+     *
+     * @throws \InvalidArgumentException if option does not exist
+     */
+    public function getOption($name)
+    {
+        if (!isset($this->options[$name])) {
+            throw new \InvalidArgumentException(sprintf('The "%s" option does not exist.', $name));
+        }
+
+        return $this->options[$name];
+    }
+
+    /**
+     * @param string $name
+     * @param mixed  $value
+     */
+    public function setOption($name, $value)
+    {
+        $this->options[$name] = $value;
+    }
 }

--- a/EventListener/PopulateListener.php
+++ b/EventListener/PopulateListener.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace FOS\ElasticaBundle\EventListener;
+
+use FOS\ElasticaBundle\Event\IndexPopulateEvent;
+use FOS\ElasticaBundle\Index\Resetter;
+
+/**
+ * PopulateListener
+ *
+ * @author Oleg Andreyev <oleg.andreyev@intexsys.lv>
+ */
+class PopulateListener
+{
+    /**
+     * @var Resetter
+     */
+    private $resetter;
+
+    /**
+     * PopulateListener constructor.
+     *
+     * @param Resetter $resetter
+     */
+    public function __construct(Resetter $resetter)
+    {
+        $this->resetter = $resetter;
+    }
+
+    /**
+     * @param IndexPopulateEvent $event
+     */
+    public function onPostIndexPopulate(IndexPopulateEvent $event)
+    {
+        if (!$event->isReset()) {
+            return;
+        }
+        $this->resetter->switchIndexAlias($event->getIndex(), $event->getOption('delete'));
+    }
+}

--- a/Index/AliasProcessor.php
+++ b/Index/AliasProcessor.php
@@ -45,11 +45,11 @@ class AliasProcessor
      * @param IndexConfig $indexConfig
      * @param Index       $index
      * @param bool        $force
+     * @param bool        $delete
      *
      * @throws AliasIsIndexException
-     * @throws \RuntimeException
      */
-    public function switchIndexAlias(IndexConfig $indexConfig, Index $index, $force = false)
+    public function switchIndexAlias(IndexConfig $indexConfig, Index $index, $force = false, $delete = true)
     {
         $client = $index->getClient();
 
@@ -64,7 +64,11 @@ class AliasProcessor
                 throw $e;
             }
 
-            $this->deleteIndex($client, $aliasName);
+            if ($delete) {
+                $this->deleteIndex($client, $aliasName);
+            } else {
+                $this->closeIndex($client, $aliasName);
+            }
         }
 
         try {
@@ -76,7 +80,11 @@ class AliasProcessor
 
         // Delete the old index after the alias has been switched
         if (null !== $oldIndexName) {
-            $this->deleteIndex($client, $oldIndexName);
+            if ($delete) {
+                $this->deleteIndex($client, $oldIndexName);
+            } else {
+                $this->closeIndex($client, $oldIndexName);
+            }
         }
     }
 
@@ -150,6 +158,30 @@ class AliasProcessor
                 $indexName,
                 $deleteOldIndexException->getMessage()
             ), 0, $deleteOldIndexException);
+        }
+    }
+
+    /**
+     * Close an index
+     *
+     * @param Client $client
+     * @param string $indexName
+     */
+    private function closeIndex(Client $client, $indexName)
+    {
+        try {
+            $path = sprintf("%s/_close", $indexName);
+            $client->request($path, Request::POST);
+        } catch (ExceptionInterface $e) {
+            throw new \RuntimeException(
+                sprintf(
+                    'Failed to close index %s with message: %s',
+                    $indexName,
+                    $e->getMessage()
+                ),
+                0,
+                $e
+            );
         }
     }
 

--- a/Index/Resetter.php
+++ b/Index/Resetter.php
@@ -148,14 +148,29 @@ class Resetter
      * A command run when a population has finished.
      *
      * @param string $indexName
+     *
+     * @deprecated
      */
     public function postPopulate($indexName)
+    {
+        $this->switchIndexAlias($indexName);
+    }
+
+    /**
+     * Switching aliases
+     *
+     * @param string $indexName
+     * @param bool   $delete Delete or close index
+     *
+     * @throws \FOS\ElasticaBundle\Exception\AliasIsIndexException
+     */
+    public function switchIndexAlias($indexName, $delete = true)
     {
         $indexConfig = $this->configManager->getIndexConfiguration($indexName);
 
         if ($indexConfig->isUseAlias()) {
             $index = $this->indexManager->getIndex($indexName);
-            $this->aliasProcessor->switchIndexAlias($indexConfig, $index);
+            $this->aliasProcessor->switchIndexAlias($indexConfig, $index, false, $delete);
         }
     }
 }

--- a/Resources/config/event_listener.xml
+++ b/Resources/config/event_listener.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="fos_elastica.populate_listener.class">FOS\ElasticaBundle\EventListener\PopulateListener</parameter>
+    </parameters>
+
+    <services>
+        <service id="fos_elastica.populate_listener" class="%fos_elastica.populate_listener.class%">
+            <tag name="kernel.event_listener" event="elastica.index.index_post_populate" method="onPostIndexPopulate" priority="-9999"/>
+            <argument type="service" id="fos_elastica.resetter"/>
+        </service>
+    </services>
+</container>

--- a/Tests/Index/ResetterTest.php
+++ b/Tests/Index/ResetterTest.php
@@ -213,7 +213,7 @@ class ResetterTest extends \PHPUnit_Framework_TestCase
         $this->aliasProcessor->expects($this->never())
             ->method('switchIndexAlias');
 
-        $this->resetter->postPopulate('index');
+        $this->resetter->switchIndexAlias('index');
     }
 
     public function testPostPopulate()
@@ -225,7 +225,7 @@ class ResetterTest extends \PHPUnit_Framework_TestCase
             ->method('switchIndexAlias')
             ->with($indexConfig, $index);
 
-        $this->resetter->postPopulate('index');
+        $this->resetter->switchIndexAlias('index');
     }
 
     private function dispatcherExpects(array $events)


### PR DESCRIPTION
In case if you don't want to delete old index (backup for emergency case) you should close it.
Adding `--no-delete` option to `PopulateCommand`
