### PR TITLE
Put a random return in README.md to demonstrate build breaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 FOSElasticaBundle
 =================
 
-This bundle provides integration with [Elasticsearch](http://www.elasticsearch.org) and [Elastica](https://github.com/ruflin/Elastica) with
+This bundle provides integration with [Elasticsearch](http://www.elasticsearch.org)
+and [Elastica](https://github.com/ruflin/Elastica) with
 Symfony. Features include:
 
 - Integrates the Elastica library into a Symfony environment


### PR DESCRIPTION
This PR verifies that CI is broken for master, due to a dependency change

A random return is introduced into the README.md file, yet the build will probably break