### PR TITLE
add post async insert objects event

### DIFF
--- a/Command/PopulateCommand.php
+++ b/Command/PopulateCommand.php
@@ -9,6 +9,7 @@ use FOS\ElasticaBundle\Index\IndexManager;
 use FOS\ElasticaBundle\Index\Resetter;
 use FOS\ElasticaBundle\Persister\Event\Events;
 use FOS\ElasticaBundle\Persister\Event\OnExceptionEvent;
+use FOS\ElasticaBundle\Persister\Event\PostAsyncInsertObjectsEvent;
 use FOS\ElasticaBundle\Persister\Event\PostInsertObjectsEvent;
 use FOS\ElasticaBundle\Persister\PagerPersisterInterface;
 use FOS\ElasticaBundle\Provider\PagerProviderRegistry;
@@ -212,6 +213,13 @@ class PopulateCommand extends ContainerAwareCommand
                     Events::POST_INSERT_OBJECTS,
                     function(PostInsertObjectsEvent $event) use ($loggerClosure) {
                         $loggerClosure(count($event->getObjects()), $event->getPager()->getNbResults());
+                    }
+                );
+
+                $this->dispatcher->addListener(
+                    Events::POST_ASYNC_INSERT_OBJECTS,
+                    function(PostAsyncInsertObjectsEvent $event) use ($loggerClosure) {
+                        $loggerClosure($event->getObjectsCount(), $event->getPager()->getNbResults(), $event->getErrorMessage());
                     }
                 );
             }

--- a/Persister/Event/Events.php
+++ b/Persister/Event/Events.php
@@ -11,6 +11,8 @@ final class Events
 
     const POST_INSERT_OBJECTS = 'elastica.pager_persister.post_insert_objects';
 
+    const POST_ASYNC_INSERT_OBJECTS = 'elastica.pager_persister.post_async_insert_objects';
+
     const ON_EXCEPTION = 'elastica.pager_persister.on_exception';
 
     const POST_PERSIST = 'elastica.pager_persister.post_persist';

--- a/Persister/Event/PostAsyncInsertObjectsEvent.php
+++ b/Persister/Event/PostAsyncInsertObjectsEvent.php
@@ -1,0 +1,83 @@
+<?php
+namespace FOS\ElasticaBundle\Persister\Event;
+
+use FOS\ElasticaBundle\Persister\ObjectPersisterInterface;
+use FOS\ElasticaBundle\Provider\PagerInterface;
+use Symfony\Component\EventDispatcher\Event;
+
+final class PostAsyncInsertObjectsEvent extends Event implements PersistEvent
+{
+    /**
+     * @var PagerInterface
+     */
+    private $pager;
+
+    /**
+     * @var ObjectPersisterInterface
+     */
+    private $objectPersister;
+
+    /**
+     * @var int
+     */
+    private $objectsCount;
+
+    /**
+     * @var string|null
+     */
+    private $errorMessage;
+
+    /**
+     * @var array
+     */
+    private $options;
+
+    public function __construct(PagerInterface $pager, ObjectPersisterInterface $objectPersister, $objectsCount, $errorMessage, array $options)
+    {
+        $this->pager = $pager;
+        $this->objectPersister = $objectPersister;
+        $this->objectsCount = $objectsCount;
+        $this->errorMessage = $errorMessage;
+        $this->options = $options;
+    }
+
+    /**
+     * @return PagerInterface
+     */
+    public function getPager()
+    {
+        return $this->pager;
+    }
+
+    /**
+     * @return array
+     */
+    public function getOptions()
+    {
+        return $this->options;
+    }
+
+    /**
+     * @return ObjectPersisterInterface
+     */
+    public function getObjectPersister()
+    {
+        return $this->objectPersister;
+    }
+
+    /**
+     * @return null|string
+     */
+    public function getErrorMessage()
+    {
+        return $this->errorMessage;
+    }
+
+    /**
+     * @return int
+     */
+    public function getObjectsCount()
+    {
+        return $this->objectsCount;
+    }
+}

