### PR TITLE
Dispatch event POST_TRANSFORM when serializer option is used

### DIFF
--- a/DependencyInjection/FOSElasticaExtension.php
+++ b/DependencyInjection/FOSElasticaExtension.php
@@ -423,6 +423,7 @@ class FOSElasticaExtension extends Extension
             $abstractId = 'fos_elastica.object_serializer_persister';
             $callbackId = sprintf('%s.%s.serializer.callback', $this->indexConfigs[$indexName]['reference'], $typeName);
             $arguments[] = array(new Reference($callbackId), 'serialize');
+            $arguments[] = new Reference('event_dispatcher');
         } else {
             $abstractId = 'fos_elastica.object_persister';
             $mapping = $this->indexConfigs[$indexName]['types'][$typeName]['mapping'];

--- a/Resources/config/persister.xml
+++ b/Resources/config/persister.xml
@@ -22,6 +22,7 @@
             <argument /> <!-- model to elastica transformer -->
             <argument /> <!-- model -->
             <argument /> <!-- serializer -->
+            <argument /> <!-- dispatcher -->
         </service>
     </services>
 </container>

--- a/Tests/Functional/SerializerTest.php
+++ b/Tests/Functional/SerializerTest.php
@@ -68,6 +68,25 @@ class SerializerTest extends WebTestCase
         $resetter->resetIndex('index');
     }
 
+    public function testIfEventOnPostTransformEventIsCalled()
+    {
+        $client = $this->createClient(array('test_case' => 'SerializerWithListener'));
+        $container = $client->getContainer();
+        $object = new TypeObj();
+        $object->id = 2;
+        $object->field1 = 'a listener will change me';
+
+        $elasticaPersister = $container->get('fos_elastica.object_persister.index.type');
+        $elasticaPersister->insertOne($object);
+
+        $elasticaType = $container->get('fos_elastica.index.index.type');
+
+        $documentData = $elasticaType->getDocument(2)->getData();
+
+        $this->assertArrayHasKey('field1', $documentData);
+        $this->assertEquals($documentData['field1'], 'post_persister');
+    }
+
     protected function setUp()
     {
         parent::setUp();

--- a/Tests/Functional/app/SerializerWithListener/EventListener/CustomPropertyListener.php
+++ b/Tests/Functional/app/SerializerWithListener/EventListener/CustomPropertyListener.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace FOS\ElasticaBundle\Tests\Functional\app\SerializerWithListener\EventListener;
+
+
+use Elastica\Document;
+use FOS\ElasticaBundle\Event\TransformEvent;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * @author Giovanni Albero <giovannialbero.solinf@gmail.com>
+ */
+class CustomPropertyListener implements EventSubscriberInterface
+{
+    public function addCustomProperty(TransformEvent $event)
+    {
+        /** @var Document $document */
+        $document = $event->getDocument();
+
+        $data = $document->getData();
+
+        if (is_string($data)) {
+            $unserializeData = json_decode($data, true);
+            $unserializeData['field1'] = 'post_persister';
+            $document->setData(json_encode($unserializeData));
+        }
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return array (
+            TransformEvent::POST_TRANSFORM => 'addCustomProperty',
+        );
+    }
+}

--- a/Tests/Functional/app/SerializerWithListener/TypeObj.yml
+++ b/Tests/Functional/app/SerializerWithListener/TypeObj.yml
@@ -1,0 +1,8 @@
+FOS\ElasticaBundle\Tests\Functional\TypeObj:
+    properties:
+        field1:
+            type: string
+    virtualProperties:
+        getSerializableColl:
+            serializedName: coll
+            type: array

--- a/Tests/Functional/app/SerializerWithListener/bundles.php
+++ b/Tests/Functional/app/SerializerWithListener/bundles.php
@@ -1,0 +1,13 @@
+<?php
+
+use Doctrine\Bundle\DoctrineBundle\DoctrineBundle;
+use FOS\ElasticaBundle\FOSElasticaBundle;
+use Symfony\Bundle\FrameworkBundle\FrameworkBundle;
+use JMS\SerializerBundle\JMSSerializerBundle;
+
+return array(
+    new FrameworkBundle(),
+    new FOSElasticaBundle(),
+    new DoctrineBundle(),
+    new JMSSerializerBundle(),
+);

--- a/Tests/Functional/app/SerializerWithListener/config.yml
+++ b/Tests/Functional/app/SerializerWithListener/config.yml
@@ -1,0 +1,70 @@
+imports:
+    - { resource: ./../config/config.yml }
+
+doctrine:
+    dbal:
+        path: %kernel.cache_dir%/db.sqlite
+        charset:  UTF8
+    orm:
+        auto_generate_proxy_classes: false
+        auto_mapping: false
+
+services:
+    indexableService:
+        class: FOS\ElasticaBundle\Tests\Functional\app\ORM\IndexableService
+
+    postTransformListener:
+        class: FOS\ElasticaBundle\Tests\Functional\app\SerializerWithListener\EventListener\CustomPropertyListener
+        tags:
+            - { name: kernel.event_subscriber }
+
+jms_serializer:
+    metadata:
+        auto_detection: true
+        directories:
+            type_obj:
+                namespace_prefix: "FOS\\ElasticaBundle\\Tests\\Functional"
+                path: "%kernel.root_dir%/Serializer"
+
+fos_elastica:
+    clients:
+        default:
+            url: http://localhost:9200
+    serializer: ~
+    indexes:
+        index:
+            index_name: foselastica_ser_test_%kernel.environment%
+            types:
+                type:
+                    properties:
+                        coll: ~
+                        field1: ~
+                    persistence:
+                        driver: orm
+                        model: FOS\ElasticaBundle\Tests\Functional\TypeObj
+                    serializer:
+                        groups: ['search', 'Default']
+                        version: 1.1
+                type_serialize_null_disabled:
+                    properties:
+                        field1: ~
+                    persistence:
+                        driver: orm
+                        model: FOS\ElasticaBundle\Tests\Functional\TypeObj
+                    serializer:
+                        serialize_null: false
+                type_serialize_null_enabled:
+                    properties:
+                        field1: ~
+                    persistence:
+                        driver: orm
+                        model: FOS\ElasticaBundle\Tests\Functional\TypeObj
+                    serializer:
+                        serialize_null: true
+                unmapped:
+                    persistence:
+                        driver: orm
+                        model: FOS\ElasticaBundle\Tests\Functional\TypeObj
+                    serializer:
+                        groups: ['search', 'Default']
+                        version: 1.1

--- a/Tests/Persister/ObjectSerializerPersisterTest.php
+++ b/Tests/Persister/ObjectSerializerPersisterTest.php
@@ -4,6 +4,7 @@ namespace FOS\ElasticaBundle\Tests\ObjectSerializerPersister;
 
 use FOS\ElasticaBundle\Persister\ObjectSerializerPersister;
 use FOS\ElasticaBundle\Transformer\ModelToElasticaIdentifierTransformer;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\PropertyAccess\PropertyAccess;
 
 class POPO
@@ -38,7 +39,9 @@ class ObjectSerializerPersisterTest extends \PHPUnit_Framework_TestCase
         $serializerMock = $this->getMockBuilder('FOS\ElasticaBundle\Serializer\Callback')->getMock();
         $serializerMock->expects($this->once())->method('serialize');
 
-        $objectPersister = new ObjectSerializerPersister($typeMock, $transformer, 'SomeClass', array($serializerMock, 'serialize'));
+        $dispatcherMock = $this->getMockBuilder('Symfony\Component\EventDispatcher\EventDispatcher')->getMock();
+
+        $objectPersister = new ObjectSerializerPersister($typeMock, $transformer, 'SomeClass', array($serializerMock, 'serialize'), $dispatcherMock);
         $objectPersister->replaceOne(new POPO());
     }
 
