### PR TITLE
fixing issue with _parent mapping and ES 2.3.3

### DIFF
--- a/DependencyInjection/FOSElasticaExtension.php
+++ b/DependencyInjection/FOSElasticaExtension.php
@@ -288,6 +288,11 @@ class FOSElasticaExtension extends Extension
                 $typeConfig['persistence'] = $type['persistence'];
             }
 
+            if (isset($type['_parent'])) {
+                // _parent mapping cannot contain `property` and `identifier`, so removing them after building `persistence`
+                unset($indexConfig['types'][$name]['mapping']['_parent']['property'], $indexConfig['types'][$name]['mapping']['_parent']['identifier']);
+            }
+
             if (isset($type['indexable_callback'])) {
                 $indexableCallbacks[sprintf('%s/%s', $indexName, $name)] = $type['indexable_callback'];
             }


### PR DESCRIPTION
This will fix issue with `Mapping definition for [_parent] has unsupported parameters:  [identifier : id] [property : null]`