### PR TITLE
Support nested_path and nested_filter sort attributes when using knp pager

### DIFF
--- a/Resources/doc/usage.md
+++ b/Resources/doc/usage.md
@@ -31,6 +31,20 @@ $countOfResults = $userPaginator->getNbResults();
 $paginator = $this->get('knp_paginator');
 $results = $finder->createPaginatorAdapter('bob');
 $pagination = $paginator->paginate($results, $page, 10);
+
+// You can specify additional options as the fourth parameter of Knp Paginator
+// paginate method to set ignore_unmapped, nested_filter and nested_sort
+
+$options = [
+    'sortIgnoreUnmapped' => true,
+    'sortNestedPath' => 'owner',
+    'sortNestedFilter' => new Query\Term(['enabled' => ['value' => true]]),
+];
+
+// sortNestedPath and sortNestedFilter also accepts a callable
+// which takes the current sort field to get the correct sort path/filter
+
+$pagination = $paginator->paginate($results, $page, 10, $options);
 ```
 
 Aggregations

--- a/Subscriber/PaginateElasticaQuerySubscriber.php
+++ b/Subscriber/PaginateElasticaQuerySubscriber.php
@@ -84,14 +84,18 @@ class PaginateElasticaQuerySubscriber implements EventSubscriberInterface
             $path = is_callable($options['sortNestedPath']) ?
                 $options['sortNestedPath']($sortField) : $options['sortNestedPath'];
 
-            $sort['nested_path'] = $path;
+            if (!empty($path)) {
+                $sort['nested_path'] = $path;
+            }
         }
 
         if (isset($options['sortNestedFilter'])) {
             $filter = is_callable($options['sortNestedFilter']) ?
                 $options['sortNestedFilter']($sortField) : $options['sortNestedFilter'];
 
-            $sort['nested_filter'] = $filter;
+            if (!empty($filter)) {
+                $sort['nested_filter'] = $filter;
+            }
         }
 
         return $sort;

--- a/Subscriber/PaginateElasticaQuerySubscriber.php
+++ b/Subscriber/PaginateElasticaQuerySubscriber.php
@@ -66,28 +66,56 @@ class PaginateElasticaQuerySubscriber implements EventSubscriberInterface
         }
 
         if (!empty($sortField)) {
-            // determine sort direction
-            $dir = 'asc';
-            $sortDirection = $this->request->get($options['sortDirectionParameterName']);
-
-            if (!$sortDirection && isset($options['defaultSortDirection'])) {
-                $sortDirection = $options['defaultSortDirection'];
-            }
-
-            if ('desc' === strtolower($sortDirection)) {
-                $dir = 'desc';
-            }
-
-            // check if the requested sort field is in the sort whitelist
-            if (isset($options['sortFieldWhitelist']) && !in_array($sortField, $options['sortFieldWhitelist'])) {
-                throw new \UnexpectedValueException(sprintf('Cannot sort by: [%s] this field is not in whitelist', $sortField));
-            }
-
-            // set sort on active query
             $event->target->getQuery()->setSort(array(
-                $sortField => array('order' => $dir, 'ignore_unmapped' => true),
+                $sortField => $this->getSort($sortField, $options),
             ));
         }
+    }
+
+    protected function getSort($sortField, array $options = [])
+    {
+        $ignoreUnmapped = isset($options['sortIgnoreUnmapped']) ? $options['sortIgnoreUnmapped'] : true;
+        $sort = [
+            'order' => $this->getSortDirection($sortField, $options),
+            'ignore_unmapped' => $ignoreUnmapped,
+        ];
+
+        if (isset($options['sortNestedPath'])) {
+            $path = is_callable($options['sortNestedPath']) ?
+                $options['sortNestedPath']($sortField) : $options['sortNestedPath'];
+
+            $sort['nested_path'] = $path;
+        }
+
+        if (isset($options['sortNestedFilter'])) {
+            $filter = is_callable($options['sortNestedFilter']) ?
+                $options['sortNestedFilter']($sortField) : $options['sortNestedFilter'];
+
+            $sort['nested_filter'] = $filter;
+        }
+
+        return $sort;
+    }
+
+    protected function getSortDirection($sortField, array $options = [])
+    {
+        $dir = 'asc';
+        $sortDirection = $this->request->get($options['sortDirectionParameterName']);
+
+        if (empty($sortDirection) && isset($options['defaultSortDirection'])) {
+            $sortDirection = $options['defaultSortDirection'];
+        }
+
+        if ('desc' === strtolower($sortDirection)) {
+            $dir = 'desc';
+        }
+
+        // check if the requested sort field is in the sort whitelist
+        if (isset($options['sortFieldWhitelist']) && !in_array($sortField, $options['sortFieldWhitelist'])) {
+            throw new \UnexpectedValueException(sprintf('Cannot sort by: [%s] this field is not in whitelist', $sortField));
+        }
+
+        return $dir;
     }
 
     /**

--- a/Tests/Subscriber/PaginateElasticaQuerySubscriberTest.php
+++ b/Tests/Subscriber/PaginateElasticaQuerySubscriberTest.php
@@ -1,0 +1,134 @@
+<?php
+
+namespace FOS\ElasticaBundle\Tests\Subscriber;
+
+use Elastica\Query;
+use FOS\ElasticaBundle\Paginator\PartialResultsInterface;
+use FOS\ElasticaBundle\Paginator\RawPaginatorAdapter;
+use FOS\ElasticaBundle\Subscriber\PaginateElasticaQuerySubscriber;
+use Knp\Component\Pager\Event\ItemsEvent;
+use Symfony\Component\HttpFoundation\Request;
+
+class PaginateElasticaQuerySubscriberTest extends \PHPUnit_Framework_TestCase
+{
+    protected function getAdapterMock()
+    {
+        return $this->getMockBuilder(RawPaginatorAdapter::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+
+    protected function getResultSetMock()
+    {
+        return $this->getMockBuilder(PartialResultsInterface::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+
+    public function testShouldDoNothingIfSortParamIsEmpty()
+    {
+        $request = new Request();
+
+        $subscriber = new PaginateElasticaQuerySubscriber();
+        $subscriber->setRequest($request);
+
+        $adapter = $this->getAdapterMock();
+        $adapter->expects($this->never())
+            ->method('getQuery');
+        $adapter->method('getResults')
+            ->willReturn($this->getResultSetMock());
+
+        $event = new ItemsEvent(0, 10);
+        $event->target = $adapter;
+
+        $subscriber->items($event);
+    }
+
+    public function sortCases()
+    {
+        $tests = [];
+
+        $expected = [
+            'createdAt' => [
+                'order' => 'asc',
+                'ignore_unmapped' => true
+            ]
+        ];
+        $tests[] = [$expected, new Request()];
+
+        $expected = [
+            'name' => [
+                'order' => 'desc',
+                'ignore_unmapped' => true
+            ]
+        ];
+        $tests[] = [$expected, new Request(['ord' => 'name', 'az' => 'desc'])];
+
+        $expected = [
+            'updatedAt' => [
+                'order' => 'asc',
+                'ignore_unmapped' => true
+            ]
+        ];
+        $tests[] = [$expected, new Request(['ord' => 'updatedAt', 'az' => 'invalid'])];
+
+        return $tests;
+    }
+
+    /**
+     * @dataProvider sortCases
+     */
+    public function testShouldSort(array $expected, Request $request)
+    {
+        $subscriber = new PaginateElasticaQuerySubscriber();
+        $subscriber->setRequest($request);
+
+        $query = new Query();
+        $adapter = $this->getAdapterMock();
+        $adapter->method('getQuery')
+            ->willReturn($query);
+
+        $adapter->method('getResults')
+            ->willReturn($this->getResultSetMock());
+
+        $event = new ItemsEvent(0, 10);
+        $event->target = $adapter;
+        $event->options = [
+            'defaultSortFieldName' => 'createdAt',
+            'sortFieldParameterName' => 'ord',
+            'sortDirectionParameterName' => 'az'
+        ];
+
+        $subscriber->items($event);
+
+        $this->assertEquals($expected, $query->getParam('sort'));
+    }
+
+    /**
+     * @expectedException \UnexpectedValueException
+     */
+    public function testShouldThrowIfFieldIsNotWhitelisted()
+    {
+        $subscriber = new PaginateElasticaQuerySubscriber();
+        $subscriber->setRequest(new Request(['ord' => 'owner']));
+
+        $query = new Query();
+        $adapter = $this->getAdapterMock();
+        $adapter->method('getQuery')
+            ->willReturn($query);
+
+        $adapter->method('getResults')
+            ->willReturn($this->getResultSetMock());
+
+        $event = new ItemsEvent(0, 10);
+        $event->target = $adapter;
+        $event->options = [
+            'defaultSortFieldName' => 'createdAt',
+            'sortFieldParameterName' => 'ord',
+            'sortDirectionParameterName' => 'az',
+            'sortFieldWhitelist' => ['createdAt', 'updatedAt']
+        ];
+
+        $subscriber->items($event);
+    }
+}


### PR DESCRIPTION
Should resolve #1159

Added support for `sortNestedPath` and `sortNestedFilter` options to knp paginator `paginate` method.
Allows to specify `nested_path` and `nested_filter` sort fields when paginating, passing a string or a callable accepting the current sort field.