### PR TITLE
Remove bad duplicate license headers

### DIFF
--- a/src/Command/ProgressClosureBuilder.php
+++ b/src/Command/ProgressClosureBuilder.php
@@ -9,15 +9,6 @@
  * file that was distributed with this source code.
  */
 
-/**
- * This file is part of the FOSElasticaBundle project.
- *
- * (c) Tim Nagel <tim@nagel.com.au>
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace FOS\ElasticaBundle\Command;
 
 use Symfony\Component\Console\Helper\ProgressBar;

--- a/src/Configuration/ConfigManager.php
+++ b/src/Configuration/ConfigManager.php
@@ -9,15 +9,6 @@
  * file that was distributed with this source code.
  */
 
-/**
- * This file is part of the FOSElasticaBundle project.
- *
- * (c) Tim Nagel <tim@nagel.com.au>
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace FOS\ElasticaBundle\Configuration;
 
 /**

--- a/src/Configuration/ManagerInterface.php
+++ b/src/Configuration/ManagerInterface.php
@@ -9,15 +9,6 @@
  * file that was distributed with this source code.
  */
 
-/**
- * This file is part of the FOSElasticaBundle project.
- *
- * (c) Tim Nagel <tim@nagel.com.au>
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace FOS\ElasticaBundle\Configuration;
 
 /**

--- a/src/Configuration/Source/ContainerSource.php
+++ b/src/Configuration/Source/ContainerSource.php
@@ -9,15 +9,6 @@
  * file that was distributed with this source code.
  */
 
-/**
- * This file is part of the FOSElasticaBundle project.
- *
- * (c) Tim Nagel <tim@nagel.com.au>
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace FOS\ElasticaBundle\Configuration\Source;
 
 use FOS\ElasticaBundle\Configuration\IndexConfig;

--- a/src/Configuration/Source/SourceInterface.php
+++ b/src/Configuration/Source/SourceInterface.php
@@ -9,15 +9,6 @@
  * file that was distributed with this source code.
  */
 
-/**
- * This file is part of the FOSElasticaBundle project.
- *
- * (c) Tim Nagel <tim@nagel.com.au>
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace FOS\ElasticaBundle\Configuration\Source;
 
 /**

--- a/src/Configuration/TypeConfig.php
+++ b/src/Configuration/TypeConfig.php
@@ -9,15 +9,6 @@
  * file that was distributed with this source code.
  */
 
-/**
- * This file is part of the FOSElasticaBundle project.
- *
- * (c) Tim Nagel <tim@nagel.com.au>
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace FOS\ElasticaBundle\Configuration;
 
 class TypeConfig

--- a/src/DependencyInjection/Compiler/ConfigSourcePass.php
+++ b/src/DependencyInjection/Compiler/ConfigSourcePass.php
@@ -9,15 +9,6 @@
  * file that was distributed with this source code.
  */
 
-/**
- * This file is part of the FOSElasticaBundle project.
- *
- * (c) Tim Nagel <tim@nagel.com.au>
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace FOS\ElasticaBundle\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;

--- a/src/DependencyInjection/Compiler/IndexPass.php
+++ b/src/DependencyInjection/Compiler/IndexPass.php
@@ -9,15 +9,6 @@
  * file that was distributed with this source code.
  */
 
-/**
- * This file is part of the FOSElasticaBundle project.
- *
- * (c) Tim Nagel <tim@nagel.com.au>
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace FOS\ElasticaBundle\DependencyInjection\Compiler;
 
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;

--- a/src/Event/IndexEvent.php
+++ b/src/Event/IndexEvent.php
@@ -9,15 +9,6 @@
  * file that was distributed with this source code.
  */
 
-/**
- * This file is part of the FOSElasticaBundle project.
- *
- * (c) Tim Nagel <tim@nagel.com.au>
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace FOS\ElasticaBundle\Event;
 
 use Symfony\Component\EventDispatcher\Event;

--- a/src/Event/IndexPopulateEvent.php
+++ b/src/Event/IndexPopulateEvent.php
@@ -9,15 +9,6 @@
  * file that was distributed with this source code.
  */
 
