### PR TITLE
remove elasticsearch service from travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,9 +40,6 @@ before_script:
 script:
   - vendor/bin/phpunit --coverage-clover=coverage.clover
 
-services:
-  - elasticsearch
-
 after_script:
   - wget https://scrutinizer-ci.com/ocular.phar
   - php ocular.phar code-coverage:upload --format=php-clover coverage.clover


### PR DESCRIPTION
Since elasticsearch is not available in trusty distro (https://docs.travis-ci.com/user/trusty-ci-environment#Data-Stores) it should not be referenced in the config at all as it is useless anyhow