### PR TITLE
Fix deprecation for symfony/config 4.2+

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -77,8 +77,7 @@ class Configuration implements ConfigurationInterface
      */
     public function getDynamicTemplateNode()
     {
-        $builder = new TreeBuilder();
-        $node = $builder->root('dynamic_templates');
+        $node = $this->createTreeBuilderNode('dynamic_templates');
 
         $node
             ->prototype('array')
@@ -108,8 +107,7 @@ class Configuration implements ConfigurationInterface
      */
     protected function getTypesNode()
     {
-        $builder = new TreeBuilder();
-        $node = $builder->root('types');
+        $node = $this->createTreeBuilderNode('types');
 
         $node
             ->useAttributeAsKey('name')
@@ -168,8 +166,7 @@ class Configuration implements ConfigurationInterface
      */
     protected function getPropertiesNode()
     {
-        $builder = new TreeBuilder();
-        $node = $builder->root('properties');
+        $node = $this->createTreeBuilderNode('properties');
 
         $node
             ->useAttributeAsKey('name')
@@ -184,8 +181,7 @@ class Configuration implements ConfigurationInterface
      */
     protected function getIdNode()
     {
-        $builder = new TreeBuilder();
-        $node = $builder->root('_id');
+        $node = $this->createTreeBuilderNode('_id');
 
         $node
             ->children()
@@ -201,8 +197,7 @@ class Configuration implements ConfigurationInterface
      */
     protected function getSourceNode()
     {
-        $builder = new TreeBuilder();
-        $node = $builder->root('_source');
+        $node = $this->createTreeBuilderNode('_source');
 
         $node
             ->children()
@@ -228,8 +223,7 @@ class Configuration implements ConfigurationInterface
      */
     protected function getRoutingNode()
     {
-        $builder = new TreeBuilder();
-        $node = $builder->root('_routing');
+        $node = $this->createTreeBuilderNode('_routing');
 
         $node
             ->children()
@@ -246,8 +240,7 @@ class Configuration implements ConfigurationInterface
      */
     protected function getParentNode()
     {
-        $builder = new TreeBuilder();
-        $node = $builder->root('_parent');
+        $node = $this->createTreeBuilderNode('_parent');
 
         $node
             ->children()
@@ -265,8 +258,7 @@ class Configuration implements ConfigurationInterface
      */
     protected function getAllNode()
     {
-        $builder = new TreeBuilder();
-        $node = $builder->root('_all');
+        $node = $this->createTreeBuilderNode('_all');
 
         $node
             ->children()
@@ -283,8 +275,7 @@ class Configuration implements ConfigurationInterface
      */
     protected function getPersistenceNode()
     {
-        $builder = new TreeBuilder();
-        $node = $builder->root('persistence');
+        $node = $this->createTreeBuilderNode('persistence');
 
         $node
             ->validate()
@@ -387,8 +378,7 @@ class Configuration implements ConfigurationInterface
      */
     protected function getSerializerNode()
     {
-        $builder = new TreeBuilder();
-        $node = $builder->root('serializer');
+        $node = $this->createTreeBuilderNode('serializer');
 
         $node
             ->addDefaultsIfNotSet()
@@ -537,5 +527,22 @@ class Configuration implements ConfigurationInterface
                 ->end()
             ->end()
         ;
+    }
+
+    /**
+     * @return ArrayNodeDefinition|\Symfony\Component\Config\Definition\Builder\NodeDefinition
+     */
+    private function createTreeBuilderNode($name)
+    {
+        $builder = new TreeBuilder($name);
+
+        if (method_exists($builder, 'getRootNode')) {
+            $node = $builder->getRootNode();
+        } else {
+            // BC layer for symfony/config 4.1 and older
+            $node = $builder->root($name);
+        }
+
+        return $node;
     }
 }


### PR DESCRIPTION
I missed all the other uses of `TreeBuilder` in https://github.com/FriendsOfSymfony/FOSElasticaBundle/pull/1475 🤦‍♂️ 