-/**
- * This file is part of the FOSElasticaBundle project.
- *
- * (c) FriendsOfSymfony <https://github.com/FriendsOfSymfony/FOSElasticaBundle/graphs/contributors>
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace FOS\ElasticaBundle\Event;
 
 /**

--- a/src/Event/IndexResetEvent.php
+++ b/src/Event/IndexResetEvent.php
@@ -9,15 +9,6 @@
  * file that was distributed with this source code.
  */
 
-/**
- * This file is part of the FOSElasticaBundle project.
- *
- * (c) Infinite Networks Pty Ltd <http://www.infinite.net.au>
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace FOS\ElasticaBundle\Event;
 
 /**

--- a/src/Event/TransformEvent.php
+++ b/src/Event/TransformEvent.php
@@ -9,15 +9,6 @@
  * file that was distributed with this source code.
  */
 
-/**
- * This file is part of the FOSElasticaBundle project.
- *
- * (c) Infinite Networks Pty Ltd <http://www.infinite.net.au>
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace FOS\ElasticaBundle\Event;
 
 use Symfony\Component\EventDispatcher\Event;

--- a/src/Event/TypePopulateEvent.php
+++ b/src/Event/TypePopulateEvent.php
@@ -9,15 +9,6 @@
  * file that was distributed with this source code.
  */
 
-/**
- * This file is part of the FOSElasticaBundle project.
- *
- * (c) FriendsOfSymfony <https://github.com/FriendsOfSymfony/FOSElasticaBundle/graphs/contributors>
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace FOS\ElasticaBundle\Event;
 
 use Symfony\Component\EventDispatcher\Event;

--- a/src/Event/TypeResetEvent.php
+++ b/src/Event/TypeResetEvent.php
@@ -9,15 +9,6 @@
  * file that was distributed with this source code.
  */
 
-/**
- * This file is part of the FOSElasticaBundle project.
- *
- * (c) Infinite Networks Pty Ltd <http://www.infinite.net.au>
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace FOS\ElasticaBundle\Event;
 
 use Symfony\Component\EventDispatcher\Event;

--- a/src/Index/AliasProcessor.php
+++ b/src/Index/AliasProcessor.php
@@ -9,15 +9,6 @@
  * file that was distributed with this source code.
  */
 
-/**
- * This file is part of the FOSElasticaBundle project.
- *
- * (c) Infinite Networks Pty Ltd <http://www.infinite.net.au>
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace FOS\ElasticaBundle\Index;
 
 use Elastica\Client;

--- a/src/Index/MappingBuilder.php
+++ b/src/Index/MappingBuilder.php
@@ -9,15 +9,6 @@
  * file that was distributed with this source code.
  */
 
-/**
- * This file is part of the FOSElasticaBundle project.
- *
- * (c) Infinite Networks Pty Ltd <http://www.infinite.net.au>
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace FOS\ElasticaBundle\Index;
 
 use FOS\ElasticaBundle\Configuration\IndexConfig;

--- a/src/Provider/Indexable.php
+++ b/src/Provider/Indexable.php
@@ -9,15 +9,6 @@
  * file that was distributed with this source code.
  */
 
-/**
- * This file is part of the FOSElasticaBundle project.
- *
- * (c) FriendsOfSymfony <https://github.com/FriendsOfSymfony/FOSElasticaBundle/graphs/contributors>
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace FOS\ElasticaBundle\Provider;
 
 use Symfony\Component\ExpressionLanguage\Expression;

--- a/src/Provider/IndexableInterface.php
+++ b/src/Provider/IndexableInterface.php
@@ -9,15 +9,6 @@
  * file that was distributed with this source code.
  */
 
-/**
- * This file is part of the FOSElasticaBundle project.
- *
- * (c) Infinite Networks Pty Ltd <http://www.infinite.net.au>
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace FOS\ElasticaBundle\Provider;
 
 interface IndexableInterface

--- a/src/Transformer/AbstractElasticaToModelTransformer.php
+++ b/src/Transformer/AbstractElasticaToModelTransformer.php
@@ -9,15 +9,6 @@
  * file that was distributed with this source code.
  */
 
-/**
- * This file is part of the FOSElasticaBundle project.
- *
- * (c) FriendsOfSymfony <https://github.com/FriendsOfSymfony/FOSElasticaBundle/graphs/contributors>
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace FOS\ElasticaBundle\Transformer;
 
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;


### PR DESCRIPTION
All files have the right header (and PHP-CS-Fixer is configured to enforce it). But a bundle of files were holding a second header after it.