### PR TITLE
Update Provider.php

### DIFF
--- a/Doctrine/PHPCR/Provider.php
+++ b/Doctrine/PHPCR/Provider.php
@@ -68,7 +68,7 @@ class Provider extends AbstractProvider
     /**
      * {@inheritDoc}
      */
-    protected function createQueryBuilder($method)
+    protected function createQueryBuilder($method,array $arguments=array())
     {
         return $this->managerRegistry
             ->getManager()


### PR DESCRIPTION
Declaration of FOS\ElasticaBundle\Doctrine\PHPCR\Provider::createQueryBuilder($method) must be compatible with FOS\ElasticaBundle\Doctrine\AbstractProvider::createQueryBuilder($method, array $arguments = Array)