### PR TITLE
Testing AbstractElasticaToModelTransformer

### DIFF
--- a/src/Transformer/AbstractElasticaToModelTransformer.php
+++ b/src/Transformer/AbstractElasticaToModelTransformer.php
@@ -31,22 +31,4 @@ abstract class AbstractElasticaToModelTransformer implements ElasticaToModelTran
     {
         $this->propertyAccessor = $propertyAccessor;
     }
-
-    /**
-     * Returns a sorting closure to be used with usort() to put retrieved objects
-     * back in the order that they were returned by ElasticSearch.
-     *
-     * @param array  $idPos
-     * @param string $identifierPath
-     *
-     * @return callable
-     */
-    protected function getSortingClosure(array $idPos, $identifierPath)
-    {
-        $propertyAccessor = $this->propertyAccessor;
-
-        return function ($a, $b) use ($idPos, $identifierPath, $propertyAccessor) {
-            return $idPos[(string) $propertyAccessor->getValue($a, $identifierPath)] > $idPos[(string) $propertyAccessor->getValue($b, $identifierPath)];
-        };
-    }
 }

--- a/tests/Unit/Transformer/AbstractElasticaToModelTransformerTest.php
+++ b/tests/Unit/Transformer/AbstractElasticaToModelTransformerTest.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the FOSElasticaBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\ElasticaBundle\Tests\Unit\Transformer;
+
+use FOS\ElasticaBundle\Transformer\AbstractElasticaToModelTransformer;
+use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
+use FOS\ElasticaBundle\Tests\Unit\UnitTestHelper;
+
+class AbstractElasticaToModelTransformerTest extends UnitTestHelper
+{
+    public function testSetPropertyAccessor()
+    {
+        $propertyAccessor = $this->mockPropertyAccesor();
+        $transformer = $this->mockAbstractElasticaToModelTransformer();
+        $transformer->setPropertyAccessor($propertyAccessor);
+        $this->assertEquals($propertyAccessor, $this->getProtectedProperty($transformer, 'propertyAccessor'));
+    }
+
+    protected function mockAbstractElasticaToModelTransformer()
+    {
+        $mock = $this
+            ->getMockBuilder(AbstractElasticaToModelTransformer::class)
+            ->getMockForAbstractClass();
+        return $mock;
+    }
+
+    protected function mockPropertyAccesor()
+    {
+        $mock = $this->createMock(PropertyAccessorInterface::class);
+        return $mock;
+    }
+}

--- a/tests/Unit/UnitTestHelper.php
+++ b/tests/Unit/UnitTestHelper.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the FOSElasticaBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\ElasticaBundle\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+
+class UnitTestHelper extends TestCase
+{
+    /**
+     * Gets a protected property on a given object via reflection.
+     *
+     * @param object $object   instance in which protected value is being modified
+     * @param string $property property on instance being modified
+     */
+    protected function getProtectedProperty($object, string $property)
+    {
+        $reflection = new \ReflectionClass($object);
+        $reflectionProperty = $reflection->getProperty($property);
+        $reflectionProperty->setAccessible(true);
+
+        return $reflectionProperty->getValue($object);
+    }
+}


### PR DESCRIPTION
Remove getSortingClosure, as it is not used anywhere
Introduce a UnitTestHelper class for some shared functionality