### PR TITLE
[Propel] Restored proper object sorting

### DIFF
--- a/Propel/ElasticaToModelTransformer.php
+++ b/Propel/ElasticaToModelTransformer.php
@@ -78,6 +78,11 @@ class ElasticaToModelTransformer extends AbstractElasticaToModelTransformer
             $_objects[] = $object;
         }
 
+        // Sort objects in the order of their IDs
+        $idPos = array_flip($ids);
+        $identifier = $this->options['identifier'];
+        usort($_objects, $this->getSortingClosure($idPos, $identifier));
+
         return $_objects;
     }
 


### PR DESCRIPTION
I've restored use of sortingClousure at Transformer because returned results always had random order.