### PR TITLE
Repository Manager refactoring

### DIFF
--- a/DependencyInjection/FOSElasticaExtension.php
+++ b/DependencyInjection/FOSElasticaExtension.php
@@ -617,13 +617,18 @@ class FOSElasticaExtension extends Extension
             $container->setDefinition($finderId, $finderDef);
         }
 
-        $managerId = sprintf('fos_elastica.manager.%s', $typeConfig['driver']);
-        $managerDef = $container->getDefinition($managerId);
-        $arguments = array( $typeConfig['model'], new Reference($finderId));
+        $indexTypeName = "$indexName/$typeName";
+        $arguments = [$indexTypeName, new Reference($finderId)];
         if (isset($typeConfig['repository'])) {
             $arguments[] = $typeConfig['repository'];
         }
-        $managerDef->addMethodCall('addEntity', $arguments);
+
+        $container->getDefinition('fos_elastica.repository_manager')
+            ->addMethodCall('addType', $arguments);
+
+        $managerId = sprintf('fos_elastica.manager.%s', $typeConfig['driver']);
+        $container->getDefinition($managerId)
+            ->addMethodCall('addEntity', [$indexTypeName]);
 
         return $finderId;
     }

--- a/DependencyInjection/FOSElasticaExtension.php
+++ b/DependencyInjection/FOSElasticaExtension.php
@@ -628,7 +628,7 @@ class FOSElasticaExtension extends Extension
 
         $managerId = sprintf('fos_elastica.manager.%s', $typeConfig['driver']);
         $container->getDefinition($managerId)
-            ->addMethodCall('addEntity', [$indexTypeName]);
+            ->addMethodCall('addEntity', [$typeConfig['model'], $indexTypeName]);
 
         return $finderId;
     }

--- a/Doctrine/RepositoryManager.php
+++ b/Doctrine/RepositoryManager.php
@@ -4,15 +4,19 @@ namespace FOS\ElasticaBundle\Doctrine;
 
 use Doctrine\Common\Annotations\Reader;
 use Doctrine\Common\Persistence\ManagerRegistry;
+use FOS\ElasticaBundle\Finder\FinderInterface;
 use FOS\ElasticaBundle\Manager\RepositoryManager as BaseManager;
+use FOS\ElasticaBundle\Manager\RepositoryManagerInterface;
 
 /**
  * @author Richard Miller <info@limethinking.co.uk>
  *
  * Allows retrieval of basic or custom repository for mapped Doctrine
  * entities/documents.
+ *
+ * @deprecated
  */
