### PR TITLE
Implement reset method in ElasticaDataCollector

### DIFF
--- a/DataCollector/ElasticaDataCollector.php
+++ b/DataCollector/ElasticaDataCollector.php
@@ -91,4 +91,12 @@ class ElasticaDataCollector extends DataCollector
     {
         return 'elastica';
     }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function reset()
+    {
+        $this->data = [];
+    }
 }


### PR DESCRIPTION
Since Symfony 3.4 class that implement DataColelctorInterface should have the reset() method.

Fix the issue #1291
