### PR TITLE
Fix resetIndexType on ES 1.x

### DIFF
--- a/Index/Resetter.php
+++ b/Index/Resetter.php
@@ -136,7 +136,8 @@ class Resetter
         }
 
         if (!empty($settings)) {
-            unset($settings['number_of_shards']);
+            unset($settings['number_of_shards'], $settings['index']['number_of_shards']);
+            unset($settings['number_of_replicas'], $settings['index']['number_of_replicas']);
             $index->close();
             $index->setSettings($settings);
             $index->open();


### PR DESCRIPTION
In version 1 of ES, the settings are different. Also the number_of_replicas cannot be changed on closed indexed as well:

> Can't update [index.number_of_replicas] on closed indices [] - can leave index in an unopenable state