### PR TITLE
Fix call of unknown method QuestionHelper::askConfirmation()

### DIFF
--- a/Command/PopulateCommand.php
+++ b/Command/PopulateCommand.php
@@ -103,7 +103,7 @@ class PopulateCommand extends ContainerAwareCommand
         if ($input->isInteractive() && $reset && $input->getOption('offset')) {
             /** @var QuestionHelper $dialog */
             $dialog = $this->getHelperSet()->get('question');
-            if (!$dialog->askConfirmation($input, $output, new Question('<question>You chose to reset the index and start indexing with an offset. Do you really want to do that?</question>'))) {
+            if (!$dialog->ask($input, $output, new Question('<question>You chose to reset the index and start indexing with an offset. Do you really want to do that?</question>'))) {
                 return;
             }
         }


### PR DESCRIPTION
QuestionHelper has no method askConfirmation(), use ask()
Problem is caused by migration from DialogHelper to QuestionHelper in this commit: https://github.com/FriendsOfSymfony/FOSElasticaBundle/commit/9824b56143f448979430f764508dddb4231e072e