### PR TITLE
Fixes: ObjectPersister not passing $routing to deleteManyByIdentifiers

### DIFF
--- a/src/Persister/ObjectPersister.php
+++ b/src/Persister/ObjectPersister.php
@@ -92,7 +92,7 @@ class ObjectPersister implements ObjectPersisterInterface
      */
     public function deleteById($id, $routing = false)
     {
-        $this->deleteManyByIdentifiers([$id]);
+        $this->deleteManyByIdentifiers([$id], $routing);
     }
 
     /**


### PR DESCRIPTION
Original bug introduced by 6d079107d40e3c195fc44774edc749143dfd40bb

Well not "introduced" but that commit supposedly provided this enhancement but didn't actually