### PR TITLE
Remove EventDispatcher deprecation warnings

### DIFF
--- a/src/Doctrine/RegisterListenersService.php
+++ b/src/Doctrine/RegisterListenersService.php
@@ -4,11 +4,11 @@ namespace FOS\ElasticaBundle\Doctrine;
 use Doctrine\Common\Persistence\ObjectManager;
 use Doctrine\ODM\MongoDB\DocumentManager;
 use Doctrine\ORM\EntityManagerInterface;
+use FOS\ElasticaBundle\EventDispatcher\LegacyEventDispatcherProxy;
 use FOS\ElasticaBundle\Persister\Event\Events;
 use FOS\ElasticaBundle\Persister\Event\PersistEvent;
 use FOS\ElasticaBundle\Provider\PagerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\EventDispatcher\LegacyEventDispatcherProxy;
 
 class RegisterListenersService
 {
@@ -19,11 +19,7 @@ class RegisterListenersService
 
     public function __construct(EventDispatcherInterface $dispatcher)
     {
-        $this->dispatcher = $dispatcher;
-
-        if (class_exists(LegacyEventDispatcherProxy::class)) {
-            $this->dispatcher = LegacyEventDispatcherProxy::decorate($dispatcher);
-        }
+        $this->dispatcher = LegacyEventDispatcherProxy::decorate($dispatcher);
     }
 
     public function register(ObjectManager $manager, PagerInterface $pager, array $options)

--- a/src/Event/ElasticaEvent.php
+++ b/src/Event/ElasticaEvent.php
@@ -11,26 +11,16 @@
 
 namespace FOS\ElasticaBundle\Event;
 
-class IndexEvent extends ElasticaEvent
-{
-    /**
-     * @var string
-     */
-    private $index;
+use Symfony\Contracts\EventDispatcher\Event as BaseEvent;
+use Symfony\Component\EventDispatcher\Event as LegacyBaseEvent;
 
-    /**
-     * @param string $index
-     */
-    public function __construct($index)
+if (class_exists(BaseEvent::class)) {
+    class ElasticaEvent extends BaseEvent
     {
-        $this->index = $index;
     }
-
-    /**
-     * @return string
-     */
-    public function getIndex()
+} else {
+    // Support Symfony 4.2 and before
+    class ElasticaEvent extends LegacyBaseEvent
     {
-        return $this->index;
     }
 }

--- a/src/Event/TransformEvent.php
+++ b/src/Event/TransformEvent.php
@@ -12,9 +12,8 @@
 namespace FOS\ElasticaBundle\Event;
 
 use Elastica\Document;
-use Symfony\Component\EventDispatcher\Event;
 
-class TransformEvent extends Event
+class TransformEvent extends ElasticaEvent
 {
     /**
      * @Event("FOS\ElasticaBundle\Event\TransformEvent")

--- a/src/EventDispatcher/LegacyEventDispatcherProxy.php
+++ b/src/EventDispatcher/LegacyEventDispatcherProxy.php
@@ -1,0 +1,125 @@
+<?php
+
+/*
+ * This file is part of the FOSElasticaBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\ElasticaBundle\EventDispatcher;
+
+use FOS\ElasticaBundle\Event\ElasticaEvent;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface as ContractsEventDispatcherInterface;
+use TypeError;
+
+final class LegacyEventDispatcherProxy
+{
+    public static function decorate(?EventDispatcherInterface $dispatcher): ?EventDispatcherInterface
+    {
+        if ($dispatcher === null) {
+            return null;
+        }
+
+        if (!$dispatcher instanceof ContractsEventDispatcherInterface) {
+            return $dispatcher;
+        }
+
+        return new class($dispatcher) implements EventDispatcherInterface {
+            /**
+             * @var EventDispatcherInterface
+             */
+            private $dispatcher;
+
+            /**
+             * @param EventDispatcherInterface $dispatcher
+             */
+            public function __construct(EventDispatcherInterface $dispatcher)
+            {
+                $this->dispatcher = $dispatcher;
+            }
+
+            /**
+             * {@inheritdoc}
+             */
+            public function dispatch($eventName/*, object $event = null*/)
+            {
+                $event = 1 < func_num_args() ? func_get_arg(1) : new ElasticaEvent();
+
+                if (!is_string($eventName)) {
+                    throw new TypeError(sprintf('Argument 1 passed to "%s::dispatch()" must be a string, %s given.', EventDispatcherInterface::class, is_object($eventName) ? get_class($eventName) : gettype($eventName)));
+                }
+
+                $this->dispatcher->dispatch($event, $eventName);
+            }
+
+            /**
+             * {@inheritdoc}
+             */
+            public function addListener($eventName, $listener, $priority = 0)
+            {
+                return $this->dispatcher->addListener($eventName, $listener, $priority);
+            }
+
+            /**
+             * {@inheritdoc}
+             */
+            public function addSubscriber(EventSubscriberInterface $subscriber)
+            {
+                return $this->dispatcher->addSubscriber($subscriber);
+            }
+
+            /**
+             * {@inheritdoc}
+             */
+            public function removeListener($eventName, $listener)
+            {
+                return $this->dispatcher->removeListener($eventName, $listener);
+            }
+
+            /**
+             * {@inheritdoc}
+             */
+            public function removeSubscriber(EventSubscriberInterface $subscriber)
+            {
+                return $this->dispatcher->removeSubscriber($subscriber);
+            }
+
+            /**
+             * {@inheritdoc}
+             */
+            public function getListeners($eventName = null): array
+            {
+                return $this->dispatcher->getListeners($eventName);
+            }
+
+            /**
+             * {@inheritdoc}
+             */
+            public function getListenerPriority($eventName, $listener): ?int
+            {
+                return $this->dispatcher->getListenerPriority($eventName, $listener);
+            }
+
+            /**
+             * {@inheritdoc}
+             */
+            public function hasListeners($eventName = null): bool
+            {
+                return $this->dispatcher->hasListeners($eventName);
+            }
+
+            /**
+             * Proxies all method calls to the original event dispatcher.
+             */
+            public function __call($method, $arguments)
+            {
+                return $this->dispatcher->{$method}(...$arguments);
+            }
+        };
+    }
+}

