### PR TITLE
Add alias to index on index creation

### DIFF
--- a/src/Command/CreateCommand.php
+++ b/src/Command/CreateCommand.php
@@ -70,6 +70,10 @@ class CreateCommand extends Command
             }
             $mapping = $this->mappingBuilder->buildIndexMapping($indexConfig);
             $index->create($mapping, false);
+
+            if ($indexConfig->isUseAlias()) {
+                $index->addAlias($indexName);
+            }
         }
 
         return 0;

--- a/tests/Unit/Command/CreateCommandTest.php
+++ b/tests/Unit/Command/CreateCommandTest.php
@@ -91,10 +91,11 @@ class CreateCommandTest extends TestCase
         $output->expects($this->once())->method('writeln');
         $this->configManager->expects($this->once())->method('getIndexConfiguration')->with($indexName)->willReturn($this->indexConfig);
         $this->indexManager->expects($this->once())->method('getIndex')->with($indexName)->willReturn($this->index);
-        $this->indexConfig->expects($this->once())->method('isUseAlias')->willReturn(true);
+        $this->indexConfig->expects($this->exactly(2))->method('isUseAlias')->willReturn(true);
         $this->aliasProcessor->expects($this->once())->method('setRootName')->with($this->indexConfig, $this->index);
         $this->mappingBuilder->expects($this->once())->method('buildIndexMapping')->with($this->indexConfig)->willReturn($mapping);
         $this->index->expects($this->once())->method('create')->with(['mapping'], false);
+        $this->index->expects($this->once())->method('addAlias')->with($indexName);
 
         $this->command->run($input, $output);
     }
@@ -111,10 +112,11 @@ class CreateCommandTest extends TestCase
         $output->expects($this->once())->method('writeln');
         $this->configManager->expects($this->once())->method('getIndexConfiguration')->with($indexName)->willReturn($this->indexConfig);
         $this->indexManager->expects($this->once())->method('getIndex')->with($indexName)->willReturn($this->index);
-        $this->indexConfig->expects($this->once())->method('isUseAlias')->willReturn(false);
+        $this->indexConfig->expects($this->exactly(2))->method('isUseAlias')->willReturn(false);
         $this->aliasProcessor->expects($this->never())->method('setRootName');
         $this->mappingBuilder->expects($this->once())->method('buildIndexMapping')->with($this->indexConfig)->willReturn($mapping);
         $this->index->expects($this->once())->method('create')->with(['mapping'], false);
+        $this->index->expects($this->never())->method('addAlias');
 
         $this->command->run($input, $output);
     }
@@ -144,8 +146,8 @@ class CreateCommandTest extends TestCase
             ->withConsecutive(['foo'], ['bar'])
             ->willReturnOnConsecutiveCalls($index1, $index2);
 
-        $indexConfig1->expects($this->once())->method('isUseAlias')->willReturn(false);
-        $indexConfig2->expects($this->once())->method('isUseAlias')->willReturn(false);
+        $indexConfig1->expects($this->exactly(2))->method('isUseAlias')->willReturn(false);
+        $indexConfig2->expects($this->exactly(2))->method('isUseAlias')->willReturn(false);
 
         $this->aliasProcessor->expects($this->never())->method('setRootName');
 
@@ -154,7 +156,9 @@ class CreateCommandTest extends TestCase
             ->willReturn($mapping);
 
         $index1->expects($this->once())->method('create')->with(['mapping'], false);
+        $index1->expects($this->never())->method('addAlias');
         $index2->expects($this->once())->method('create')->with(['mapping'], false);
+        $index2->expects($this->never())->method('addAlias');
 
         $this->command->run($input, $output);
     }


### PR DESCRIPTION
I have configured aliases for my indexes with `use_alias: true` and wanted to use . `./bin/console fos:elastica:create` to create them. 
I expected the command to create the index and adding the configured alias, but it only created the indexes. So here is a fix for that.

