### PR TITLE
Global flag to disable object indexing (for long import tasks)

### DIFF
--- a/Doctrine/Listener.php
+++ b/Doctrine/Listener.php
@@ -143,6 +143,11 @@ class Listener
      */
     private function persistScheduled()
     {
+        // Don't persist if indexing is disabled
+        if (!$this->indexable->isIndexingEnabled()) {
+            return;
+        }
+
         if (count($this->scheduledForInsertion)) {
             $this->objectPersister->insertMany($this->scheduledForInsertion);
             $this->scheduledForInsertion = array();

--- a/Provider/Indexable.php
+++ b/Provider/Indexable.php
@@ -54,6 +54,11 @@ class Indexable implements IndexableInterface
     private $propertyAccessor;
 
     /**
+     * @var bool
+     */
+    private $indexingEnabled = true;
+
+    /**
      * @param array $callbacks
      * @param ContainerInterface $container
      */
@@ -75,6 +80,10 @@ class Indexable implements IndexableInterface
      */
     public function isObjectIndexable($indexName, $typeName, $object)
     {
+        if(!$this->indexingEnabled) {
+            return false;
+        }
+
         $type = sprintf('%s/%s', $indexName, $typeName);
         $callback = $this->getCallback($type, $object);
         if (!$callback) {
@@ -93,6 +102,26 @@ class Indexable implements IndexableInterface
             : call_user_func($callback, $object);
     }
 
+    /**
+     * Returns true if global indexing is enabled, false otherwise.
+     * 
+     * @return bool
+     */
+    public function isIndexingEnabled()
+    {
+        return $this->indexingEnabled;
+    }
+
+    /**
+     * Sets global indexing.
+     * 
+     * @param bool $indexingEnabled
+     */
+    public function setIndexingEnabled($indexingEnabled)
+    {
+        $this->indexingEnabled = $indexingEnabled;
+    }
+    
     /**
      * Builds and initialises a callback.
      *

--- a/Provider/IndexableInterface.php
+++ b/Provider/IndexableInterface.php
@@ -23,4 +23,18 @@ interface IndexableInterface
      * @return bool
      */
     public function isObjectIndexable($indexName, $typeName, $object);
+
+    /**
+     * Returns true if global indexing is enabled, false otherwise.
+     *
+     * @return bool
+     */
+    public function isIndexingEnabled();
+
+    /**
+     * Sets global indexing.
+     *
+     * @param bool $indexingEnabled
+     */
+    public function setIndexingEnabled($indexingEnabled);
 }

--- a/Tests/Doctrine/AbstractListenerTest.php
+++ b/Tests/Doctrine/AbstractListenerTest.php
@@ -7,7 +7,7 @@ namespace FOS\ElasticaBundle\Tests\Doctrine;
  *
  * @author Richard Miller <info@limethinking.co.uk>
  */
-abstract class ListenerTest extends \PHPUnit_Framework_TestCase
+abstract class AbstractListenerTest extends \PHPUnit_Framework_TestCase
 {
     public function testObjectInsertedOnPersist()
     {
@@ -250,18 +250,23 @@ abstract class ListenerTest extends \PHPUnit_Framework_TestCase
      * @param string          $indexName
      * @param string          $typeName
      * @param Listener\Entity $object
-     * @param boolean         $return
+     * @param boolean         $isObjectIndexable
+     * @param boolean         $isIndexingEnabled
      */
-    private function getMockIndexable($indexName, $typeName, $object, $return = null)
+    private function getMockIndexable($indexName, $typeName, $object, $isObjectIndexable = null, $isIndexingEnabled = true)
     {
         $mock = $this->getMock('FOS\ElasticaBundle\Provider\IndexableInterface');
 
-        if (null !== $return) {
+        if (null !== $isObjectIndexable) {
             $mock->expects($this->once())
                 ->method('isObjectIndexable')
                 ->with($indexName, $typeName, $object)
-                ->will($this->returnValue($return));
+                ->will($this->returnValue($isObjectIndexable));
         }
+
+        $mock->expects($this->once())
+            ->method('isIndexingEnabled')
+            ->will($this->returnValue($isIndexingEnabled));
 
         return $mock;
     }

--- a/Tests/Doctrine/AbstractListenerTest.php
+++ b/Tests/Doctrine/AbstractListenerTest.php
@@ -169,6 +169,56 @@ abstract class AbstractListenerTest extends \PHPUnit_Framework_TestCase
         $listener->postFlush($eventArgs);
     }
 
+    public function testObjectNotInsertedIfIndexingDisabled()
+    {
+        $entity = new Listener\Entity(1);
+        $persister = $this->getMockPersister($entity, 'index', 'type');
+        $eventArgs = $this->createLifecycleEventArgs($entity, $this->getMockObjectManager());
+        $indexable = $this->getMockIndexable('index', 'type', $entity, null, false);
+
+        $listener = $this->createListener($persister, $indexable, array('indexName' => 'index', 'typeName' => 'type'));
+        $listener->postPersist($eventArgs);
+
+        $persister->expects($this->never())
+            ->method('insertOne');
+        $persister->expects($this->never())
+            ->method('insertMany');
+
+        $listener->postFlush($eventArgs);
+    }
+
+    public function testObjectNotReplacedIfIndexingDisabled()
+    {
+        $entity = new Listener\Entity(1);
+        $persister = $this->getMockPersister($entity, 'index', 'type');
+        $eventArgs = $this->createLifecycleEventArgs($entity, $this->getMockObjectManager());
+        $indexable = $this->getMockIndexable('index', 'type', $entity, true, false);
+
+        $listener = $this->createListener($persister, $indexable, array('indexName' => 'index', 'typeName' => 'type'));
+        $listener->postUpdate($eventArgs);
+
+        $persister->expects($this->never())
+            ->method('replaceMany');
+
+        $listener->postFlush($eventArgs);
+    }
+
+    public function testObjectNotDeletedIfIndexingDisabled()
+    {
+        $entity = new Listener\Entity(1);
+        $persister = $this->getMockPersister($entity, 'index', 'type');
+        $eventArgs = $this->createLifecycleEventArgs($entity, $this->getMockObjectManager());
+        $indexable = $this->getMockIndexable('index', 'type', $entity, null, false);
+
+        $listener = $this->createListener($persister, $indexable, array('indexName' => 'index', 'typeName' => 'type'));
+        $listener->preRemove($eventArgs);
+
+        $persister->expects($this->never())
+            ->method('deleteManyByIdentifiers');
+
+        $listener->postFlush($eventArgs);
+    }
+
     abstract protected function getLifecycleEventArgsClass();
 
     abstract protected function getListenerClass();

--- a/Tests/Doctrine/MongoDB/ListenerTest.php
+++ b/Tests/Doctrine/MongoDB/ListenerTest.php
@@ -2,7 +2,7 @@
 
 namespace FOS\ElasticaBundle\Tests\Doctrine\MongoDB;
 
-use FOS\ElasticaBundle\Tests\Doctrine\ListenerTest as BaseListenerTest;
+use FOS\ElasticaBundle\Tests\Doctrine\AbstractListenerTest as BaseListenerTest;
 
 class ListenerTest extends BaseListenerTest
 {

--- a/Tests/Doctrine/ORM/ListenerTest.php
+++ b/Tests/Doctrine/ORM/ListenerTest.php
@@ -2,7 +2,7 @@
 
 namespace FOS\ElasticaBundle\Tests\Doctrine\ORM;
 
-use FOS\ElasticaBundle\Tests\Doctrine\ListenerTest as BaseListenerTest;
+use FOS\ElasticaBundle\Tests\Doctrine\AbstractListenerTest as BaseListenerTest;
 
 class ListenerTest extends BaseListenerTest
 {

--- a/Tests/Doctrine/PHPCR/ListenerTest.php
+++ b/Tests/Doctrine/PHPCR/ListenerTest.php
@@ -2,7 +2,7 @@
 
 namespace FOS\ElasticaBundle\Tests\Doctrine\PHPCR;
 
-use FOS\ElasticaBundle\Tests\Doctrine\ListenerTest as BaseListenerTest;
+use FOS\ElasticaBundle\Tests\Doctrine\AbstractListenerTest as BaseListenerTest;
 
 class ListenerTest extends BaseListenerTest
 {

--- a/Tests/Provider/IndexableTest.php
+++ b/Tests/Provider/IndexableTest.php
@@ -62,6 +62,15 @@ class IndexableTest extends \PHPUnit_Framework_TestCase
         );
     }
 
+    public function testObjectIsNotIndexableIfIndexingDisabled()
+    {
+        $indexable = new Indexable(array(), $this->container);
+        $indexable->setIndexingEnabled(false);
+        $index = $indexable->isObjectIndexable('index', 'type', new Entity());
+
+        $this->assertFalse($index);
+    }
+
     public function provideIsIndexableCallbacks()
     {
         return array(


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | no |
| New feature? | yes |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| Fixed tickets | #1026 |

We have a legacy script that creates and updates entities using Doctrine but also inserts new records with the QueryBuilder. At the end we get partially indexed data and have to run fos:elastica:populate to index it properly.
Moreover, old scripts works now significantly slower because of the Listener in FOSElasticaBundle.
In our case it would be much better to disable object indexing for console scripts and run reindexing manually when we ready for it.
My proposal is to disable Listener by extending the Indexer:

``` php
// In a console script before operations with EntityManager
$indexable = $this->getContainer()->get('fos_elastica.indexable');
$indexable->setIndexingEnabled(false);

// Create entities, persist remove, flush...
```
