### PR TITLE
Add return codes to commands to fix deprecated null return values

### DIFF
--- a/src/Command/CreateCommand.php
+++ b/src/Command/CreateCommand.php
@@ -71,5 +71,7 @@ class CreateCommand extends Command
             $mapping = $this->mappingBuilder->buildIndexMapping($indexConfig);
             $index->create($mapping, false);
         }
+
+        return 0;
     }
 }

--- a/src/Command/PopulateCommand.php
+++ b/src/Command/PopulateCommand.php
@@ -170,6 +170,8 @@ class PopulateCommand extends Command
                 $this->populateIndex($output, $index, $reset, $options);
             }
         }
+
+        return 0;
     }
 
     /**

--- a/src/Command/ResetCommand.php
+++ b/src/Command/ResetCommand.php
@@ -73,5 +73,7 @@ class ResetCommand extends Command
                 $this->resetter->resetIndex($index, false, $force);
             }
         }
+
+        return 0;
     }
 }

--- a/src/Command/SearchCommand.php
+++ b/src/Command/SearchCommand.php
@@ -69,6 +69,8 @@ class SearchCommand extends Command
         foreach ($resultSet->getResults() as $result) {
             $output->writeLn($this->formatResult($result, $input->getOption('show-field'), $input->getOption('show-source'), $input->getOption('show-id'), $input->getOption('explain')));
         }
+
+        return 0;
     }
 
     /**


### PR DESCRIPTION
Non-int status codes in Command::execute() are deprecated since Symfony 4.4:

- https://github.com/symfony/symfony/issues/33747
- https://github.com/symfony/symfony/pull/33775

