### PR TITLE
add note about doctrine cache in queue consumers

### DIFF
--- a/doc/cookbook/doctrine-queue-listener.md
+++ b/doc/cookbook/doctrine-queue-listener.md
@@ -49,6 +49,14 @@ enqueue_elastica:
               model_class: 'AppBundle\Entity\Blog'
 ```
 
+You'll probably want to enable clearing the entitymanager in the queue consumer to avoid sending cached entities to elastisearch:
+
+```
+enqueue:
+    extensions:
+        doctrine_clear_identity_map_extension: true
+```
+
 Don't forget to run some queue consumers (the more you run the better performance you might get):
 
 ```bash


### PR DESCRIPTION
Had to do a bit of debugging to figure out why updating entities wasn't synced properly to elasticsearch. 