### PR TITLE
Fix MongoDB config

### DIFF
--- a/Resources/config/mongodb.xml
+++ b/Resources/config/mongodb.xml
@@ -43,7 +43,7 @@
 
         <service id="fos_elastica.manager.mongodb" class="%fos_elastica.manager.mongodb.class%">
             <argument type="service" id="doctrine_mongodb"/>
-            <argument type="service" id="annotation_reader"/>
+            <argument type="service" id="fos_elastica.repository_manager"/>
         </service>
     </services>
 </container>


### PR DESCRIPTION
I get this exception with symfony2 using doctrine and mongodb:

`Fatal Error: Argument 2 passed to FOS\ElasticaBundle\Doctrine\RepositoryManager::__construct() must implement interface FOS\ElasticaBundle\Manager\RepositoryManagerInterface, instance of Doctrine\Common\Annotations\CachedReader given`

I don't know if this issue needs more code but it seems to work.
