### PR TITLE
Call postPopulate with reset option

### DIFF
--- a/Command/PopulateCommand.php
+++ b/Command/PopulateCommand.php
@@ -151,7 +151,7 @@ class PopulateCommand extends ContainerAwareCommand
 
         $this->dispatcher->dispatch(IndexPopulateEvent::POST_INDEX_POPULATE, $event);
 
-        $this->refreshIndex($output, $index, !$reset);
+        $this->refreshIndex($output, $index, $reset);
     }
 
     /**


### PR DESCRIPTION
Automatic index switch doesn't work due to this commit
[fixing bug with using --no-reset without --type](https://github.com/FriendsOfSymfony/FOSElasticaBundle/commit/5bbee65058946e7124586699478982ff0304bd85)

Fixes #1140 