--- a/Tests/Persister/Event/PostAsyncInsertObjectsEventTest.php
+++ b/Tests/Persister/Event/PostAsyncInsertObjectsEventTest.php
@@ -1,0 +1,104 @@
+<?php
+namespace FOS\ElasticaBundle\Tests\Persister\Event;
+
+use FOS\ElasticaBundle\Persister\Event\PersistEvent;
+use FOS\ElasticaBundle\Persister\Event\PostAsyncInsertObjectsEvent;
+use FOS\ElasticaBundle\Persister\ObjectPersisterInterface;
+use FOS\ElasticaBundle\Provider\PagerInterface;
+use Symfony\Component\EventDispatcher\Event;
+
+final class PostAsyncInsertObjectsEventTest extends \PHPUnit_Framework_TestCase
+{
+    public function testShouldBeSubClassOfEventClass()
+    {
+        $rc = new \ReflectionClass(PostAsyncInsertObjectsEvent::class);
+
+        $this->assertTrue($rc->isSubclassOf(Event::class));
+    }
+
+    public function testShouldImplementPersistEventInterface()
+    {
+        $rc = new \ReflectionClass(PostAsyncInsertObjectsEvent::class);
+
+        $this->assertTrue($rc->implementsInterface(PersistEvent::class));
+    }
+
+    public function testShouldFinal()
+    {
+        $rc = new \ReflectionClass(PostAsyncInsertObjectsEvent::class);
+
+        $this->assertTrue($rc->isFinal());
+    }
+
+    public function testCouldBeConstructedWithPagerAndObjectPersisterAndObjectsCountAndOptions()
+    {
+        new PostAsyncInsertObjectsEvent(
+            $this->createPagerMock(),
+            $this->createObjectPersisterMock(),
+            123,
+            $errorMessage = '',
+            $options = []
+        );
+    }
+
+    public function testShouldAllowGetPagerSetInConstructor()
+    {
+        $expectedPager = $this->createPagerMock();
+
+        $event = new PostAsyncInsertObjectsEvent($expectedPager, $this->createObjectPersisterMock(), 123, '', []);
+
+        $this->assertSame($expectedPager, $event->getPager());
+    }
+
+    public function testShouldAllowGetObjectPersisterSetInConstructor()
+    {
+        $expectedPersister = $this->createObjectPersisterMock();
+
+        $event = new PostAsyncInsertObjectsEvent($this->createPagerMock(), $expectedPersister, 123, '', []);
+
+        $this->assertSame($expectedPersister, $event->getObjectPersister());
+    }
+
+    public function testShouldAllowGetOptionsSetInConstructor()
+    {
+        $expectedOptions = ['foo' => 'fooVal', 'bar' => 'barVal'];
+
+        $event = new PostAsyncInsertObjectsEvent($this->createPagerMock(), $this->createObjectPersisterMock(), 123, '', $expectedOptions);
+
+        $this->assertSame($expectedOptions, $event->getOptions());
+    }
+
+    public function testShouldAllowGetObjectsSetInConstructor()
+    {
+        $expectedObjectsCount = 321;
+
+        $event = new PostAsyncInsertObjectsEvent($this->createPagerMock(), $this->createObjectPersisterMock(), $expectedObjectsCount, '', []);
+
+        $this->assertSame($expectedObjectsCount, $event->getObjectsCount());
+    }
+
+    public function testShouldAllowGetErrorMessageSetInConstructor()
+    {
+        $expectedErrorMessage = 'theErrorMessage';
+
+        $event = new PostAsyncInsertObjectsEvent($this->createPagerMock(), $this->createObjectPersisterMock(), [], 'theErrorMessage', []);
+
+        $this->assertSame($expectedErrorMessage, $event->getErrorMessage());
+    }
+
+    /**
+     * @return ObjectPersisterInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private function createObjectPersisterMock()
+    {
+        return $this->getMock(ObjectPersisterInterface::class, [], [], '', false);
+    }
+
+    /**
+     * @return PagerInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private function createPagerMock()
+    {
+        return $this->getMock(PagerInterface::class, [], [], '', false);
+    }
+}


### PR DESCRIPTION
The event should be used by async pager persisters that do not fetch objects itself but delegate it to some workers or so. 