### PR TITLE
Add support for Elastica 7.0.x-dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ composer.lock
 composer.phar
 .php_cs
 .php_cs.cache
-.idea

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ composer.lock
 composer.phar
 .php_cs
 .php_cs.cache
+.idea

--- a/src/DependencyInjection/FOSElasticaExtension.php
+++ b/src/DependencyInjection/FOSElasticaExtension.php
@@ -145,6 +145,7 @@ class FOSElasticaExtension extends Extension
 
             $clientDef = new ChildDefinition('fos_elastica.client_prototype');
             $clientDef->replaceArgument(0, $clientConfig);
+            $clientDef->replaceArgument(1, null);
 
             $logger = $clientConfig['connections'][0]['logger'];
             if (false !== $logger) {


### PR DESCRIPTION
I tried to use the `7.0.x-dev` branch in our Symfony project to add support for Elasticsearch 7, by adding the following the our composer.json:

```
"ruflin/elastica": "7.0.x-dev as 6.1.1",
```

Unfortunately this triggered the following errors:
```
Argument 3 passed to Elastica\\Connection\\ConnectionPool::__construct() must be callable or null, string given, called in \/var\/www\/html\/vendor\/ruflin\/elastica\/lib\/Elastica\/Client.php on line 148","detail":"Argument 3 passed to Elastica\\Connection\\ConnectionPool::__construct() must be callable or null, string given, called in \/var\/www\/html\/vendor\/ruflin\/elastica\/lib\/Elastica\/Client.php on line 148 in \/var\/www\/html\/vendor\/ruflin\/elastica\/lib\/Elastica\/Connection\/ConnectionPool.php at 38","source":{"trace":"#0 \/var\/www\/html\/vendor\/ruflin\/elastica\/lib\/Elastica\/Client.php(148): Elastica\\Connection\\ConnectionPool-\u003E__construct(Array, Object(Elastica\\Connection\\Strategy\\Simple), \u0027\u0027)\n#1 
```
Caused by: https://github.com/ruflin/Elastica/pull/1560/files#diff-8e887bc266b94f257045ee28810a5607R38

It seems that Symfony's DI passes an empty string for `$callback` to the `\FOS\ElasticaBundle\Elastica\Client` constructor. 
I couldn't find any usages of this $callback param in this FOSElasticaBundle so I decided to set it to `null` to pass the param type check.

This PR should still be compatible with older versions of the Elastica library.