### PR TITLE
Fix phpstan warnings in projects

### DIFF
--- a/src/Repository.php
+++ b/src/Repository.php
@@ -68,7 +68,7 @@ class Repository
     }
 
     /**
-     * @param string $query
+     * @param mixed $query
      * @param array  $options
      *
      * @return Paginator\PaginatorAdapterInterface


### PR DESCRIPTION
phpstan error :
`Parameter #1 $query of method FOS\ElasticaBundle\Repository::createPaginatorAdapter() expects string,  Elastica\Query given.`

In the interface `FOS\ElasticaBundle\Finder\PaginatedFinderInterface`, the method `createPaginatorAdapter` accepts `* @param mixed $query` but in `FOS\ElasticaBundle\Repository`, this method accepts only `* @param string $query`.
The next block of code is correct but in phpstan, it throws an error because of parameter type in Repository
```
/** @var Elastica\Query $query */
$query = $this->getQueryFromData($requestQuery, $user);
$count = $this->createPaginatorAdapter($query)->getTotalHits();
```

So I suggest to change the PHPDoc of this method which will keep the same behavior :+1: 