### PR TITLE
Fixed PopulateCommand when --offset has been specified

### DIFF
--- a/Command/PopulateCommand.php
+++ b/Command/PopulateCommand.php
@@ -174,8 +174,9 @@ class PopulateCommand extends ContainerAwareCommand
             $this->resetter->resetIndexType($index, $type);
         }
 
+        $offset = $options['offset'];
         $provider = $this->providerRegistry->getProvider($index, $type);
-        $loggerClosure = $this->progressClosureBuilder->build($output, 'Populating', $index, $type);
+        $loggerClosure = $this->progressClosureBuilder->build($output, 'Populating', $index, $type, $offset);
         $provider->populate($loggerClosure, $event->getOptions());
 
         $this->dispatcher->dispatch(TypePopulateEvent::POST_TYPE_POPULATE, $event);

--- a/Command/ProgressClosureBuilder.php
+++ b/Command/ProgressClosureBuilder.php
@@ -24,22 +24,24 @@ class ProgressClosureBuilder
      * @param string          $action
      * @param string          $index
      * @param string          $type
+     * @param integer         $offset
      *
      * @return callable
      */
-    public function build(OutputInterface $output, $action, $index, $type)
+    public function build(OutputInterface $output, $action, $index, $type, $offset)
     {
         if (!class_exists('Symfony\Component\Console\Helper\ProgressBar') ||
             !is_callable(array('Symfony\Component\Console\Helper\ProgressBar', 'getProgress'))) {
-            return $this->buildLegacy($output, $action, $index, $type);
+            return $this->buildLegacy($output, $action, $index, $type, $offset);
         }
 
         $progress = null;
 
-        return function ($increment, $totalObjects, $message = null) use (&$progress, $output, $action, $index, $type) {
+        return function ($increment, $totalObjects, $message = null) use (&$progress, $output, $action, $index, $type, $offset) {
             if (null === $progress) {
                 $progress = new ProgressBar($output, $totalObjects);
                 $progress->start();
+                $progress->setProgress($offset);
             }
 
             if (null !== $message) {
@@ -55,20 +57,21 @@ class ProgressClosureBuilder
 
     /**
      * Builds a legacy closure that outputs lines for each step. Used in cases
-     * where the ProgressBar component doesnt exist or does not have the correct
+     * where the ProgressBar component doesn't exist or does not have the correct
      * methods to support what we need.
      *
      * @param OutputInterface $output
      * @param string          $action
      * @param string          $index
      * @param string          $type
+     * @param integer         $offset
      *
      * @return callable
      */
-    private function buildLegacy(OutputInterface $output, $action, $index, $type)
+    private function buildLegacy(OutputInterface $output, $action, $index, $type, $offset)
     {
         $lastStep = null;
-        $current = 0;
+        $current = $offset;
 
         return function ($increment, $totalObjects, $message = null) use ($output, $action, $index, $type, &$lastStep, &$current) {
             if ($current + $increment > $totalObjects) {


### PR DESCRIPTION
This fixes the  #914 issue. ProgressBar now starts at the position of the specified offset. I was also considering if it should start at 0 with max value decreased by offset value.