### PR TITLE
[BUG] UndefinedOptionsException: The options "reset" do not exist.

### DIFF
--- a/Provider/AbstractProvider.php
+++ b/Provider/AbstractProvider.php
@@ -105,6 +105,7 @@ abstract class AbstractProvider implements ProviderInterface
     protected function configureOptions()
     {
         $this->resolver->setDefaults(array(
+            'reset' => true,
             'batch_size' => 100,
             'skip_indexable_check' => false,
         ));


### PR DESCRIPTION
When using `\FOS\ElasticaBundle\Provider\AbstractProvider` (Doctrine ORM)

```
[Symfony\Component\OptionsResolver\Exception\UndefinedOptionsException]
  The options "reset" do not exist. Defined options are: "batch_size", "clear_object_manager", "debug_logging", "igno
  re_errors", "indexName", "offset", "query_builder_method", "skip_indexable_check", "sleep", "typeName".

```