### PR TITLE
[documentation] missing content type to req

### DIFF
--- a/doc/cookbook/aliased-indexes.md
+++ b/doc/cookbook/aliased-indexes.md
@@ -40,7 +40,7 @@ fos_elastica:
 ```
 
 ```bash
-$ curl -XPOST 'http://localhost:9200/_aliases' -d '
+$ curl -XPOST 'http://localhost:9200/_aliases' -H 'Content-Type: application/json' -d '
 {
     "actions" : [
         { "add" : { "index" : "app", "alias" : "app_prod" } }


### PR DESCRIPTION
missing content type to req else error 406 `{"error":"Content-Type header [application/x-www-form-urlencoded] is not supported","status":406}`