### PR TITLE
Replace mongodb reqs to doctrine_mongodb for pager service

### DIFF
--- a/src/Resources/config/mongodb.xml
+++ b/src/Resources/config/mongodb.xml
@@ -8,7 +8,7 @@
         <defaults public="false" />
 
         <service id="fos_elastica.pager_provider.prototype.mongodb" class="FOS\ElasticaBundle\Doctrine\MongoDBPagerProvider" public="true" abstract="true">
-            <argument type="service" id="doctrine" /> <!-- manager registry -->
+            <argument type="service" id="doctrine_mongodb" /> <!-- manager registry -->
             <argument type="service" id="fos_elastica.doctrine.register_listeners" />
             <argument /> <!-- model -->
             <argument type="collection" /> <!-- options -->


### PR DESCRIPTION
This PR patch #1375 issue on 5.* tag.

More info in #1375.

```
    [Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException]     
    The service "fos_elastica.pager_provider.app.user" has a dependency on     
    a non-existent service "doctrine". 
```