### PR TITLE
Fix for MongoDB

### DIFF
--- a/Doctrine/MongoDB/Provider.php
+++ b/Doctrine/MongoDB/Provider.php
@@ -77,11 +77,12 @@ class Provider extends AbstractProvider
     /**
      * {@inheritDoc}
      */
-    protected function createQueryBuilder($method)
+    protected function createQueryBuilder($method, array $arguments = array())
     {
-        return $this->managerRegistry
+        $repository = $this->managerRegistry
             ->getManagerForClass($this->objectClass)
-            ->getRepository($this->objectClass)
-            ->{$method}();
+            ->getRepository($this->objectClass);
+
+        return call_user_func_array([$repository, $method], $arguments);
     }
 }


### PR DESCRIPTION
After pull  #1007  , i found next error:

`Fatal error: Declaration of FOS\ElasticaBundle\Doctrine\MongoDB\Provider::createQueryBuilder() must be compatible with FOS\ElasticaBundle\Doctrine\AbstractProvider::createQueryBuilder($method, array $arguments = Array)      `

Added "Allow passing extra parameters to queryBuilder factory" to MongoDB