### PR TITLE
Execution time in profiler is not accurate 

### DIFF
--- a/DataCollector/ElasticaDataCollector.php
+++ b/DataCollector/ElasticaDataCollector.php
@@ -63,6 +63,19 @@ class ElasticaDataCollector extends DataCollector
     }
 
     /**
+     * @return int
+     */
+    public function getExecutionTime()
+    {
+        $time = 0;
+        foreach ($this->data['queries'] as $query) {
+            $time += $query['executionMS'];
+        }
+
+        return $time;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function getName()

--- a/Elastica/Client.php
+++ b/Elastica/Client.php
@@ -43,14 +43,13 @@ class Client extends BaseClient
             $this->stopwatch->start('es_request', 'fos_elastica');
         }
 
-        $start = microtime(true);
         $response = parent::request($path, $method, $data, $query);
         $responseData = $response->getData();
 
         if (isset($responseData['took']) && isset($responseData['hits'])) {
-            $this->logQuery($path, $method, $data, $query, $start, $response->getEngineTime(), $responseData['hits']['total']);
+            $this->logQuery($path, $method, $data, $query, $response->getQueryTime(), $response->getEngineTime(), $responseData['hits']['total']);
         } else {
-            $this->logQuery($path, $method, $data, $query, $start, 0, 0);
+            $this->logQuery($path, $method, $data, $query, $response->getQueryTime(), 0, 0);
         }
 
         if ($this->stopwatch) {
@@ -91,24 +90,28 @@ class Client extends BaseClient
      * @param string $method
      * @param array  $data
      * @param array  $query
-     * @param int    $start
+     * @param int    $queryTime
+     * @param int    $engineMS
+     * @param int    $itemCount
      */
-    private function logQuery($path, $method, $data, array $query, $start, $engineMS = 0, $itemCount = 0)
+    private function logQuery($path, $method, $data, array $query, $queryTime, $engineMS = 0, $itemCount = 0)
     {
         if (!$this->_logger or !$this->_logger instanceof ElasticaLogger) {
             return;
         }
 
-        $time = microtime(true) - $start;
+
         $connection = $this->getLastRequest()->getConnection();
 
-        $connection_array = array(
+        $connectionArray = array(
             'host' => $connection->getHost(),
             'port' => $connection->getPort(),
             'transport' => $connection->getTransport(),
             'headers' => $connection->hasConfig('headers') ? $connection->getConfig('headers') : array(),
         );
 
-        $this->_logger->logQuery($path, $method, $data, $time, $connection_array, $query, $engineMS, $itemCount);
+        /** @var ElasticaLogger $logger */
+        $logger = $this->_logger;
+        $logger->logQuery($path, $method, $data, $queryTime, $connectionArray, $query, $engineMS, $itemCount);
     }
 }

--- a/Logger/ElasticaLogger.php
+++ b/Logger/ElasticaLogger.php
@@ -2,6 +2,7 @@
 
 namespace FOS\ElasticaBundle\Logger;
 
+use Psr\Log\AbstractLogger;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -12,7 +13,7 @@ use Psr\Log\LoggerInterface;
  *
  * @author Gordon Franke <info@nevalon.de>
  */
-class ElasticaLogger implements LoggerInterface
+class ElasticaLogger extends AbstractLogger
 {
     /**
      * @var LoggerInterface
@@ -44,23 +45,26 @@ class ElasticaLogger implements LoggerInterface
     /**
      * Logs a query.
      *
-     * @param string $path       Path to call
-     * @param string $method     Rest method to use (GET, POST, DELETE, PUT)
-     * @param array  $data       Arguments
-     * @param float  $time       Execution time
+     * @param string $path Path to call
+     * @param string $method Rest method to use (GET, POST, DELETE, PUT)
+     * @param array  $data Arguments
+     * @param float  $queryTime Execution time (in seconds)
      * @param array  $connection Host, port, transport, and headers of the query
-     * @param array  $query      Arguments
+     * @param array  $query Arguments
+     * @param int    $engineTime
+     * @param int    $itemCount
      */
-    public function logQuery($path, $method, $data, $time, $connection = array(), $query = array(), $engineTime = 0, $itemCount = 0)
+    public function logQuery($path, $method, $data, $queryTime, $connection = array(), $query = array(), $engineTime = 0, $itemCount = 0)
     {
+        $executionMS = $queryTime * 1000;
+
         if ($this->debug) {
             $e = new \Exception();
-
             $this->queries[] = array(
                 'path' => $path,
                 'method' => $method,
                 'data' => $data,
-                'executionMS' => $time,
+                'executionMS' => $executionMS,
                 'engineMS' => $engineTime,
                 'connection' => $connection,
                 'queryString' => $query,
@@ -70,7 +74,7 @@ class ElasticaLogger implements LoggerInterface
         }
 
         if (null !== $this->logger) {
-            $message = sprintf("%s (%s) %0.2f ms", $path, $method, $time * 1000);
+            $message = sprintf("%s (%s) %0.2f ms", $path, $method, $executionMS);
             $this->logger->info($message, (array) $data);
         }
     }
@@ -93,70 +97,6 @@ class ElasticaLogger implements LoggerInterface
     public function getQueries()
     {
         return $this->queries;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function emergency($message, array $context = array())
-    {
-        return $this->logger->emergency($message, $context);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function alert($message, array $context = array())
-    {
-        return $this->logger->alert($message, $context);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function critical($message, array $context = array())
-    {
-        return $this->logger->critical($message, $context);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function error($message, array $context = array())
-    {
-        return $this->logger->error($message, $context);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function warning($message, array $context = array())
-    {
-        return $this->logger->warning($message, $context);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function notice($message, array $context = array())
-    {
-        return $this->logger->notice($message, $context);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function info($message, array $context = array())
-    {
-        return $this->logger->info($message, $context);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function debug($message, array $context = array())
-    {
-        return $this->logger->debug($message, $context);
     }
 
     /**

--- a/Resources/views/Collector/elastica.html.twig
+++ b/Resources/views/Collector/elastica.html.twig
@@ -31,6 +31,10 @@
             <b>Query Time</b>
             <span>{{ '%0.2f'|format(collector.time) }} ms</span>
         </div>
+        <div class="sf-toolbar-info-piece">
+            <b>Execution Time</b>
+            <span>{{ '%0.2f'|format(collector.executionTime) }} ms</span>
+        </div>
     {% endset %}
     {% include 'WebProfilerBundle:Profiler:toolbar_item.html.twig' with { 'link': profiler_url } %}
 {% endblock %}
@@ -68,7 +72,7 @@
                     <strong>Query time</strong>: {{ query.engineMS }} ms<br />
                     <strong>Item count</strong>: {{ query.itemCount }}<br />
                     <small>
-                        <strong>Time</strong>: {{ '%0.2f'|format(query.executionMS * 1000) }} ms
+                        <strong>Time</strong>: {{ '%0.2f'|format(query.executionMS) }} ms
                     </small>
                     {% if query.connection.transport in ['Http', 'Https'] %}{# cURL support only HTTP #}
                         <a href="#elastica_curl_query_{{ key }}" onclick="return toggle_details(this);" style="text-decoration: none;" title="Get the cURL repeatable query">

--- a/Tests/Elastica/ClientTest.php
+++ b/Tests/Elastica/ClientTest.php
@@ -23,7 +23,10 @@ class ClientTest extends \PHPUnit_Framework_TestCase
                 'foo',
                 Request::GET,
                 $this->isType('array'),
-                $this->isType('float'),
+                $this->logicalOr(
+                    $this->isType('float'),
+                    $this->isNull()
+                ),
                 $this->isType('array'),
                 $this->isType('array')
             );

--- a/Tests/Logger/ElasticaLoggerTest.php
+++ b/Tests/Logger/ElasticaLoggerTest.php
@@ -33,8 +33,9 @@ class ElasticaLoggerTest extends \PHPUnit_Framework_TestCase
             ->getMock();
 
         $loggerMock->expects($this->once())
-            ->method($level)
+            ->method('log')
             ->with(
+                $level,
                 $this->equalTo($message),
                 $this->equalTo($context)
             );
@@ -77,7 +78,7 @@ class ElasticaLoggerTest extends \PHPUnit_Framework_TestCase
             'path'        => $path,
             'method'      => $method,
             'data'        => $data,
-            'executionMS' => $time,
+            'executionMS' => $time * 1000,
             'connection'  => $connection,
             'queryString' => $query,
             'engineMS' => 0,


### PR DESCRIPTION
I've noticed that execution time in profiler is wrong:

- Removed `$start` and `$end` from overridden `Client` in favor of `getQueryTime`
- Code Style fixes and improved type hinting in `logQuery`
- Cleaned `ElasticaLogger` by extending `AbstractLogger` which already implemented all methods required by interface

Before:
![image](https://cloud.githubusercontent.com/assets/1244112/18961986/9999b0ea-8677-11e6-8bcc-540ff5ba997c.png)
![image](https://cloud.githubusercontent.com/assets/1244112/18962183/730d6826-8678-11e6-960b-bbcb8eeedca8.png)

After:
![image](https://cloud.githubusercontent.com/assets/1244112/18961947/79a994f8-8677-11e6-8e83-d5bb39f5ea3b.png)
![image](https://cloud.githubusercontent.com/assets/1244112/18962258/c95356a0-8678-11e6-9cb4-d6cea84367dd.png)
