### PR TITLE
Missing Parameters in $loggerClosure function in Manual Provider

### DIFF
--- a/Resources/doc/cookbook/manual-provider.md
+++ b/Resources/doc/cookbook/manual-provider.md
@@ -42,8 +42,11 @@ class UserProvider implements ProviderInterface
      */
     public function populate(\Closure $loggerClosure = null, array $options = array())
     {
+        $batchSize = 1;
+        $totalObjects = 1;
+
         if ($loggerClosure) {
-            $loggerClosure('Indexing users');
+            $loggerClosure($batchSize, $totalObjects, 'Indexing users');
         }
 
         $document = new Document();


### PR DESCRIPTION
Fix to prevent the following exception while populating with manual provider:

> [Symfony\Component\Debug\Exception\ContextErrorException]
>  Warning: Missing argument 2 for FOS\ElasticaBundle\Command\ProgressClosureBuilder::FOS\Elastica
>  Bundle\Command\{closure}(), called in /vagrant/src/Acme/UserBundle/Provider/UserProvider.php on line 34 and defined

Trace:
> at /vagrant/vendor/friendsofsymfony/elastica-bundle/Command/ProgressClosureBuilder.php:39
> Symfony\Component\Debug\ErrorHandler->handleError() at /vagrant/vendor/friendsofsymfony/elastica-bundle/Command/ProgressClosureBuilder.php:39