### PR TITLE
Fix call to Type::deleteIds

### DIFF
--- a/src/Persister/ObjectPersister.php
+++ b/src/Persister/ObjectPersister.php
@@ -152,7 +152,7 @@ class ObjectPersister implements ObjectPersisterInterface
     public function deleteManyByIdentifiers(array $identifiers, $routing = false)
     {
         try {
-            $this->type->deleteIds($identifiers, $this->type->getIndex(), $this->type, $routing);
+            $this->type->deleteIds($identifiers, $routing);
         } catch (BulkException $e) {
             $this->log($e);
         }


### PR DESCRIPTION
#1441 broke deletion of documents from elasticsearch because it switched from `Client::deleteIds` to `Type::deleteIds` without removing the `$index` and `$type` arguments that aren't accepted by `Type::deleteIds`.