### PR TITLE
Subscribe to console.terminate event when defer is true

### DIFF
--- a/DependencyInjection/FOSElasticaExtension.php
+++ b/DependencyInjection/FOSElasticaExtension.php
@@ -537,7 +537,11 @@ class FOSElasticaExtension extends Extension
             $listenerDef->setPublic(true);
             $listenerDef->addTag(
                 'kernel.event_listener',
-                ['event' => 'kernel.terminate', 'method' => 'onKernelTerminate']
+                ['event' => 'kernel.terminate', 'method' => 'onTerminate']
+            );
+            $listenerDef->addTag(
+                'kernel.event_listener',
+                ['event' => 'console.terminate', 'method' => 'onTerminate']
             );
             $listenerConfig['defer'] = true;
         }

--- a/Doctrine/Listener.php
+++ b/Doctrine/Listener.php
@@ -100,10 +100,10 @@ class Listener
     }
 
     /**
-     * Handler for the "kernel.terminate" Symfony event. This event is subscribed to if the listener is configured to
-     * persist asynchronously.
+     * Handler for the "kernel.terminate" and "console.terminate" Symfony events.
+     * These event are subscribed to if the listener is configured to persist asynchronously.
      */
-    public function onKernelTerminate()
+    public function onTerminate()
     {
         if ($this->config['defer']) {
             $this->config['defer'] = false;

--- a/Resources/doc/types.md
+++ b/Resources/doc/types.md
@@ -329,7 +329,7 @@ You can also choose to only listen for some of the events:
 You can also tell ElasticaBundle to update the indexes after Symfony response has returned.
 This is useful when you want your responses to return quickly and not be slowed down by round
 trips to your Elasticsearch instance. All updates to Elasticsearch will be batched up and
-only fire after the `kernel.terminate` event.
+only fire after the `kernel.terminate` and `console.terminate` events.
 
 ```yaml
                     persistence:

--- a/Tests/Doctrine/AbstractListenerTest.php
+++ b/Tests/Doctrine/AbstractListenerTest.php
@@ -212,7 +212,7 @@ abstract class ListenerTest extends \PHPUnit_Framework_TestCase
         $refScheduledForInsertion->setValue($listener, $scheduledForInsertion);
         $persister->expects($this->once())->method('insertMany')->with($scheduledForInsertion);
 
-        $listener->onKernelTerminate();
+        $listener->onTerminate();
     }
 
     abstract protected function getLifecycleEventArgsClass();


### PR DESCRIPTION
This PR improves https://github.com/FriendsOfSymfony/FOSElasticaBundle/pull/878, by also subscribing to the `console.terminate` event, in order to handle entities persisted in CLI commands.