### PR TITLE
Fix call to twig templates with Symfony 3.3

### DIFF
--- a/Resources/config/config.xml
+++ b/Resources/config/config.xml
@@ -24,7 +24,7 @@
         </service>
 
         <service id="fos_elastica.data_collector" class="FOS\ElasticaBundle\DataCollector\ElasticaDataCollector">
-            <tag name="data_collector" template="FOSElasticaBundle:Collector:elastica" id="elastica" />
+            <tag name="data_collector" template="FOSElastica/Collector/elastica.html.twig" id="elastica" />
             <argument type="service" id="fos_elastica.logger" />
         </service>
 

--- a/Resources/views/Collector/elastica.html.twig
+++ b/Resources/views/Collector/elastica.html.twig
@@ -1,4 +1,4 @@
-{% extends 'WebProfilerBundle:Profiler:layout.html.twig' %}
+{% extends '@WebProfiler/Profiler/layout.html.twig' %}
 
 {% block toolbar %}
     {% set profiler_markup_version = profiler_markup_version|default(1) %}
@@ -36,7 +36,7 @@
             <span>{{ '%0.2f'|format(collector.executionTime) }} ms</span>
         </div>
     {% endset %}
-    {% include 'WebProfilerBundle:Profiler:toolbar_item.html.twig' with { 'link': profiler_url } %}
+    {% include '@WebProfiler/Profiler/toolbar_item.html.twig' with { 'link': profiler_url } %}
 {% endblock %}
 
 {% block menu %}


### PR DESCRIPTION
Hi,

This is a PR to make compatible with Symfony 3.3 the call of twig templates.

Without this PR, web debug toolbar throw this exception : "The profiler template "FOSElasticaBundle:Collector:elastica.html.twig" for data collector "elastica" does not exist."