### PR TITLE
Cast identifier to string in Transformer and Doctrine listener

### DIFF
--- a/Doctrine/Listener.php
+++ b/Doctrine/Listener.php
@@ -222,7 +222,12 @@ class Listener
      */
     private function scheduleForDeletion($object)
     {
-        if ($identifierValue = $this->propertyAccessor->getValue($object, $this->config['identifier'])) {
+        $identifierValue = $this->propertyAccessor->getValue($object, $this->config['identifier']);
+        if ($identifierValue && !is_scalar($identifierValue)) {
+            $identifierValue = (string) $identifierValue;
+        }
+
+        if ($identifierValue) {
             $this->scheduledForDeletion[] = $identifierValue;
         }
     }

--- a/Tests/Transformer/ModelToElasticaAutoTransformerTest.php
+++ b/Tests/Transformer/ModelToElasticaAutoTransformerTest.php
@@ -201,7 +201,7 @@ class ModelToElasticaAutoTransformerTest extends \PHPUnit_Framework_TestCase
         $data = $document->getData();
 
         $this->assertInstanceOf('Elastica\Document', $document);
-        $this->assertSame(123, (int) $document->getId());
+        $this->assertSame(123, $document->getId());
         $this->assertSame('someName', $data['name']);
     }
 
@@ -220,7 +220,7 @@ class ModelToElasticaAutoTransformerTest extends \PHPUnit_Framework_TestCase
         $data = $document->getData();
 
         $this->assertInstanceOf('Elastica\Document', $document);
-        $this->assertSame(123, (int) $document->getId());
+        $this->assertSame(123, $document->getId());
         $this->assertSame('someName', $data['name']);
         $this->assertSame(7.2, $data['float']);
         $this->assertTrue($data['bool']);

--- a/Tests/Transformer/ModelToElasticaAutoTransformerTest.php
+++ b/Tests/Transformer/ModelToElasticaAutoTransformerTest.php
@@ -201,7 +201,7 @@ class ModelToElasticaAutoTransformerTest extends \PHPUnit_Framework_TestCase
         $data = $document->getData();
 
         $this->assertInstanceOf('Elastica\Document', $document);
-        $this->assertSame(123, $document->getId());
+        $this->assertSame(123, (int) $document->getId());
         $this->assertSame('someName', $data['name']);
     }
 
@@ -220,7 +220,7 @@ class ModelToElasticaAutoTransformerTest extends \PHPUnit_Framework_TestCase
         $data = $document->getData();
 
         $this->assertInstanceOf('Elastica\Document', $document);
-        $this->assertSame(123, $document->getId());
+        $this->assertSame(123, (int) $document->getId());
         $this->assertSame('someName', $data['name']);
         $this->assertSame(7.2, $data['float']);
         $this->assertTrue($data['bool']);

--- a/Tests/Transformer/ModelToElasticaAutoTransformerTest.php
+++ b/Tests/Transformer/ModelToElasticaAutoTransformerTest.php
@@ -540,6 +540,20 @@ class ModelToElasticaAutoTransformerTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('bar', $data['unmappedValue']);
     }
 
+    public function testIdentifierIsCastedToString()
+    {
+        $idObject = new CastableObject();;
+        $idObject->foo = '00000000-0000-0000-0000-000000000000';
+
+        $object = new \stdClass();
+        $object->id = $idObject;
+
+        $transformer = $this->getTransformer();
+        $document = $transformer->transform($object, []);
+
+        $this->assertSame('string', gettype($document->getId()));
+    }
+
     /**
      * @param null|\Symfony\Component\EventDispatcher\EventDispatcherInterface $dispatcher
      *

--- a/Transformer/ModelToElasticaAutoTransformer.php
+++ b/Transformer/ModelToElasticaAutoTransformer.php
@@ -76,7 +76,11 @@ class ModelToElasticaAutoTransformer implements ModelToElasticaTransformerInterf
      **/
     public function transform($object, array $fields)
     {
-        $identifier = (string) $this->propertyAccessor->getValue($object, $this->options['identifier']);
+        $identifier = $this->propertyAccessor->getValue($object, $this->options['identifier']);
+        if ($identifier && !is_scalar($identifier)) {
+            $identifier = (string) $identifier;
+        }
+
         $document = $this->transformObjectToDocument($object, $fields, $identifier);
 
         return $document;

--- a/Transformer/ModelToElasticaAutoTransformer.php
+++ b/Transformer/ModelToElasticaAutoTransformer.php
@@ -76,7 +76,7 @@ class ModelToElasticaAutoTransformer implements ModelToElasticaTransformerInterf
      **/
     public function transform($object, array $fields)
     {
-        $identifier = $this->propertyAccessor->getValue($object, $this->options['identifier']);
+        $identifier = (string) $this->propertyAccessor->getValue($object, $this->options['identifier']);
         $document = $this->transformObjectToDocument($object, $fields, $identifier);
 
         return $document;


### PR DESCRIPTION
While #1067 solved issues when using value objects as the ID for the `AbstractElasticaToModelTransformer`, the `ModelToElasticaAutoTransformer` has a similar issue when an object is used as the model's ID.

This results in an object as the document's `_id` parameter instead of its value, which then causes the following when populating indexes:
```
[Elastica\Exception\ResponseException]
Malformed action/metadata line [1], expected a simple value for field [_id] but found [START_OBJECT]
```

This PR fixes this behavior by casting the model's identifier to a string. The `Document` then transforms correctly to:

```
array:1 [
  0 => Elastica\Document {#962
    #_data: array:1 [
      "firstname" => "Vic"
    ]
    #_docAsUpsert: false
    #_autoPopulate: false
    #_upsert: null
    #_params: array:3 [
      "_id" => "00000000-0000-0000-0000-000000000000"
      "_type" => ""
      "_index" => ""
    ]
    #_rawParams: []
  }
]
```

Unit test is included.