### PR TITLE
Fix deleting objects with identifier as object value

### DIFF
--- a/Doctrine/Listener.php
+++ b/Doctrine/Listener.php
@@ -190,7 +190,7 @@ class Listener
     private function scheduleForDeletion($object)
     {
         if ($identifierValue = $this->propertyAccessor->getValue($object, $this->config['identifier'])) {
-            $this->scheduledForDeletion[] = $identifierValue;
+            $this->scheduledForDeletion[] = (string)$identifierValue;
         }
     }
 


### PR DESCRIPTION
Hi,

I use FOSElastica in DDD symfony project. In this project identifiers of root aggregates are implemented as Value Object. For example this is UserId (Identifier of User entity): https://gist.github.com/szepczynski/306c2e3bc793b679a7cb3c8a89abaa7e

I create mapping, add some functionality and write some tests. In test I got few errors related with identifier.

I started with this mapping: 
https://gist.github.com/szepczynski/78a4d700bb06f50fdc3b59623d1f9329

and got error: Elastica\Exception\ResponseException: Malformed action/metadata line [1], expected a simple value for field [_id] but found [START_OBJECT]

I change the identifier to id.value but this change make error when bundle trying to get results from doctrine repository:
```
[Semantical Error] line 0, col 50 near 'value IN(:va': Error: Class User\Domain\Model\User has no field or association named id.value
```

This PR fix problem with Identifiers as Value Objects by casting it to string. Value Object must have implemented __toString method.