@@ -58,7 +61,9 @@ class ObjectSerializerPersisterTest extends \PHPUnit_Framework_TestCase
         $serializerMock = $this->getMockBuilder('FOS\ElasticaBundle\Serializer\Callback')->getMock();
         $serializerMock->expects($this->once())->method('serialize');
 
-        $objectPersister = new ObjectSerializerPersister($typeMock, $transformer, 'SomeClass', array($serializerMock, 'serialize'));
+        $dispatcherMock = $this->getMockBuilder('Symfony\Component\EventDispatcher\EventDispatcher')->getMock();
+
+        $objectPersister = new ObjectSerializerPersister($typeMock, $transformer, 'SomeClass', array($serializerMock, 'serialize'), $dispatcherMock);
         $objectPersister->insertOne(new POPO());
     }
 
@@ -78,7 +83,9 @@ class ObjectSerializerPersisterTest extends \PHPUnit_Framework_TestCase
         $serializerMock = $this->getMockBuilder('FOS\ElasticaBundle\Serializer\Callback')->getMock();
         $serializerMock->expects($this->once())->method('serialize');
 
-        $objectPersister = new ObjectSerializerPersister($typeMock, $transformer, 'SomeClass', array($serializerMock, 'serialize'));
+        $dispatcherMock = $this->getMockBuilder('Symfony\Component\EventDispatcher\EventDispatcher')->getMock();
+
+        $objectPersister = new ObjectSerializerPersister($typeMock, $transformer, 'SomeClass', array($serializerMock, 'serialize'), $dispatcherMock);
         $objectPersister->deleteOne(new POPO());
     }
 
@@ -102,7 +109,9 @@ class ObjectSerializerPersisterTest extends \PHPUnit_Framework_TestCase
         $serializerMock = $this->getMockBuilder('FOS\ElasticaBundle\Serializer\Callback')->getMock();
         $serializerMock->expects($this->exactly(2))->method('serialize');
 
-        $objectPersister = new ObjectSerializerPersister($typeMock, $transformer, 'SomeClass', array($serializerMock, 'serialize'));
+        $dispatcherMock = $this->getMockBuilder('Symfony\Component\EventDispatcher\EventDispatcher')->getMock();
+
+        $objectPersister = new ObjectSerializerPersister($typeMock, $transformer, 'SomeClass', array($serializerMock, 'serialize'), $dispatcherMock);
         $objectPersister->insertMany(array(new POPO(), new POPO()));
     }
 


### PR DESCRIPTION
#1142

Now when serialize option is used the listener on `POST_TRANSFORM` event will be called.

I don't know if this PR is welcome because the data is serialized and is not possible to do something like this

``` php
$document = $event->getDocument();
$document->set('newkey', 'value');
```

but you must parse data and set it again into document, like in the test introduced with this PR.

``` php
$document = $event->getDocument();
$data = $document->getData();
if (is_string($data)) {
  $unserializeData = json_decode($data, true);
  $unserializeData['field1'] = 'post_persister';
  $document->setData(json_encode($unserializeData));
}
```

@eloirobe @AmOrFeU86
I recommend to try this fork on your private project to receive some more feedback here.
Thanks a lot
