### PR TITLE
don't try to change number_of_shards on existing index

### DIFF
--- a/Index/Resetter.php
+++ b/Index/Resetter.php
@@ -136,6 +136,7 @@ class Resetter
         }
 
         if (!empty($settings)) {
+            unset($settings['number_of_shards']);
             $index->close();
             $index->setSettings($settings);
             $index->open();


### PR DESCRIPTION
when resetting index type and applying settings - parameter number_of_shards should be skipped, as it cannot be changed for existing index - elasticsearch would throw exception:
`ElasticsearchIllegalArgumentException[can't change the number of shards for an index]`

was introduced in #911 