### PR TITLE
Restore property and identifier in _parent node mapping

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -418,6 +418,8 @@ class Configuration implements ConfigurationInterface
         $node
             ->children()
                 ->scalarNode('type')->end()
+                ->scalarNode('property')->defaultValue(null)->end()
+                ->scalarNode('identifier')->defaultValue('id')->end()
             ->end()
         ;
 

--- a/Index/MappingBuilder.php
+++ b/Index/MappingBuilder.php
@@ -95,9 +95,11 @@ class MappingBuilder
             $mapping['_meta']['model'] = $typeConfig->getModel();
         }
 
+        unset($mapping['_parent']['identifier'], $mapping['_parent']['property']);
+
         if (empty($mapping)) {
             // Empty mapping, we want it encoded as a {} instead of a []
-            $mapping = new \stdClass();
+            $mapping = new \ArrayObject();
         }
 
         return $mapping;

--- a/Tests/DependencyInjection/fixtures/config.yml
+++ b/Tests/DependencyInjection/fixtures/config.yml
@@ -18,4 +18,4 @@ fos_elastica:
                     persistence:
                         driver: orm
                         model: foo_model
-                    _parent: { type: "parent_field" }
+                    _parent: { type: "parent_field", property: "parent" }

--- a/Tests/Functional/app/Basic/config.yml
+++ b/Tests/Functional/app/Basic/config.yml
@@ -93,6 +93,8 @@ fos_elastica:
                         dynamic_allowed: { type: object, dynamic: true }
                     _parent:
                         type: "parent"
+                        property: "parent"
+                        identifier: "id"
                 null_mappings:
                     mappings: ~
         empty_index: ~

--- a/Tests/Index/MappingBuilderTest.php
+++ b/Tests/Index/MappingBuilderTest.php
@@ -32,6 +32,11 @@ class MappingBuilderTest extends \PHPUnit_Framework_TestCase
                     'type' => 'string',
                     'store' => false
                 ),
+            ),
+            '_parent' => array(
+                'type' => 'parent_type',
+                'identifier' => 'name',
+                'property' => 'parent_property'
             )
         ));
 
@@ -42,6 +47,10 @@ class MappingBuilderTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($mapping['properties']['stored']['store']);
         $this->assertArrayHasKey('store', $mapping['properties']['unstored']);
         $this->assertFalse($mapping['properties']['unstored']['store']);
+
+        $this->assertArrayHasKey('_parent', $mapping);
+        $this->assertArrayNotHasKey('identifier', $mapping['_parent']);
+        $this->assertArrayNotHasKey('property', $mapping['_parent']);
     }
 
 }


### PR DESCRIPTION
Fixes a bug introduced in #1069 

`identifier` and `property` fields were removed instead of just being deleted from mapping array before sending it to ES