### PR TITLE
Improve populate command performances

### DIFF
--- a/Doctrine/ORM/SliceFetcher.php
+++ b/Doctrine/ORM/SliceFetcher.php
@@ -22,6 +22,9 @@ use FOS\ElasticaBundle\Exception\InvalidArgumentTypeException;
  */
 class SliceFetcher implements SliceFetcherInterface
 {
+    /** @var int $lastId */
+    private $lastId = 0;
+
     /**
      * This method should remain in sync with Provider::fetchSlice until that method is deprecated and
      * removed.
@@ -34,6 +37,8 @@ class SliceFetcher implements SliceFetcherInterface
             throw new InvalidArgumentTypeException($queryBuilder, 'Doctrine\ORM\QueryBuilder');
         }
 
+        $rootAlias = $queryBuilder->getRootAliases()[0];
+
         /*
          * An orderBy DQL  part is required to avoid feching the same row twice.
          * @see http://stackoverflow.com/questions/6314879/does-limit-offset-length-require-order-by-for-pagination
@@ -42,18 +47,20 @@ class SliceFetcher implements SliceFetcherInterface
          */
         $orderBy = $queryBuilder->getDQLPart('orderBy');
         if (empty($orderBy)) {
-            $rootAliases = $queryBuilder->getRootAliases();
-
             foreach ($identifierFieldNames as $fieldName) {
-                $queryBuilder->addOrderBy($rootAliases[0].'.'.$fieldName);
+                $queryBuilder->addOrderBy("$rootAlias.$fieldName");
             }
         }
 
-        return $queryBuilder
-            ->setFirstResult($offset)
+        $results = $queryBuilder
+            ->where("$rootAlias.id > $this->lastId")
             ->setMaxResults($limit)
             ->getQuery()
             ->getResult()
         ;
+
+        $this->lastId = (end($results))->getId();
+        reset($results);
+        return $results;
     }
 }


### PR DESCRIPTION
Using the offset in the slice fetcher makes it hard
when it comes to huge volumes of data (like 100k indexes).

This modification intend to use the last item id instead of the offset.

I ran the populate command on **100K** indexes. Here are the results I got: 
- With the use of offset: **1 minute and 10 seconds**
- With this fix: **40 seconds**

We ran this fix on our pre-production environment (**1893337** indexes):
- Without the fix: **~4 hours**
- With the fix: **12 minutes and 5 seconds**