### PR TITLE
remove outdated elasticsearch doc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,6 +31,9 @@ matrix:
     - php: 7.2
       env: SYMFONY_VERSION="^3"
 
+before_install:
+  - if [[ $COVERAGE != true ]]; then phpenv config-rm xdebug.ini || true; fi
+
 install:
   # To be removed when this issue will be resolved: https://github.com/composer/composer/issues/5355
   - if [[ "$COMPOSER_FLAGS" == *"--prefer-lowest"* ]]; then composer update --prefer-dist --no-interaction --prefer-stable --quiet; fi

--- a/doc/setup.md
+++ b/doc/setup.md
@@ -48,9 +48,7 @@ C: Basic Bundle Configuration
 -----------------------------
 
 The basic minimal configuration for FOSElasticaBundle is one client with one Elasticsearch
-index. In almost all cases, an application will only need a single index. An index can
-be considered comparable to a Doctrine Entity Manager, where the index will hold multiple
-type definitions.
+index.
 
 ```yaml
 #app/config/config.yml


### PR DESCRIPTION
- types and indexes difference is removed with ES 6
- also disable xdebug when not using coverage