### PR TITLE
Allow setting transport connection persistency

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -488,6 +488,7 @@ class Configuration implements ConfigurationInterface
                                         ->scalarNode('retryOnConflict')
                                             ->defaultValue(0)
                                         ->end()
+                                        ->booleanNode('persistent')->defaultValue(true)->end()
                                     ->end()
                                 ->end()
                             ->end()


### PR DESCRIPTION
ES services, especially the managed ones (like Azure's), tend to break a connection if it's idle long enough. This PR introduces a configuration setting to be propagated through to the transport layer setup, allowing to use a non-persistent connection (the implicit default there is a persistent connection).