### PR TITLE
Change callback argument to null in Client

### DIFF
--- a/src/Resources/config/config.xml
+++ b/src/Resources/config/config.xml
@@ -14,7 +14,7 @@
 
         <service id="fos_elastica.client_prototype" class="FOS\ElasticaBundle\Elastica\Client" public="true" abstract="true">
             <argument type="collection" /> <!-- configuration -->
-            <argument /> <!-- callback -->
+            <argument>null</argument> <!-- callback -->
 
             <call method="setStopwatch">
                 <argument type="service" id="debug.stopwatch" on-invalid="null" />


### PR DESCRIPTION
I was trying the `master` branch of `elastica` and [the `$callback` argument of ConnectionPool](https://github.com/ruflin/Elastica/blob/master/lib/Elastica/Connection/ConnectionPool.php#L38) has now a `callable` type, this `$callback` comes from [Client](https://github.com/ruflin/Elastica/blob/master/lib/Elastica/Client.php#L67).

The thing is that apparently, defining `<argument />` means an empty string, so it fails to create the Client.