### PR TITLE
Change minimum php version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         { "name": "Jeremy Mikola", "email": "jmikola@gmail.com" }
     ],
     "require": {
-        "php": ">=5.6.0",
+        "php": "^5.6.0|^7.0",
         "symfony/framework-bundle": "^3.2|^4",
         "symfony/console": "^3.2|^4",
         "symfony/dependency-injection": "^3.3|^4",


### PR DESCRIPTION
Small fix to be more consistent with semantic versioning. We cannot be 100% sure, that this bundle will work with php 8