### PR TITLE
Fix PaginateElasticaQuerySubscriberTest

### DIFF
--- a/src/Subscriber/PaginateElasticaQuerySubscriber.php
+++ b/src/Subscriber/PaginateElasticaQuerySubscriber.php
@@ -149,7 +149,7 @@ class PaginateElasticaQuerySubscriber implements EventSubscriberInterface
      */
     private function getFromRequest(?string $key)
     {
-        if (null !== $request = $this->getRequest()) {
+        if (null !== $key && null !== $request = $this->getRequest()) {
             return $request->get($key);
         }
 


### PR DESCRIPTION
This will fix:

```
FOS\ElasticaBundle\Tests\Unit\Subscriber\PaginateElasticaQuerySubscriberTest::testShouldDoNothingIfSortParamIsEmpty
TypeError: Argument 1 passed to Symfony\Component\HttpFoundation\Request::get() must be of the type string, null given, called in ./FOSElasticaBundle/src/Subscriber/PaginateElasticaQuerySubscriber.php on line 153
```