### PR TITLE
Fix a defect when populating a new type in 3.2.x

### DIFF
--- a/Index/Resetter.php
+++ b/Index/Resetter.php
@@ -138,9 +138,16 @@ class Resetter
         if (!empty($settings)) {
             unset($settings['number_of_shards'], $settings['index']['number_of_shards']);
             unset($settings['number_of_replicas'], $settings['index']['number_of_replicas']);
-            $index->close();
-            $index->setSettings($settings);
-            $index->open();
+
+            if (empty($settings['index'])) {
+                unset($settings['index']);
+            }
+
+            if (!empty($settings)) {
+                $index->close();
+                $index->setSettings($settings);
+                $index->open();
+            }
         }
 
         $mapping = new Mapping();


### PR DESCRIPTION
We've spotted a problem where if we try and reset a type using:

`php app/console fos:elastica:reset --index=index_name --type=type_name -v `

... we get an error saying:

```
[Elastica\Exception\ResponseException]
ActionRequestValidationException[Validation Failed: 1: no settings to update;]
```

Our understanding of this is that the `$settings` array starts out containing the `number_of_shards` and `number_of replicas`, but these are then removed. This leaves the `$settings` array empty again, and ElasticSearch isn't happy with an empty `$settings` array.

We've applied the following and seen the issue resolved.