-class RepositoryManager extends BaseManager
+class RepositoryManager implements RepositoryManagerInterface
 {
     /** @var array */
     protected $entities = array();
@@ -24,13 +28,31 @@ class RepositoryManager extends BaseManager
     protected $managerRegistry;
 
     /**
-     * @param ManagerRegistry $managerRegistry
-     * @param Reader          $reader
+     * @var RepositoryManagerInterface
      */
-    public function __construct(ManagerRegistry $managerRegistry, Reader $reader)
+    private $repositoryManager;
+
+    /**
+     * @param ManagerRegistry $managerRegistry
+     * @param RepositoryManagerInterface $repositoryManager
+     */
+    public function __construct(ManagerRegistry $managerRegistry, RepositoryManagerInterface $repositoryManager)
     {
         $this->managerRegistry = $managerRegistry;
-        parent::__construct($reader);
+        $this->repositoryManager = $repositoryManager;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function addType($indexTypeName, FinderInterface $finder, $repositoryName = null)
+    {
+        throw new \LogicException(__METHOD__.' should not be called. Call addType on the main repository manager');
+    }
+
+    public function addEntity($entityName, $indexTypeName)
+    {
+        $this->entities[$entityName] = $indexTypeName;
     }
 
     /**
@@ -46,6 +68,10 @@ class RepositoryManager extends BaseManager
             $realEntityName = $this->managerRegistry->getAliasNamespace($namespaceAlias).'\\'.$simpleClassName;
         }
 
-        return parent::getRepository($realEntityName);
+        if (isset($this->entities[$realEntityName])) {
+            $realEntityName = $this->entities[$realEntityName];
+        }
+
+        return $this->repositoryManager->getRepository($realEntityName);
     }
 }

--- a/Manager/RepositoryManager.php
+++ b/Manager/RepositoryManager.php
@@ -4,6 +4,7 @@ namespace FOS\ElasticaBundle\Manager;
 
 use Doctrine\Common\Annotations\Reader;
 use FOS\ElasticaBundle\Finder\FinderInterface;
+use FOS\ElasticaBundle\Repository;
 use RuntimeException;
 
 /**
@@ -14,20 +15,28 @@ use RuntimeException;
  */
 class RepositoryManager implements RepositoryManagerInterface
 {
-    protected $entities = array();
-    protected $repositories = array();
-    protected $reader;
+    /**
+     * @var array
+     */
+    private $types;
 
-    public function __construct(Reader $reader)
+    /**
+     * @var Repository[]
+     */
+    private $repositories;
+
+    public function __construct()
     {
-        $this->reader = $reader;
+        $this->types = [];
+        $this->repositories = [];
     }
 
-    public function addEntity($entityName, FinderInterface $finder, $repositoryName = null)
+    public function addType($indexTypeName, FinderInterface $finder, $repositoryName = null)
     {
-        $this->entities[$entityName] = array();
-        $this->entities[$entityName]['finder'] = $finder;
-        $this->entities[$entityName]['repositoryName'] = $repositoryName;
+        $this->types[$indexTypeName] = [
+            'finder' => $finder,
+            'repositoryName' => $repositoryName
+        ];
     }
 
     /**
@@ -35,57 +44,52 @@ class RepositoryManager implements RepositoryManagerInterface
      *
      * Returns custom repository if one specified otherwise
      * returns a basic repository.
+     *
+     * @param string $typeName
+     *
+     * @return Repository
      */
-    public function getRepository($entityName)
+    public function getRepository($typeName)
     {
-        if (isset($this->repositories[$entityName])) {
-            return $this->repositories[$entityName];
+        if (isset($this->repositories[$typeName])) {
+            return $this->repositories[$typeName];
         }
 
-        if (!isset($this->entities[$entityName])) {
-            throw new RuntimeException(sprintf('No search finder configured for %s', $entityName));
+        if (!isset($this->types[$typeName])) {
+            throw new RuntimeException(sprintf('No search finder configured for %s', $typeName));
         }
 
-        $repository = $this->createRepository($entityName);
-        $this->repositories[$entityName] = $repository;
+        $repository = $this->createRepository($typeName);
+        $this->repositories[$typeName] = $repository;
 
         return $repository;
     }
 
     /**
-     * @param string $entityName
+     * @param $typeName
      *
      * @return string
      */
-    protected function getRepositoryName($entityName)
+    protected function getRepositoryName($typeName)
     {
-        if (isset($this->entities[$entityName]['repositoryName'])) {
-            return $this->entities[$entityName]['repositoryName'];
-        }
-
-        $refClass   = new \ReflectionClass($entityName);
-        $annotation = $this->reader->getClassAnnotation($refClass, 'FOS\\ElasticaBundle\\Annotation\\Search');
-        if ($annotation) {
-            $this->entities[$entityName]['repositoryName']
-                = $annotation->repositoryClass;
-
-            return $annotation->repositoryClass;
+        if (isset($this->types[$typeName]['repositoryName'])) {
+            return $this->types[$typeName]['repositoryName'];
         }
 
         return 'FOS\ElasticaBundle\Repository';
     }
 
     /**
-     * @param string $entityName
+     * @param $typeName
      *
      * @return mixed
      */
-    private function createRepository($entityName)
+    private function createRepository($typeName)
     {
-        if (!class_exists($repositoryName = $this->getRepositoryName($entityName))) {
-            throw new RuntimeException(sprintf('%s repository for %s does not exist', $repositoryName, $entityName));
+        if (!class_exists($repositoryName = $this->getRepositoryName($typeName))) {
+            throw new RuntimeException(sprintf('%s repository for %s does not exist', $repositoryName, $typeName));
         }
 
-        return new $repositoryName($this->entities[$entityName]['finder']);
+        return new $repositoryName($this->types[$typeName]['finder']);
     }
 }

--- a/Manager/RepositoryManagerInterface.php
+++ b/Manager/RepositoryManagerInterface.php
@@ -3,6 +3,7 @@
 namespace FOS\ElasticaBundle\Manager;
 
 use FOS\ElasticaBundle\Finder\FinderInterface;
+use FOS\ElasticaBundle\Repository;
 
 /**
  * @author Richard Miller <info@limethinking.co.uk>
@@ -13,14 +14,14 @@ use FOS\ElasticaBundle\Finder\FinderInterface;
 interface RepositoryManagerInterface
 {
     /**
-     * Adds entity name and its finder.
+     * Adds type name and its finder.
      * Custom repository class name can also be added.
      *
-     * @param string $entityName
+     * @param string $indexTypeName The type name in "index/type" format
      * @param        $finder
      * @param string $repositoryName
      */
-    public function addEntity($entityName, FinderInterface $finder, $repositoryName = null);
+    public function addType($indexTypeName, FinderInterface $finder, $repositoryName = null);
 
     /**
      * Return repository for entity.
@@ -28,7 +29,9 @@ interface RepositoryManagerInterface
      * Returns custom repository if one specified otherwise
      * returns a basic repository.
      *
-     * @param string $entityName
+     * @param $typeName
+     *
+     * @return Repository
      */
-    public function getRepository($entityName);
+    public function getRepository($typeName);
 }

--- a/Resources/config/index.xml
+++ b/Resources/config/index.xml
@@ -12,9 +12,12 @@
         <parameter key="fos_elastica.index_manager.class">FOS\ElasticaBundle\Index\IndexManager</parameter>
         <parameter key="fos_elastica.resetter.class">FOS\ElasticaBundle\Index\Resetter</parameter>
         <parameter key="fos_elastica.type.class">Elastica\Type</parameter>
+        <parameter key="fos_elastica.repository_manager.class">FOS\ElasticaBundle\Manager\RepositoryManager</parameter>
     </parameters>
 
     <services>
+        <service id="fos_elastica.repository_manager" class="%fos_elastica.repository_manager.class%" />
+
         <service id="fos_elastica.alias_processor" class="%fos_elastica.alias_processor.class%" />
 
         <service id="fos_elastica.indexable" class="%fos_elastica.indexable.class%">

--- a/Resources/config/orm.xml
+++ b/Resources/config/orm.xml
@@ -43,7 +43,7 @@
 
         <service id="fos_elastica.manager.orm" class="%fos_elastica.manager.orm.class%">
             <argument type="service" id="doctrine" />
-            <argument type="service" id="annotation_reader" />
+            <argument type="service" id="fos_elastica.repository_manager" />
         </service>
     </services>
 </container>

--- a/Tests/Functional/PersistenceRepositoryTest.php
+++ b/Tests/Functional/PersistenceRepositoryTest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace FOS\ElasticaBundle\Tests\Functional;
+
+class PersistenceRepositoryTest extends WebTestCase
+{
+    public function testRepositoryShouldBeSetCorrectly()
+    {
+        $client = $this->createClient(array('test_case' => 'ORM'));
+
+        $repository = $client->getContainer()->get('fos_elastica.manager.orm')
+            ->getRepository('FOS\ElasticaBundle\Tests\Functional\TypeObject');
+
+        $this->assertNotNull($repository);
+        $this->assertEquals('FOS\ElasticaBundle\Tests\Functional\TypeObjectRepository', get_class($repository));
+    }
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->deleteTmpDir('Basic');
+    }
+
+    protected function tearDown()
+    {
+        parent::tearDown();
+
+        $this->deleteTmpDir('Basic');
+    }
+}

--- a/Tests/Functional/TypeObject.php
+++ b/Tests/Functional/TypeObject.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * This file is part of the FOSElasticaBundle project.
+ *
+ * (c) Infinite Networks Pty Ltd <http://www.infinite.net.au>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\ElasticaBundle\Tests\Functional;
+
+class TypeObject
+{
+    public $id = 5;
+    public $coll;
+    public $field1;
+    public $field2;
+    public $field3;
+
+    public function isIndexable()
+    {
+        return true;
+    }
+
+    public function isntIndexable()
+    {
+        return false;
+    }
+
+    public function getSerializableColl()
+    {
+        return iterator_to_array($this->coll, false);
+    }
+}

--- a/Tests/Functional/TypeObjectRepository.php
+++ b/Tests/Functional/TypeObjectRepository.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace FOS\ElasticaBundle\Tests\Functional;
+
+use FOS\ElasticaBundle\Repository;
+
+class TypeObjectRepository extends Repository
+{
+}

--- a/Tests/Functional/app/ORM/config.yml
+++ b/Tests/Functional/app/ORM/config.yml
@@ -77,6 +77,16 @@ fos_elastica:
                             property_path: coll
                         dynamic:
                             property_path: false
+                type_with_repository:
+                    properties:
+                        field1: ~
+                        coll: ~
+                    persistence:
+                        driver: orm
+                        model: FOS\ElasticaBundle\Tests\Functional\TypeObject
+                        repository: FOS\ElasticaBundle\Tests\Functional\TypeObjectRepository
+                        finder: ~
+                        provider: ~
         second_index:
             index_name: foselastica_orm_test_second_%kernel.environment%
             types:

--- a/Tests/Manager/RepositoryManagerTest.php
+++ b/Tests/Manager/RepositoryManagerTest.php
@@ -2,7 +2,6 @@
 
 namespace FOS\ElasticaBundle\Tests\Manager;
 
-use FOS\ElasticaBundle\Configuration\Search;
 use FOS\ElasticaBundle\Manager\RepositoryManager;
 
 class CustomRepository
@@ -18,53 +17,43 @@ class Entity
  */
 class RepositoryManagerTest extends \PHPUnit_Framework_TestCase
 {
-    /**
-     * @return \PHPUnit_Framework_MockObject_MockObject|\FOS\ElasticaBundle\Finder\TransformedFinder
-     */
-    private function createFinderMock()
+    public function testThatGetRepositoryReturnsDefaultRepository()
     {
+        /** @var $finderMock \PHPUnit_Framework_MockObject_MockObject|\FOS\ElasticaBundle\Finder\TransformedFinder */
         $finderMock = $this->getMockBuilder('FOS\ElasticaBundle\Finder\TransformedFinder')
             ->disableOriginalConstructor()
             ->getMock();
 
-        return $finderMock;
-    }
-
-    /**
-     * @return \PHPUnit_Framework_MockObject_MockObject|\Doctrine\Common\Annotations\Reader
-     */
-    private function createReaderMock()
-    {
+        /** @var $readerMock \PHPUnit_Framework_MockObject_MockObject|\Doctrine\Common\Annotations\Reader */
         $readerMock = $this->getMockBuilder('Doctrine\Common\Annotations\Reader')
             ->disableOriginalConstructor()
             ->getMock();
 
-        return $readerMock;
-    }
-
-    public function testThatGetRepositoryReturnsDefaultRepository()
-    {
-        $finderMock = $this->createFinderMock();
-        $readerMock = $this->createReaderMock();
-
-        $entityName = 'FOS\ElasticaBundle\Tests\Manager\Entity';
+        $typeName = 'index/type';
 
         $manager = new RepositoryManager($readerMock);
-        $manager->addEntity($entityName, $finderMock);
-        $repository = $manager->getRepository($entityName);
+        $manager->addType($typeName, $finderMock);
+        $repository = $manager->getRepository($typeName);
         $this->assertInstanceOf('FOS\ElasticaBundle\Repository', $repository);
     }
 
     public function testThatGetRepositoryReturnsCustomRepository()
     {
-        $finderMock = $this->createFinderMock();
-        $readerMock = $this->createReaderMock();
+        /** @var $finderMock \PHPUnit_Framework_MockObject_MockObject|\FOS\ElasticaBundle\Finder\TransformedFinder */
+        $finderMock = $this->getMockBuilder('FOS\ElasticaBundle\Finder\TransformedFinder')
+            ->disableOriginalConstructor()
+            ->getMock();
 
-        $entityName = 'FOS\ElasticaBundle\Tests\Manager\Entity';
+        /** @var $readerMock \PHPUnit_Framework_MockObject_MockObject|\Doctrine\Common\Annotations\Reader */
+        $readerMock = $this->getMockBuilder('Doctrine\Common\Annotations\Reader')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $typeName = 'index/type';
 
         $manager = new RepositoryManager($readerMock);
-        $manager->addEntity($entityName, $finderMock, 'FOS\ElasticaBundle\Tests\Manager\CustomRepository');
-        $repository = $manager->getRepository($entityName);
+        $manager->addType($typeName, $finderMock, 'FOS\ElasticaBundle\Tests\Manager\CustomRepository');
+        $repository = $manager->getRepository($typeName);
         $this->assertInstanceOf('FOS\ElasticaBundle\Tests\Manager\CustomRepository', $repository);
     }
 
@@ -73,14 +62,21 @@ class RepositoryManagerTest extends \PHPUnit_Framework_TestCase
      */
     public function testThatGetRepositoryThrowsExceptionIfEntityNotConfigured()
     {
-        $finderMock = $this->createFinderMock();
-        $readerMock = $this->createReaderMock();
+        /** @var $finderMock \PHPUnit_Framework_MockObject_MockObject|\FOS\ElasticaBundle\Finder\TransformedFinder */
+        $finderMock = $this->getMockBuilder('FOS\ElasticaBundle\Finder\TransformedFinder')
+            ->disableOriginalConstructor()
+            ->getMock();
 
-        $entityName = 'FOS\ElasticaBundle\Tests\Manager\Entity';
+        /** @var $readerMock \PHPUnit_Framework_MockObject_MockObject|\Doctrine\Common\Annotations\Reader */
+        $readerMock = $this->getMockBuilder('Doctrine\Common\Annotations\Reader')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $typeName = 'index/type';
 
         $manager = new RepositoryManager($readerMock);
-        $manager->addEntity($entityName, $finderMock);
-        $manager->getRepository('Missing Entity');
+        $manager->addType($typeName, $finderMock);
+        $manager->getRepository('Missing type');
     }
 
     /**
@@ -88,70 +84,20 @@ class RepositoryManagerTest extends \PHPUnit_Framework_TestCase
      */
     public function testThatGetRepositoryThrowsExceptionIfCustomRepositoryNotFound()
     {
-        $finderMock = $this->createFinderMock();
-        $readerMock = $this->createReaderMock();
+        /** @var $finderMock \PHPUnit_Framework_MockObject_MockObject|\FOS\ElasticaBundle\Finder\TransformedFinder */
+        $finderMock = $this->getMockBuilder('FOS\ElasticaBundle\Finder\TransformedFinder')
+            ->disableOriginalConstructor()
+            ->getMock();
 
-        $entityName = 'FOS\ElasticaBundle\Tests\Manager\Entity';
+        /** @var $readerMock \PHPUnit_Framework_MockObject_MockObject|\Doctrine\Common\Annotations\Reader */
+        $readerMock = $this->getMockBuilder('Doctrine\Common\Annotations\Reader')
+            ->disableOriginalConstructor()
+            ->getMock();
 
-        $manager = new RepositoryManager($readerMock);
-        $manager->addEntity($entityName, $finderMock, 'FOS\ElasticaBundle\Tests\MissingRepository');
-        $manager->getRepository('FOS\ElasticaBundle\Tests\Manager\Entity');
-    }
-
-    /**
-     * @expectedException \RuntimeException
-     */
-    public function testThatGetRepositoryThrowsExceptionIfEntityDoesNotExist()
-    {
-        $finderMock = $this->createFinderMock();
-        $readerMock = $this->createReaderMock();
-
-        $entityName = 'FOS\ElasticaBundle\Tests\Manager\Entity';
+        $typeName = 'index/type';
 
         $manager = new RepositoryManager($readerMock);
-        $manager->addEntity($entityName, $finderMock, 'FOS\ElasticaBundle\Tests\MissingRepository');
-        $manager->getRepository('Missing Entity');
-    }
-
-    public function testThatGetRepositoryCachesRepositoryInstances()
-    {
-        $finderMock = $this->createFinderMock();
-        $readerMock = $this->createReaderMock();
-
-        $entityName = 'FOS\ElasticaBundle\Tests\Manager\Entity';
-
-        $manager = new RepositoryManager($readerMock);
-        $manager->addEntity($entityName, $finderMock, 'FOS\ElasticaBundle\Tests\Manager\CustomRepository');
-        $repository = $manager->getRepository($entityName);
-        $this->assertInstanceOf('FOS\ElasticaBundle\Tests\Manager\CustomRepository', $repository);
-
-        $repository2 = $manager->getRepository($entityName);
-        $this->assertInstanceOf('FOS\ElasticaBundle\Tests\Manager\CustomRepository', $repository2);
-        $this->assertSame($repository, $repository2);
-    }
-
-    public function testGetRepositoryNameCanReadFromClassAnnotation()
-    {
-        $repositoryClass = 'FOS\ElasticaBundle\Tests\Manager\CustomRepository';
-
-        $annotation = new Search;
-        $annotation->repositoryClass = $repositoryClass;
-
-        $finderMock = $this->createFinderMock();
-        $readerMock = $this->createReaderMock();
-
-        $readerMock
-            ->expects($this->once())
-            ->method('getClassAnnotation')
-            ->will($this->returnValue($annotation));
-
-        $entityName = 'FOS\ElasticaBundle\Tests\Manager\Entity';
-
-        $manager = new RepositoryManager($readerMock);
-        $manager->addEntity($entityName, $finderMock);
-
-        $repository = $manager->getRepository($entityName);
-
-        $this->assertInstanceOf($repositoryClass, $repository);
+        $manager->addType($typeName, $finderMock, 'FOS\ElasticaBundle\Tests\MissingRepository');
+        $manager->getRepository($typeName);
     }
 }


### PR DESCRIPTION
i've ported the repositoryManager refactoring from our fork as requested in https://github.com/FriendsOfSymfony/FOSElasticaBundle/pull/1069#issuecomment-238535208

As stated in the original PR:
Currently there is no way to create more than one type associated with a model, each with its own repository class.
This PR adds this possibility, refactoring the RepositoryManager class

Now a repository can be retrieved through the `fos_elastica.repository_manager` service calling getRepository method with `index/type` string as first argument.
Old doctrine repository manager class has been deprecated, but are still working as expected.

BC breaks are present ONLY if the doctrine repository manager has been extended, while usage remains the same