### PR TITLE
Use Elasticsearch host and port parameters in all tests

### DIFF
--- a/tests/Functional/app/ORM/config.yml
+++ b/tests/Functional/app/ORM/config.yml
@@ -20,7 +20,7 @@ services:
 fos_elastica:
     clients:
         default:
-            url: "http://localhost:9200"
+            url: "http://%fos_elastica.host%:%fos_elastica.port%"
     indexes:
         fos_elastica_orm_test:
             types:

--- a/tests/Functional/app/Serializer/config.yml
+++ b/tests/Functional/app/Serializer/config.yml
@@ -24,7 +24,7 @@ jms_serializer:
 fos_elastica:
     clients:
         default:
-            url: "http://localhost:9200"
+            url: "http://%fos_elastica.host%:%fos_elastica.port%"
     serializer:
         serializer: jms_serializer
     indexes:


### PR DESCRIPTION
Use the Elasticsearch host and port parameters in all tests instead of the default localhost:9200.