### PR TITLE
Cast identifier to string

### DIFF
--- a/CHANGELOG-4.0.md
+++ b/CHANGELOG-4.0.md
@@ -12,6 +12,7 @@ in 4.0 versions.
 * Add new options to populate command: --first-page, last-page, --max-per-page. They work only if you use v5 providers API.
 * Deprecate some options of populate command: --batch-size and --offset.
 * Deprecate Propel support
+* Cast value objects used as identifier in Elasticsearch to string
 
 ### 4.0.1 (2017-08-10)
 

--- a/Doctrine/Listener.php
+++ b/Doctrine/Listener.php
@@ -189,13 +189,8 @@ class Listener
      */
     private function scheduleForDeletion($object)
     {
-        $identifierValue = $this->propertyAccessor->getValue($object, $this->config['identifier']);
-        if ($identifierValue && !is_scalar($identifierValue)) {
-            $identifierValue = (string) $identifierValue;
-        }
-
-        if ($identifierValue) {
-            $this->scheduledForDeletion[] = $identifierValue;
+        if ($identifierValue = $this->propertyAccessor->getValue($object, $this->config['identifier'])) {
+            $this->scheduledForDeletion[] = !is_scalar($identifierValue) ? (string) $identifierValue : $identifierValue;
         }
     }
 

--- a/Doctrine/Listener.php
+++ b/Doctrine/Listener.php
@@ -189,7 +189,12 @@ class Listener
      */
     private function scheduleForDeletion($object)
     {
-        if ($identifierValue = $this->propertyAccessor->getValue($object, $this->config['identifier'])) {
+        $identifierValue = $this->propertyAccessor->getValue($object, $this->config['identifier']);
+        if ($identifierValue && !is_scalar($identifierValue)) {
+            $identifierValue = (string) $identifierValue;
+        }
+
+        if ($identifierValue) {
             $this->scheduledForDeletion[] = $identifierValue;
         }
     }

--- a/Tests/Transformer/ModelToElasticaAutoTransformerTest.php
+++ b/Tests/Transformer/ModelToElasticaAutoTransformerTest.php
@@ -542,7 +542,7 @@ class ModelToElasticaAutoTransformerTest extends \PHPUnit_Framework_TestCase
         $transformer = $this->getTransformer();
         $document = $transformer->transform($object, []);
 
-        $this->assertSame('string', gettype($document->getId()));
+        $this->assertSame('00000000-0000-0000-0000-000000000000', $document->getId());
     }
 
     /**

--- a/Tests/Transformer/ModelToElasticaAutoTransformerTest.php
+++ b/Tests/Transformer/ModelToElasticaAutoTransformerTest.php
@@ -531,6 +531,20 @@ class ModelToElasticaAutoTransformerTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('bar', $data['unmappedValue']);
     }
 
+    public function testIdentifierIsCastedToString()
+    {
+        $idObject = new CastableObject();;
+        $idObject->foo = '00000000-0000-0000-0000-000000000000';
+
+        $object = new \stdClass();
+        $object->id = $idObject;
+
+        $transformer = $this->getTransformer();
+        $document = $transformer->transform($object, []);
+
+        $this->assertSame('string', gettype($document->getId()));
+    }
+
     /**
      * @param null|\Symfony\Component\EventDispatcher\EventDispatcherInterface $dispatcher
      *

--- a/Transformer/ModelToElasticaAutoTransformer.php
+++ b/Transformer/ModelToElasticaAutoTransformer.php
@@ -67,7 +67,11 @@ class ModelToElasticaAutoTransformer implements ModelToElasticaTransformerInterf
      **/
     public function transform($object, array $fields)
     {
-        $identifier = (string) $this->propertyAccessor->getValue($object, $this->options['identifier']);
+        $identifier = $this->propertyAccessor->getValue($object, $this->options['identifier']);
+        if ($identifier && !is_scalar($identifier)) {
+            $identifier = (string) $identifier;
+        }
+
         $document = $this->transformObjectToDocument($object, $fields, $identifier);
 
         return $document;


### PR DESCRIPTION
Rebased #1327 against 4.x. Will then merge 4.x into master.

When we add scalar type declarations in the future, this is what would happen implicitly anyway.
And it is concistent with #1067