### PR TITLE
PRE_INDEX_RESET should be aware about originalName

### DIFF
--- a/Index/Resetter.php
+++ b/Index/Resetter.php
@@ -89,12 +89,12 @@ class Resetter
         $indexConfig = $this->configManager->getIndexConfiguration($indexName);
         $index = $this->indexManager->getIndex($indexName);
 
-        $event = new IndexResetEvent($indexName, $populating, $force);
-        $this->dispatcher->dispatch(IndexResetEvent::PRE_INDEX_RESET, $event);
-
         if ($indexConfig->isUseAlias()) {
             $this->aliasProcessor->setRootName($indexConfig, $index);
         }
+
+        $event = new IndexResetEvent($indexName, $populating, $force);
+        $this->dispatcher->dispatch(IndexResetEvent::PRE_INDEX_RESET, $event);
 
         $mapping = $this->mappingBuilder->buildIndexMapping($indexConfig);
         $index->create($mapping, true);


### PR DESCRIPTION
We have `PRE_INDEX_RESET` event, which is triggered before creating a new index, but currently it's not aware of "real" index name because it's called before `AliasProcessor::setRootName`.

In this PR I just moved PRE_INDEX_RESET dispatch after `AliasProcessor::setRootName` is called.