### PR TITLE
Fix pagination of ORM queries when populating

### DIFF
--- a/src/Doctrine/ORMPagerProvider.php
+++ b/src/Doctrine/ORMPagerProvider.php
@@ -12,6 +12,8 @@
 namespace FOS\ElasticaBundle\Doctrine;
 
 use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\ORM\Query\Expr\From;
+use Doctrine\ORM\QueryBuilder;
 use FOS\ElasticaBundle\Provider\PagerfantaPager;
 use FOS\ElasticaBundle\Provider\PagerProviderInterface;
 use Pagerfanta\Adapter\DoctrineORMAdapter;
@@ -65,10 +67,32 @@ final class ORMPagerProvider implements PagerProviderInterface
         $manager = $this->doctrine->getManagerForClass($this->objectClass);
         $repository = $manager->getRepository($this->objectClass);
 
-        $pager = new PagerfantaPager(new Pagerfanta(new DoctrineORMAdapter(call_user_func(
-            [$repository, $options['query_builder_method']],
-            self::ENTITY_ALIAS
-        ))));
+        $qb = \call_user_func([$repository, $options['query_builder_method']], self::ENTITY_ALIAS);
+
+        // Ensure that the query builder has a sorting configured. Without a ORDER BY clause, the SQL standard does not
+        // guarantee any order, which breaks the pagination (second page might use a different sorting that when retrieving
+        // the first page).
+        // If the QueryBuilder already has its own ordering, or the method returned a Query instead of a QueryBuilder, we
+        // assume that the query already provides a proper sorting. This allows giving full control over sorting if wanted
+        // when using a custom method.
+        if ($qb instanceof QueryBuilder && empty($qb->getDQLPart('orderBy'))) {
+            // When getting root aliases, the QueryBuilder normalizes all from parts to From objects, in case they were added as string using the low-level API.
+            // This side-effect allows us to be sure to get only From objects in the next call.
+            $qb->getRootAliases();
+
+            /** @var From[] $fromClauses */
+            $fromClauses = $qb->getDQLPart('from');
+
+            foreach ($fromClauses as $fromClause) {
+                $identifiers = $manager->getClassMetadata($fromClause->getFrom())->getIdentifierFieldNames();
+
+                foreach ($identifiers as $identifier) {
+                    $qb->addOrderBy($fromClause->getAlias().'.'.$identifier);
+                }
+            }
+        }
+
+        $pager = new PagerfantaPager(new Pagerfanta(new DoctrineORMAdapter($qb)));
 
         $this->registerListenersService->register($manager, $pager, $options);
 

--- a/tests/Unit/Doctrine/ORMPagerProviderTest.php
+++ b/tests/Unit/Doctrine/ORMPagerProviderTest.php
@@ -4,6 +4,7 @@ namespace FOS\ElasticaBundle\Tests\Unit\Doctrine;
 
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\EntityRepository;
+use Doctrine\ORM\Query\Expr\OrderBy;
 use Doctrine\ORM\QueryBuilder;
 use FOS\ElasticaBundle\Doctrine\ORMPagerProvider;
 use FOS\ElasticaBundle\Doctrine\RegisterListenersService;
@@ -33,12 +34,15 @@ class ORMPagerProviderTest extends TestCase
         new ORMPagerProvider($doctrine, $this->createRegisterListenersServiceMock(), $objectClass, $baseConfig);
     }
 
-    public function testShouldReturnPagerfanataPagerWithDoctrineODMMongoDBAdapter()
+    public function testShouldReturnPagerfantaPagerWithDoctrineORMAdapter()
     {
         $objectClass = 'anObjectClass';
         $baseConfig = ['query_builder_method' => 'createQueryBuilder'];
 
         $expectedBuilder = $this->createMock(QueryBuilder::class);
+        $expectedBuilder->method('getDQLPart')
+            ->with('orderBy')
+            ->willReturn(array($this->createMock(OrderBy::class)));
 
         $repository = $this->createMock(EntityRepository::class);
         $repository
@@ -76,11 +80,16 @@ class ORMPagerProviderTest extends TestCase
         $objectClass = 'anObjectClass';
         $baseConfig = ['query_builder_method' => 'createQueryBuilder'];
 
+        $expectedBuilder = $this->createMock(QueryBuilder::class);
+        $expectedBuilder->method('getDQLPart')
+            ->with('orderBy')
+            ->willReturn(array($this->createMock(OrderBy::class)));
+
         $repository = $this->createMock(DoctrineORMCustomRepositoryMock::class);
         $repository
             ->expects($this->once())
             ->method('createCustomQueryBuilder')
-            ->willReturn($this->createMock(QueryBuilder::class));
+            ->willReturn($expectedBuilder);
 
         $manager = $this->createMock(EntityManager::class);
         $manager
@@ -109,11 +118,16 @@ class ORMPagerProviderTest extends TestCase
         $objectClass = 'anObjectClass';
         $baseConfig = ['query_builder_method' => 'createQueryBuilder'];
 
+        $expectedBuilder = $this->createMock(QueryBuilder::class);
+        $expectedBuilder->method('getDQLPart')
+            ->with('orderBy')
+            ->willReturn(array($this->createMock(OrderBy::class)));
+
         $repository = $this->createMock(EntityRepository::class);
         $repository
             ->expects($this->once())
             ->method('createQueryBuilder')
-            ->willReturn($this->createMock(QueryBuilder::class));
+            ->willReturn($expectedBuilder);
 
         $manager = $this->createMock(EntityManager::class);
         $manager


### PR DESCRIPTION
Paginating a DQL query which does not have a ORDER BY clause does not work cross-platform, as the sorting is undefined in such case.
MySQL is not affected by the bug because it always adds an implicit sorting by insertion order (which is a compliant way to implement the undefined order but tends to hide this issue from developers having to deal with other platforms too). But PostgreSQL is impacted for instance.