### PR TITLE
Fix support for decorating persister services

### DIFF
--- a/src/DependencyInjection/Compiler/RegisterPagerPersistersPass.php
+++ b/src/DependencyInjection/Compiler/RegisterPagerPersistersPass.php
@@ -47,10 +47,10 @@ final class RegisterPagerPersistersPass implements CompilerPassInterface
                 }
 
                 $persisterDef = $container->getDefinition($id);
-                if (!$persisterDef->getFactory()) {
+                if (!$persisterDef->getFactory() && $persisterDef->getClass()) {
                     // You are on your own if you use a factory to create a persister.
                     // It would fail in runtime if the factory does not return a proper persister.
-                    $this->assertClassImplementsPagerPersisterInterface($id, $persisterDef->getClass());
+                    $this->assertClassImplementsPagerPersisterInterface($id, $container->getParameterBag()->resolveValue($persisterDef->getClass()));
                 }
 
                 $nameToServiceIdMap[$persisterName] = $id;

--- a/src/DependencyInjection/Compiler/RegisterPagerPersistersPass.php
+++ b/src/DependencyInjection/Compiler/RegisterPagerPersistersPass.php
@@ -29,7 +29,7 @@ final class RegisterPagerPersistersPass implements CompilerPassInterface
         $registry = $container->getDefinition('fos_elastica.pager_persister_registry');
 
         $nameToServiceIdMap = [];
-        foreach ($container->findTaggedServiceIds('fos_elastica.pager_persister') as $id => $attributes) {
+        foreach ($container->findTaggedServiceIds('fos_elastica.pager_persister', true) as $id => $attributes) {
             foreach ($attributes as $attribute) {
                 if (!isset($attribute['persisterName'])) {
                     throw new \InvalidArgumentException(sprintf('Elastica pager persister "%s" must specify the "persisterName" attribute.', $id));
@@ -51,6 +51,10 @@ final class RegisterPagerPersistersPass implements CompilerPassInterface
                     // You are on your own if you use a factory to create a persister.
                     // It would fail in runtime if the factory does not return a proper persister.
                     $this->assertClassImplementsPagerPersisterInterface($id, $container->getParameterBag()->resolveValue($persisterDef->getClass()));
+                }
+
+                if (!$persisterDef->isPublic()) {
+                    throw new \InvalidArgumentException(sprintf('Elastica pager persister "%s" must be a public service', $id));
                 }
 
                 $nameToServiceIdMap[$persisterName] = $id;

--- a/src/DependencyInjection/Compiler/RegisterPagerProvidersPass.php
+++ b/src/DependencyInjection/Compiler/RegisterPagerProvidersPass.php
@@ -50,10 +50,10 @@ final class RegisterPagerProvidersPass implements CompilerPassInterface
                 }
 
                 $providerDef = $container->getDefinition($id);
-                if (!$providerDef->getFactory()) {
+                if (!$providerDef->getFactory() && $providerDef->getClass()) {
                     // You are on your own if you use a factory to create a provider.
                     // It would fail in runtime if the factory does not return a proper provider.
-                    $this->assertClassImplementsPagerProviderInterface($id, $providerDef->getClass());
+                    $this->assertClassImplementsPagerProviderInterface($id, $container->getParameterBag()->resolveValue($providerDef->getClass()));
                 }
 
                 $registeredProviders[$index][$type] = $id;

--- a/src/DependencyInjection/Compiler/RegisterPagerProvidersPass.php
+++ b/src/DependencyInjection/Compiler/RegisterPagerProvidersPass.php
@@ -30,7 +30,7 @@ final class RegisterPagerProvidersPass implements CompilerPassInterface
         $registry = $container->getDefinition('fos_elastica.pager_provider_registry');
 
         $registeredProviders = [];
-        foreach ($container->findTaggedServiceIds('fos_elastica.pager_provider') as $id => $attributes) {
+        foreach ($container->findTaggedServiceIds('fos_elastica.pager_provider', true) as $id => $attributes) {
             foreach ($attributes as $attribute) {
                 if (!isset($attribute['type'])) {
                     throw new \InvalidArgumentException(sprintf('Elastica provider "%s" must specify the "type" attribute.', $id));
@@ -54,6 +54,10 @@ final class RegisterPagerProvidersPass implements CompilerPassInterface
                     // You are on your own if you use a factory to create a provider.
                     // It would fail in runtime if the factory does not return a proper provider.
                     $this->assertClassImplementsPagerProviderInterface($id, $container->getParameterBag()->resolveValue($providerDef->getClass()));
+                }
+
+                if (!$providerDef->isPublic()) {
+                    throw new \InvalidArgumentException(sprintf('Elastica persister "%s" must be a public service', $id));
                 }
 
                 $registeredProviders[$index][$type] = $id;

--- a/src/DependencyInjection/Compiler/RegisterPersistersPass.php
+++ b/src/DependencyInjection/Compiler/RegisterPersistersPass.php
@@ -30,7 +30,7 @@ final class RegisterPersistersPass implements CompilerPassInterface
         $registry = $container->getDefinition('fos_elastica.persister_registry');
 
         $registeredPersisters = [];
-        foreach ($container->findTaggedServiceIds('fos_elastica.persister') as $id => $attributes) {
+        foreach ($container->findTaggedServiceIds('fos_elastica.persister', true) as $id => $attributes) {
             foreach ($attributes as $attribute) {
                 if (!isset($attribute['type'])) {
                     throw new \InvalidArgumentException(sprintf('Elastica persister "%s" must specify the "type" attribute.', $id));
@@ -54,6 +54,10 @@ final class RegisterPersistersPass implements CompilerPassInterface
                     // You are on your own if you use a factory to create a persister.
                     // It would fail in runtime if the factory does not return a proper persister.
                     $this->assertClassImplementsPersisterInterface($id, $container->getParameterBag()->resolveValue($persisterDef->getClass()));
+                }
+
+                if (!$persisterDef->isPublic()) {
+                    throw new \InvalidArgumentException(sprintf('Elastica persister "%s" must be a public service', $id));
                 }
 
                 $registeredPersisters[$index][$type] = $id;

--- a/src/DependencyInjection/Compiler/RegisterPersistersPass.php
+++ b/src/DependencyInjection/Compiler/RegisterPersistersPass.php
@@ -50,10 +50,10 @@ final class RegisterPersistersPass implements CompilerPassInterface
                 }
 
                 $persisterDef = $container->getDefinition($id);
-                if (!$persisterDef->getFactory()) {
+                if (!$persisterDef->getFactory() && $persisterDef->getClass()) {
                     // You are on your own if you use a factory to create a persister.
                     // It would fail in runtime if the factory does not return a proper persister.
-                    $this->assertClassImplementsPersisterInterface($id, $persisterDef->getClass());
+                    $this->assertClassImplementsPersisterInterface($id, $container->getParameterBag()->resolveValue($persisterDef->getClass()));
                 }
 
                 $registeredPersisters[$index][$type] = $id;

--- a/src/FOSElasticaBundle.php
+++ b/src/FOSElasticaBundle.php
@@ -18,7 +18,6 @@ use FOS\ElasticaBundle\DependencyInjection\Compiler\TransformerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use FOS\ElasticaBundle\DependencyInjection\Compiler\RegisterPagerProvidersPass;
 use FOS\ElasticaBundle\DependencyInjection\Compiler\RegisterPersistersPass;
-use Symfony\Component\DependencyInjection\Compiler\PassConfig;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class FOSElasticaBundle extends Bundle
@@ -32,8 +31,8 @@ class FOSElasticaBundle extends Bundle
 
         $container->addCompilerPass(new ConfigSourcePass());
         $container->addCompilerPass(new IndexPass());
-        $container->addCompilerPass(new RegisterPagerProvidersPass(), PassConfig::TYPE_BEFORE_REMOVING);
-        $container->addCompilerPass(new RegisterPersistersPass(), PassConfig::TYPE_BEFORE_REMOVING);
+        $container->addCompilerPass(new RegisterPagerProvidersPass());
+        $container->addCompilerPass(new RegisterPersistersPass());
         $container->addCompilerPass(new RegisterPagerPersistersPass());
         $container->addCompilerPass(new TransformerPass());
     }


### PR DESCRIPTION
Waiting until the before_removing step to check for persisters breaks support for service decoration, as it has already been resolved at this point (and so the original id won't be used anymore to reference the service).
The only benefit was that the class was already resolved in case a parameter was used, but this is solved in a better way by resolving the value.

Note that decorating object persisters was working totally fine in version 3.x of the bundle (and yes, I have a project which is just migrating away from ES 1.7 now).