### PR TITLE
Fix paginate subscriber when request stack is empty (eg. console).

### DIFF
--- a/src/Subscriber/PaginateElasticaQuerySubscriber.php
+++ b/src/Subscriber/PaginateElasticaQuerySubscriber.php
@@ -74,7 +74,7 @@ class PaginateElasticaQuerySubscriber implements EventSubscriberInterface
     protected function setSorting(ItemsEvent $event)
     {
         $options = $event->options;
-        $sortField = $this->getRequest()->get($options['sortFieldParameterName']);
+        $sortField = $this->getFromRequest($options['sortFieldParameterName']);
 
         if (!$sortField && isset($options['defaultSortFieldName'])) {
             $sortField = $options['defaultSortFieldName'];
@@ -117,7 +117,7 @@ class PaginateElasticaQuerySubscriber implements EventSubscriberInterface
     protected function getSortDirection($sortField, array $options = [])
     {
         $dir = 'asc';
-        $sortDirection = $this->getRequest()->get($options['sortDirectionParameterName']);
+        $sortDirection = $this->getFromRequest($options['sortDirectionParameterName']);
 
         if (empty($sortDirection) && isset($options['defaultSortDirection'])) {
             $sortDirection = $options['defaultSortDirection'];
@@ -141,5 +141,18 @@ class PaginateElasticaQuerySubscriber implements EventSubscriberInterface
     private function getRequest()
     {
         return $this->requestStack->getCurrentRequest();
+    }
+
+    /**
+     * @param string|null $key
+     * @return mixed|null
+     */
+    private function getFromRequest(?string $key)
+    {
+        if (null !== $request = $this->getRequest()) {
+            return $request->get($key);
+        }
+
+        return null;
     }
 }

--- a/tests/Unit/Subscriber/PaginateElasticaQuerySubscriberTest.php
+++ b/tests/Unit/Subscriber/PaginateElasticaQuerySubscriberTest.php
@@ -271,6 +271,22 @@ class PaginateElasticaQuerySubscriberTest extends TestCase
         ], $query->toArray());
     }
 
+    public function testShouldDoNothingIfNoRequest()
+    {
+        $subscriber = new PaginateElasticaQuerySubscriber($this->getRequestStack());
+
+        $adapter = $this->getAdapterMock();
+        $adapter->expects($this->never())
+            ->method('getQuery');
+        $adapter->method('getResults')
+            ->willReturn($this->getResultSetMock());
+
+        $event = new ItemsEvent(0, 10);
+        $event->target = $adapter;
+
+        $subscriber->items($event);
+    }
+
     protected function getAdapterMock()
     {
         return $this->createMock(RawPaginatorAdapter::class);


### PR DESCRIPTION
Fix #1202 

PaginateElasticaQuerySubscriber depending on RequestStack but there is no check if the stack is empty or not on usage. When using pagination from console, the stack is empty.

Add a default null when request stack is empty.