--- a/src/Index/Resetter.php
+++ b/src/Index/Resetter.php
@@ -17,8 +17,8 @@ use FOS\ElasticaBundle\Configuration\ManagerInterface;
 use Elastica\Client;
 use FOS\ElasticaBundle\Event\IndexResetEvent;
 use FOS\ElasticaBundle\Event\TypeResetEvent;
+use FOS\ElasticaBundle\EventDispatcher\LegacyEventDispatcherProxy;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\EventDispatcher\LegacyEventDispatcherProxy;
 
 /**
  * Deletes and recreates indexes.
@@ -67,12 +67,7 @@ class Resetter implements ResetterInterface
     ) {
         $this->aliasProcessor = $aliasProcessor;
         $this->configManager = $configManager;
-        $this->dispatcher = $eventDispatcher;
-
-        if (class_exists(LegacyEventDispatcherProxy::class)) {
-            $this->dispatcher = LegacyEventDispatcherProxy::decorate($eventDispatcher);
-        }
-
+        $this->dispatcher = LegacyEventDispatcherProxy::decorate($eventDispatcher);
         $this->indexManager = $indexManager;
         $this->mappingBuilder = $mappingBuilder;
     }

--- a/src/Persister/Event/OnExceptionEvent.php
+++ b/src/Persister/Event/OnExceptionEvent.php
@@ -1,11 +1,11 @@
 <?php
 namespace FOS\ElasticaBundle\Persister\Event;
 
+use FOS\ElasticaBundle\Event\ElasticaEvent;
 use FOS\ElasticaBundle\Persister\ObjectPersisterInterface;
 use FOS\ElasticaBundle\Provider\PagerInterface;
-use Symfony\Component\EventDispatcher\Event;
 
-final class OnExceptionEvent extends Event implements PersistEvent
+final class OnExceptionEvent extends ElasticaEvent implements PersistEvent
 {
     /**
      * @var PagerInterface

--- a/src/Persister/Event/PostAsyncInsertObjectsEvent.php
+++ b/src/Persister/Event/PostAsyncInsertObjectsEvent.php
@@ -1,11 +1,11 @@
 <?php
 namespace FOS\ElasticaBundle\Persister\Event;
 
+use FOS\ElasticaBundle\Event\ElasticaEvent;
 use FOS\ElasticaBundle\Persister\ObjectPersisterInterface;
 use FOS\ElasticaBundle\Provider\PagerInterface;
-use Symfony\Component\EventDispatcher\Event;
 
-final class PostAsyncInsertObjectsEvent extends Event implements PersistEvent
+final class PostAsyncInsertObjectsEvent extends ElasticaEvent implements PersistEvent
 {
     /**
      * @var PagerInterface

--- a/src/Persister/Event/PostInsertObjectsEvent.php
+++ b/src/Persister/Event/PostInsertObjectsEvent.php
@@ -1,11 +1,11 @@
 <?php
 namespace FOS\ElasticaBundle\Persister\Event;
 
+use FOS\ElasticaBundle\Event\ElasticaEvent;
 use FOS\ElasticaBundle\Persister\ObjectPersisterInterface;
 use FOS\ElasticaBundle\Provider\PagerInterface;
-use Symfony\Component\EventDispatcher\Event;
 
-final class PostInsertObjectsEvent extends Event implements PersistEvent
+final class PostInsertObjectsEvent extends ElasticaEvent implements PersistEvent
 {
     /**
      * @var PagerInterface

--- a/src/Persister/Event/PostPersistEvent.php
+++ b/src/Persister/Event/PostPersistEvent.php
@@ -1,11 +1,11 @@
 <?php
 namespace FOS\ElasticaBundle\Persister\Event;
 
+use FOS\ElasticaBundle\Event\ElasticaEvent;
 use FOS\ElasticaBundle\Persister\ObjectPersisterInterface;
 use FOS\ElasticaBundle\Provider\PagerInterface;
-use Symfony\Component\EventDispatcher\Event;
 
-final class PostPersistEvent extends Event implements PersistEvent
+final class PostPersistEvent extends ElasticaEvent implements PersistEvent
 {
     /**
      * @var PagerInterface

--- a/src/Persister/Event/PreFetchObjectsEvent.php
+++ b/src/Persister/Event/PreFetchObjectsEvent.php
@@ -1,11 +1,11 @@
 <?php
 namespace FOS\ElasticaBundle\Persister\Event;
 
+use FOS\ElasticaBundle\Event\ElasticaEvent;
 use FOS\ElasticaBundle\Persister\ObjectPersisterInterface;
 use FOS\ElasticaBundle\Provider\PagerInterface;
-use Symfony\Component\EventDispatcher\Event;
 
-final class PreFetchObjectsEvent extends Event implements PersistEvent
+final class PreFetchObjectsEvent extends ElasticaEvent implements PersistEvent
 {
     /**
      * @var PagerInterface

--- a/src/Persister/Event/PreInsertObjectsEvent.php
+++ b/src/Persister/Event/PreInsertObjectsEvent.php
@@ -1,11 +1,11 @@
 <?php
 namespace FOS\ElasticaBundle\Persister\Event;
 
+use FOS\ElasticaBundle\Event\ElasticaEvent;
 use FOS\ElasticaBundle\Persister\ObjectPersisterInterface;
 use FOS\ElasticaBundle\Provider\PagerInterface;
-use Symfony\Component\EventDispatcher\Event;
 
-final class PreInsertObjectsEvent extends Event implements PersistEvent
+final class PreInsertObjectsEvent extends ElasticaEvent implements PersistEvent
 {
     /**
      * @var PagerInterface

--- a/src/Persister/Event/PrePersistEvent.php
+++ b/src/Persister/Event/PrePersistEvent.php
@@ -1,11 +1,11 @@
 <?php
 namespace FOS\ElasticaBundle\Persister\Event;
 
+use FOS\ElasticaBundle\Event\ElasticaEvent;
 use FOS\ElasticaBundle\Persister\ObjectPersisterInterface;
 use FOS\ElasticaBundle\Provider\PagerInterface;
-use Symfony\Component\EventDispatcher\Event;
 
-final class PrePersistEvent extends Event implements PersistEvent
+final class PrePersistEvent extends ElasticaEvent implements PersistEvent
 {
     /**
      * @var PagerInterface

--- a/src/Persister/InPlacePagerPersister.php
+++ b/src/Persister/InPlacePagerPersister.php
@@ -2,6 +2,7 @@
 
 namespace FOS\ElasticaBundle\Persister;
 
+use FOS\ElasticaBundle\EventDispatcher\LegacyEventDispatcherProxy;
 use FOS\ElasticaBundle\Persister\Event\Events;
 use FOS\ElasticaBundle\Persister\Event\OnExceptionEvent;
 use FOS\ElasticaBundle\Persister\Event\PostInsertObjectsEvent;
@@ -11,7 +12,6 @@ use FOS\ElasticaBundle\Persister\Event\PreInsertObjectsEvent;
 use FOS\ElasticaBundle\Persister\Event\PrePersistEvent;
 use FOS\ElasticaBundle\Provider\PagerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\EventDispatcher\LegacyEventDispatcherProxy;
 
 final class InPlacePagerPersister implements PagerPersisterInterface
 {
@@ -34,11 +34,7 @@ final class InPlacePagerPersister implements PagerPersisterInterface
     public function __construct(PersisterRegistry $registry, EventDispatcherInterface $dispatcher)
     {
         $this->registry = $registry;
-        $this->dispatcher = $dispatcher;
-
-        if (class_exists(LegacyEventDispatcherProxy::class)) {
-            $this->dispatcher = LegacyEventDispatcherProxy::decorate($dispatcher);
-        }
+        $this->dispatcher = LegacyEventDispatcherProxy::decorate($dispatcher);
     }
 
     /**

--- a/src/Transformer/ModelToElasticaAutoTransformer.php
+++ b/src/Transformer/ModelToElasticaAutoTransformer.php
@@ -13,8 +13,8 @@ namespace FOS\ElasticaBundle\Transformer;
 
 use Elastica\Document;
 use FOS\ElasticaBundle\Event\TransformEvent;
+use FOS\ElasticaBundle\EventDispatcher\LegacyEventDispatcherProxy;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
-use Symfony\Component\EventDispatcher\LegacyEventDispatcherProxy;
 use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 
 /**
@@ -55,11 +55,7 @@ class ModelToElasticaAutoTransformer implements ModelToElasticaTransformerInterf
     public function __construct(array $options = [], EventDispatcherInterface $dispatcher = null)
     {
         $this->options = array_merge($this->options, $options);
-        $this->dispatcher = $dispatcher;
-
-        if (class_exists(LegacyEventDispatcherProxy::class)) {
-            $this->dispatcher = LegacyEventDispatcherProxy::decorate($dispatcher);
-        }
+        $this->dispatcher = LegacyEventDispatcherProxy::decorate($dispatcher);
     }
 
     /**

--- a/tests/Unit/Persister/Event/OnExceptionEventTest.php
+++ b/tests/Unit/Persister/Event/OnExceptionEventTest.php
@@ -6,7 +6,8 @@ use FOS\ElasticaBundle\Persister\Event\PersistEvent;
 use FOS\ElasticaBundle\Persister\ObjectPersisterInterface;
 use FOS\ElasticaBundle\Provider\PagerInterface;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
+use Symfony\Component\EventDispatcher\Event as LegacyEvent;
 
 final class OnExceptionEventTest extends TestCase
 {
@@ -14,7 +15,11 @@ final class OnExceptionEventTest extends TestCase
     {
         $rc = new \ReflectionClass(OnExceptionEvent::class);
 
-        $this->assertTrue($rc->isSubclassOf(Event::class));
+        if (class_exists(Event::class)) {
+            $this->assertTrue($rc->isSubclassOf(Event::class));
+        } else {
+            $this->assertTrue($rc->isSubclassOf(LegacyEvent::class));
+        }
     }
 
     public function testShouldImplementPersistEventInterface()

--- a/tests/Unit/Persister/Event/PostAsyncInsertObjectsEventTest.php
+++ b/tests/Unit/Persister/Event/PostAsyncInsertObjectsEventTest.php
@@ -6,7 +6,8 @@ use FOS\ElasticaBundle\Persister\Event\PostAsyncInsertObjectsEvent;
 use FOS\ElasticaBundle\Persister\ObjectPersisterInterface;
 use FOS\ElasticaBundle\Provider\PagerInterface;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
+use Symfony\Component\EventDispatcher\Event as LegacyEvent;
 
 final class PostAsyncInsertObjectsEventTest extends TestCase
 {
@@ -14,7 +15,11 @@ final class PostAsyncInsertObjectsEventTest extends TestCase
     {
         $rc = new \ReflectionClass(PostAsyncInsertObjectsEvent::class);
 
-        $this->assertTrue($rc->isSubclassOf(Event::class));
+        if (class_exists(Event::class)) {
+            $this->assertTrue($rc->isSubclassOf(Event::class));
+        } else {
+            $this->assertTrue($rc->isSubclassOf(LegacyEvent::class));
+        }
     }
 
     public function testShouldImplementPersistEventInterface()

--- a/tests/Unit/Persister/Event/PostInsertObjectsEventTest.php
+++ b/tests/Unit/Persister/Event/PostInsertObjectsEventTest.php
@@ -6,7 +6,8 @@ use FOS\ElasticaBundle\Persister\Event\PostInsertObjectsEvent;
 use FOS\ElasticaBundle\Persister\ObjectPersisterInterface;
 use FOS\ElasticaBundle\Provider\PagerInterface;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
+use Symfony\Component\EventDispatcher\Event as LegacyEvent;
 
 final class PostInsertObjectsEventTest extends TestCase
 {
@@ -14,7 +15,11 @@ final class PostInsertObjectsEventTest extends TestCase
     {
         $rc = new \ReflectionClass(PostInsertObjectsEvent::class);
 
-        $this->assertTrue($rc->isSubclassOf(Event::class));
+        if (class_exists(Event::class)) {
+            $this->assertTrue($rc->isSubclassOf(Event::class));
+        } else {
+            $this->assertTrue($rc->isSubclassOf(LegacyEvent::class));
+        }
     }
 
     public function testShouldImplementPersistEventInterface()

--- a/tests/Unit/Persister/Event/PostPersistEventTest.php
+++ b/tests/Unit/Persister/Event/PostPersistEventTest.php
@@ -6,7 +6,8 @@ use FOS\ElasticaBundle\Persister\Event\PostPersistEvent;
 use FOS\ElasticaBundle\Persister\ObjectPersisterInterface;
 use FOS\ElasticaBundle\Provider\PagerInterface;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
+use Symfony\Component\EventDispatcher\Event as LegacyEvent;
 
 final class PostPersistEventTest extends TestCase
 {
@@ -14,7 +15,11 @@ final class PostPersistEventTest extends TestCase
     {
         $rc = new \ReflectionClass(PostPersistEvent::class);
 
-        $this->assertTrue($rc->isSubclassOf(Event::class));
+        if (class_exists(Event::class)) {
+            $this->assertTrue($rc->isSubclassOf(Event::class));
+        } else {
+            $this->assertTrue($rc->isSubclassOf(LegacyEvent::class));
+        }
     }
 
     public function testShouldImplementPersistEventInterface()

--- a/tests/Unit/Persister/Event/PreFetchObjectsEventTest.php
+++ b/tests/Unit/Persister/Event/PreFetchObjectsEventTest.php
@@ -6,7 +6,8 @@ use FOS\ElasticaBundle\Persister\Event\PreFetchObjectsEvent;
 use FOS\ElasticaBundle\Persister\ObjectPersisterInterface;
 use FOS\ElasticaBundle\Provider\PagerInterface;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
+use Symfony\Component\EventDispatcher\Event as LegacyEvent;
 
 final class PreFetchObjectsEventTest extends TestCase
 {
@@ -14,7 +15,11 @@ final class PreFetchObjectsEventTest extends TestCase
     {
         $rc = new \ReflectionClass(PreFetchObjectsEvent::class);
 
-        $this->assertTrue($rc->isSubclassOf(Event::class));
+        if (class_exists(Event::class)) {
+            $this->assertTrue($rc->isSubclassOf(Event::class));
+        } else {
+            $this->assertTrue($rc->isSubclassOf(LegacyEvent::class));
+        }
     }
 
     public function testShouldImplementPersistEventInterface()

--- a/tests/Unit/Persister/Event/PreInsertObjectsEventTest.php
+++ b/tests/Unit/Persister/Event/PreInsertObjectsEventTest.php
@@ -6,7 +6,8 @@ use FOS\ElasticaBundle\Persister\Event\PreInsertObjectsEvent;
 use FOS\ElasticaBundle\Persister\ObjectPersisterInterface;
 use FOS\ElasticaBundle\Provider\PagerInterface;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
+use Symfony\Component\EventDispatcher\Event as LegacyEvent;
 
 final class PreInsertObjectsEventTest extends TestCase
 {
@@ -14,7 +15,11 @@ final class PreInsertObjectsEventTest extends TestCase
     {
         $rc = new \ReflectionClass(PreInsertObjectsEvent::class);
 
-        $this->assertTrue($rc->isSubclassOf(Event::class));
+        if (class_exists(Event::class)) {
+            $this->assertTrue($rc->isSubclassOf(Event::class));
+        } else {
+            $this->assertTrue($rc->isSubclassOf(LegacyEvent::class));
+        }
     }
 
     public function testShouldImplementPersistEventInterface()

--- a/tests/Unit/Persister/Event/PrePersistEventTest.php
+++ b/tests/Unit/Persister/Event/PrePersistEventTest.php
@@ -6,7 +6,8 @@ use FOS\ElasticaBundle\Persister\Event\PrePersistEvent;
 use FOS\ElasticaBundle\Persister\ObjectPersisterInterface;
 use FOS\ElasticaBundle\Provider\PagerInterface;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
+use Symfony\Component\EventDispatcher\Event as LegacyEvent;
 
 final class PrePersistEventTest extends TestCase
 {
@@ -14,7 +15,11 @@ final class PrePersistEventTest extends TestCase
     {
         $rc = new \ReflectionClass(PrePersistEvent::class);
 
-        $this->assertTrue($rc->isSubclassOf(Event::class));
+        if (class_exists(Event::class)) {
+            $this->assertTrue($rc->isSubclassOf(Event::class));
+        } else {
+            $this->assertTrue($rc->isSubclassOf(LegacyEvent::class));
+        }
     }
 
     public function testShouldImplementPersistEventInterface()


### PR DESCRIPTION
- Instead of the deprecated `Symfony\Component\EventDispatcher\Event`, extend the `Symfony\Contract\EventDispatcher\Event` if existent in order to remove deprecation warnings. For Symfony 4.2 and before, we still use `Symfony\Component\EventDispatcher\Event`.

- Add a bundle specific implementation of the `LegacyEventDispatcherProxy` that works for all versions of Symfony and will not throw deprecation warnings.