### PR TITLE
Added an ssl key to the DependecyInjection config

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -131,6 +131,7 @@ class Configuration implements ConfigurationInterface
                                         ->scalarNode('aws_secret_access_key')->end()
                                         ->scalarNode('aws_region')->end()
                                         ->scalarNode('aws_session_token')->end()
+                                        ->booleanNode('ssl')->defaultValue(false)->end()
                                         ->scalarNode('logger')
                                             ->defaultValue($this->debug ? 'fos_elastica.logger' : false)
                                             ->treatNullLike('fos_elastica.logger')

--- a/Tests/DependencyInjection/ConfigurationTest.php
+++ b/Tests/DependencyInjection/ConfigurationTest.php
@@ -306,6 +306,7 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
                     'aws_secret_access_key' => 'AWS_SECRET',
                     'aws_region' => 'AWS_REGION',
                     'aws_session_token' => 'AWS_SESSION_TOKEN',
+                    'ssl' => true
                 ],
             ],
         ]);
@@ -315,5 +316,6 @@ class ConfigurationTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('AWS_SECRET', $connection['aws_secret_access_key']);
         $this->assertSame('AWS_REGION', $connection['aws_region']);
         $this->assertSame('AWS_SESSION_TOKEN', $connection['aws_session_token']);
+        $this->assertTrue($connection['ssl']);
     }
 }


### PR DESCRIPTION
When trying to set up the `AwsAuthV4` transport to use port 443 I found this block of code in the underlying Elastica class:
https://github.com/ruflin/Elastica/blob/master/lib/Elastica/Transport/AwsAuthV4.php#L77

I couldn't find anywhere to be able to define the `ssl` config that it was looking for, this PR adds that to a connection in the same way all of the AWS_* config is set.

If it's just a case of me missing where to set up this config, please point me in the right direction :D