### PR TITLE
Add optional routing to ObjectPersister::deleteById

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "5.0.x-dev"
+            "dev-master": "5.1.x-dev"
         }
     }
 }

--- a/src/Persister/ObjectPersister.php
+++ b/src/Persister/ObjectPersister.php
@@ -88,7 +88,7 @@ class ObjectPersister implements ObjectPersisterInterface
     /**
      * {@inheritdoc}
      */
-    public function deleteById($id)
+    public function deleteById($id, $routing = false)
     {
         $this->deleteManyByIdentifiers([$id]);
     }
@@ -147,10 +147,10 @@ class ObjectPersister implements ObjectPersisterInterface
     /**
      * {@inheritdoc}
      */
-    public function deleteManyByIdentifiers(array $identifiers)
+    public function deleteManyByIdentifiers(array $identifiers, $routing = false)
     {
         try {
-            $this->type->getIndex()->getClient()->deleteIds($identifiers, $this->type->getIndex(), $this->type);
+            $this->type->deleteIds($identifiers, $this->type->getIndex(), $this->type, $routing);
         } catch (BulkException $e) {
             $this->log($e);
         }

--- a/src/Persister/ObjectPersisterInterface.php
+++ b/src/Persister/ObjectPersisterInterface.php
@@ -53,9 +53,10 @@ interface ObjectPersisterInterface
     /**
      * Deletes one object in the type by id.
      *
-     * @param mixed $id
+     * @param mixed       $id
+     * @param string|bool $routing
      */
-    public function deleteById($id);
+    public function deleteById($id, $routing = false);
 
     /**
      * Bulk inserts an array of objects in the type.
@@ -81,7 +82,8 @@ interface ObjectPersisterInterface
     /**
      * Bulk deletes records from an array of identifiers.
      *
-     * @param array $identifiers array of domain model object identifiers
+     * @param array       $identifiers array of domain model object identifiers
+     * @param string|bool $routing     optional routing key for all identifiers
      */
-    public function deleteManyByIdentifiers(array $identifiers);
+    public function deleteManyByIdentifiers(array $identifiers, $routing = false);
 }


### PR DESCRIPTION
Fixes https://github.com/FriendsOfSymfony/FOSElasticaBundle/issues/1268
Closes https://github.com/FriendsOfSymfony/FOSElasticaBundle/pull/1428