### PR TITLE
Added usage documentation on how to pass general ES query parameters.

### DIFF
--- a/doc/usage.md
+++ b/doc/usage.md
@@ -46,6 +46,15 @@ $options = [
 $pagination = $paginator->paginate($results, $page, 10, $options);
 ```
 
+When searching with a finder, parameters can be passed which influence the Elasticsearch query in general.
+
+For example, the `search_type` parameter (see [the Elasticsearch documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-search-type.html))
+can be set as follows:
+
+```php
+$results = $finder->findHybrid('example.net', null, ['search_type' => 'dfs_query_then_fetch']);
+```
+
 Aggregations
 -----------------
 


### PR DESCRIPTION
I had a hard time finding out exactly where and how to pass ES query parameters - in my case, I needed to have `?search_type=dfs_query_then_fetch` added to the ES HTTP call, but couldn't find any hints in the docs.

I have added a paragraph to the usage chapter which should point people into the right direction.