### PR TITLE
Convert identifierValue to string if it is an object during deletion

### DIFF
--- a/Doctrine/Listener.php
+++ b/Doctrine/Listener.php
@@ -190,7 +190,7 @@ class Listener
     private function scheduleForDeletion($object)
     {
         if ($identifierValue = $this->propertyAccessor->getValue($object, $this->config['identifier'])) {
-            $this->scheduledForDeletion[] = $identifierValue;
+            $this->scheduledForDeletion[] = is_object($identifierValue) ? (string) $identifierValue : $identifierValue;
         }
     }
 


### PR DESCRIPTION
This should address the problem of using a ValueObject as an ID. 
It will only convert the value to string if the value is object.