### PR TITLE
Disable normalize keys for headers

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -138,6 +138,7 @@ class Configuration implements ConfigurationInterface
                                         ->end()
                                         ->booleanNode('compression')->defaultValue(false)->end()
                                         ->arrayNode('headers')
+                                            ->normalizeKeys(false)
                                             ->useAttributeAsKey('name')
                                             ->prototype('scalar')->end()
                                         ->end()


### PR DESCRIPTION
This snippet disables normalization (replacing - to _) for headers, for example "Content-Header" is named as "Content_Header" 