### PR TITLE
[BUG] using --no-reset without --type

### DIFF
--- a/Command/PopulateCommand.php
+++ b/Command/PopulateCommand.php
@@ -151,7 +151,7 @@ class PopulateCommand extends ContainerAwareCommand
 
         $this->dispatcher->dispatch(IndexPopulateEvent::POST_INDEX_POPULATE, $event);
 
-        $this->refreshIndex($output, $index);
+        $this->refreshIndex($output, $index, !$reset);
     }
 
     /**


### PR DESCRIPTION
Accidentally discovered annoying bug.  
We have "large" dev-index (~12Gb ~6 millions docs) and when we need to update N documents we use `--no-reset` with `--type`, but today when running update `--type` wasn't added and `PopulateCommand` delete current index. :(

Fix: do not `postPopulate`, if `--no-reset` is passed.