### PR TITLE
Removed search annotation from documentation

### DIFF
--- a/Resources/doc/cookbook/custom-repositories.md
+++ b/Resources/doc/cookbook/custom-repositories.md
@@ -54,23 +54,3 @@ $repository = $repositoryManager->getRepository('UserBundle:User');
 /** var array of Acme\UserBundle\Entity\User */
 $users = $repository->findWithCustomQuery('bob');
 ```
-
-Alternatively you can specify the custom repository using an annotation in the entity:
-
-```php
-<?php
-
-namespace Application\UserBundle\Entity;
-
-use FOS\ElasticaBundle\Annotation\Search;
-
-/**
- * @Search(repositoryClass="Acme\ElasticaBundle\SearchRepository\UserRepository")
- */
-class User
-{
-
-   //---
-
-}
-```


### PR DESCRIPTION
Removed by documentation reference to annotation `@Search` to declare a custom repository,
In ref. to PR #1119 .
