### PR TITLE
Clone $query  because size is set to 0 in ruflin package, causing 0 results

### DIFF
--- a/Paginator/RawPaginatorAdapter.php
+++ b/Paginator/RawPaginatorAdapter.php
@@ -118,7 +118,8 @@ class RawPaginatorAdapter implements PaginatorAdapterInterface
     public function getTotalHits($genuineTotal = false)
     {
         if (!isset($this->totalHits)) {
-            $this->totalHits = $this->searchable->count($this->query);
+            $query = clone $this->query;
+            $this->totalHits = $this->searchable->count($query);
         }
 
         return $this->query->hasParam('size') && !$genuineTotal


### PR DESCRIPTION
$paginator = $finder->findPaginated($boolQuery);
$paginator->setMaxPerPage(25);
$paginator->setCurrentPage($page);

empty because in ruflin/elastica/lib/Elastica/Search.php is

$query = $this->getQuery();
$query->setSize(0);