### PR TITLE
added support for Symfony 5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,8 @@ matrix:
       env: DEPENDENCIES="symfony/flex" SYMFONY_VERSION="^3.4"
     - php: 7.4
       env: DEPENDENCIES="symfony/flex" SYMFONY_VERSION="^4.4"
+    - php: 7.4
+      env: DEPENDENCIES="symfony/flex" SYMFONY_VERSION="^5.0"
 
 before_install:
   - if [[ $COVERAGE != true ]]; then phpenv config-rm xdebug.ini || true; fi

--- a/composer.json
+++ b/composer.json
@@ -13,30 +13,30 @@
     ],
     "require": {
         "php": "^7.1",
-        "symfony/framework-bundle": "^3.4|^4.3",
-        "symfony/console": "^3.4|^4.3",
-        "symfony/dependency-injection": "^3.4|^4.3",
-        "symfony/property-access": "^3.4|^4.3",
+        "symfony/framework-bundle": "^3.4|^4.3|^5",
+        "symfony/console": "^3.4|^4.3|^5",
+        "symfony/dependency-injection": "^3.4|^4.3|^5",
+        "symfony/property-access": "^3.4|^4.3|^5",
         "pagerfanta/pagerfanta": "^1.0.5|^2.0",
         "psr/log": "^1.0",
         "ruflin/elastica": "^5.3.5|^6.1.1"
     },
     "require-dev": {
         "doctrine/orm": "^2.5",
-        "doctrine/doctrine-bundle": "^1.6",
+        "doctrine/doctrine-bundle": "^1.6|^2",
         "doctrine/persistence": "^1.3.3",
         "doctrine/phpcr-bundle": "^1.3|^2.0",
         "doctrine/phpcr-odm": "^1.4",
         "jackalope/jackalope-doctrine-dbal": "^1.2",
-        "jms/serializer-bundle": "^2.2",
-        "phpunit/phpunit": "^5.7.11|^6.5",
-        "knplabs/knp-components": "^1.2",
-        "symfony/expression-language" : "^3.4|^4.3",
-        "symfony/twig-bundle": "^3.4|^4.3",
-        "symfony/serializer": "^3.4|^4.3",
-        "symfony/yaml": "^3.4|^4.3",
+        "jms/serializer-bundle": "^2.4|^3.5",
+        "phpunit/phpunit": "^6.5.14",
+        "knplabs/knp-components": "^1.2|^2.3",
+        "symfony/expression-language" : "^3.4|^4.3|^5",
+        "symfony/twig-bundle": "^3.4|^4.3|^5",
+        "symfony/serializer": "^3.4|^4.3|^5",
+        "symfony/yaml": "^3.4|^4.3|^5",
         "friendsofphp/php-cs-fixer": "^2.2",
-        "symfony/web-profiler-bundle": "^3.4|^4.3"
+        "symfony/web-profiler-bundle": "^3.4|^4.3|^5"
     },
     "suggest": {
         "enqueue/elastica-bundle": "The bundle adds extra features to FOSElasticaBundle bundle. Aimed to improve performance."

--- a/src/Command/CreateCommand.php
+++ b/src/Command/CreateCommand.php
@@ -55,7 +55,7 @@ class CreateCommand extends Command
         ;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $indexName = $input->getOption('index');
         $indexes = null === $indexName ? array_keys($this->indexManager->getAllIndexes()) : [$indexName];
@@ -71,5 +71,7 @@ class CreateCommand extends Command
             $mapping = $this->mappingBuilder->buildIndexMapping($indexConfig);
             $index->create($mapping, false);
         }
+
+        return 0;
     }
 }

--- a/src/Command/ResetCommand.php
+++ b/src/Command/ResetCommand.php
@@ -49,7 +49,7 @@ class ResetCommand extends Command
         ;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $index = $input->getOption('index');
         $type = $input->getOption('type');
@@ -73,5 +73,7 @@ class ResetCommand extends Command
                 $this->resetter->resetIndex($index, false, $force);
             }
         }
+
+        return 0;
     }
 }

--- a/src/Command/ResetTemplatesCommand.php
+++ b/src/Command/ResetTemplatesCommand.php
@@ -63,7 +63,7 @@ final class ResetTemplatesCommand extends Command
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $indexTemplate = $input->getOption('index');
         $deleteByPattern = $input->getOption('force-delete');

--- a/src/Command/SearchCommand.php
+++ b/src/Command/SearchCommand.php
@@ -52,7 +52,7 @@ class SearchCommand extends Command
         ;
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $indexName = $input->getOption('index');
         $index = $this->indexManager->getIndex($indexName ? $indexName : null);
@@ -69,6 +69,8 @@ class SearchCommand extends Command
         foreach ($resultSet->getResults() as $result) {
             $output->writeLn($this->formatResult($result, $input->getOption('show-field'), $input->getOption('show-source'), $input->getOption('show-id'), $input->getOption('explain')));
         }
+
+        return 0;
     }
 
     /**

--- a/src/DataCollector/ElasticaDataCollector.php
+++ b/src/DataCollector/ElasticaDataCollector.php
@@ -15,77 +15,154 @@ use FOS\ElasticaBundle\Logger\ElasticaLogger;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\DataCollector\DataCollector;
+use Symfony\Component\HttpKernel\Kernel;
 
-/**
- * Data collector collecting elastica statistics.
- *
- * @author Gordon Franke <info@nevalon.de>
- */
-class ElasticaDataCollector extends DataCollector
-{
-    protected $logger;
-
-    public function __construct(ElasticaLogger $logger)
-    {
-        $this->logger = $logger;
-    }
-
-    public function collect(Request $request, Response $response, \Exception $exception = null)
-    {
-        $this->data['nb_queries'] = $this->logger->getNbQueries();
-        $this->data['queries'] = $this->logger->getQueries();
-    }
-
+if (Kernel::VERSION_ID >= 50000) {
     /**
-     * @return mixed
+     * Data collector collecting elastica statistics.
+     *
+     * @author Gordon Franke <info@nevalon.de>
      */
-    public function getQueryCount()
+    class ElasticaDataCollector extends DataCollector
     {
-        return $this->data['nb_queries'];
-    }
+        protected $logger;
 
-    /**
-     * @return mixed
-     */
-    public function getQueries()
-    {
-        return $this->data['queries'];
-    }
-
-    /**
-     * @return int
-     */
-    public function getTime()
-    {
-        $time = 0;
-        foreach ($this->data['queries'] as $query) {
-            $time += $query['engineMS'];
+        public function __construct(ElasticaLogger $logger)
+        {
+            $this->logger = $logger;
         }
 
-        return $time;
-    }
-
-    /**
-     * @return int
-     */
-    public function getExecutionTime()
-    {
-        $time = 0;
-        foreach ($this->data['queries'] as $query) {
-            $time += $query['executionMS'];
+        public function collect(Request $request, Response $response, \Throwable $exception = null)
+        {
+            $this->data['nb_queries'] = $this->logger->getNbQueries();
+            $this->data['queries'] = $this->logger->getQueries();
         }
 
-        return $time;
-    }
+        /**
+         * @return mixed
+         */
+        public function getQueryCount()
+        {
+            return $this->data['nb_queries'];
+        }
 
-    public function getName()
-    {
-        return 'elastica';
-    }
+        /**
+         * @return mixed
+         */
+        public function getQueries()
+        {
+            return $this->data['queries'];
+        }
 
-    public function reset()
+        /**
+         * @return int
+         */
+        public function getTime()
+        {
+            $time = 0;
+            foreach ($this->data['queries'] as $query) {
+                $time += $query['engineMS'];
+            }
+
+            return $time;
+        }
+
+        /**
+         * @return int
+         */
+        public function getExecutionTime()
+        {
+            $time = 0;
+            foreach ($this->data['queries'] as $query) {
+                $time += $query['executionMS'];
+            }
+
+            return $time;
+        }
+
+        public function getName()
+        {
+            return 'elastica';
+        }
+
+        public function reset()
+        {
+            $this->logger->reset();
+            $this->data = [];
+        }
+    }
+} else {
+    /**
+     * Data collector collecting elastica statistics.
+     *
+     * @author Gordon Franke <info@nevalon.de>
+     */
+    class ElasticaDataCollector extends DataCollector
     {
-        $this->logger->reset();
-        $this->data = [];
+        protected $logger;
+
+        public function __construct(ElasticaLogger $logger)
+        {
+            $this->logger = $logger;
+        }
+
+        public function collect(Request $request, Response $response, \Exception $exception = null)
+        {
+            $this->data['nb_queries'] = $this->logger->getNbQueries();
+            $this->data['queries'] = $this->logger->getQueries();
+        }
+
+        /**
+         * @return mixed
+         */
+        public function getQueryCount()
+        {
+            return $this->data['nb_queries'];
+        }
+
+        /**
+         * @return mixed
+         */
+        public function getQueries()
+        {
+            return $this->data['queries'];
+        }
+
+        /**
+         * @return int
+         */
+        public function getTime()
+        {
+            $time = 0;
+            foreach ($this->data['queries'] as $query) {
+                $time += $query['engineMS'];
+            }
+
+            return $time;
+        }
+
+        /**
+         * @return int
+         */
+        public function getExecutionTime()
+        {
+            $time = 0;
+            foreach ($this->data['queries'] as $query) {
+                $time += $query['executionMS'];
+            }
+
+            return $time;
+        }
+
+        public function getName()
+        {
+            return 'elastica';
+        }
+
+        public function reset()
+        {
+            $this->logger->reset();
+            $this->data = [];
+        }
     }
 }

--- a/src/Doctrine/RegisterListenersService.php
+++ b/src/Doctrine/RegisterListenersService.php
@@ -17,17 +17,21 @@ use Doctrine\Persistence\ObjectManager;
 use FOS\ElasticaBundle\Persister\Event\Events;
 use FOS\ElasticaBundle\Persister\Event\PersistEvent;
 use FOS\ElasticaBundle\Provider\PagerInterface;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface as LegacyEventDispatcherInterface;
 use Symfony\Component\EventDispatcher\LegacyEventDispatcherProxy;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 class RegisterListenersService
 {
     /**
-     * @var EventDispatcherInterface
+     * @var EventDispatcherInterface|LegacyEventDispatcherInterface
      */
     private $dispatcher;
 
-    public function __construct(EventDispatcherInterface $dispatcher)
+    /**
+     * @param EventDispatcherInterface|LegacyEventDispatcherInterface $dispatcher
+     */
+    public function __construct(/* EventDispatcherInterface */ $dispatcher)
     {
         $this->dispatcher = $dispatcher;
 

--- a/src/Event/AbstractEvent.php
+++ b/src/Event/AbstractEvent.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FOS\ElasticaBundle\Event;
+
+use Symfony\Component\EventDispatcher\Event as LegacyEvent;
+use Symfony\Contracts\EventDispatcher\Event;
+
+if (!class_exists(Event::class)) {
+    /**
+     * Symfony 3.4
+     */
+    abstract class AbstractEvent extends LegacyEvent
+    {
+    }
+} else {
+    /**
+     * Symfony >= 4.3
+     */
+    abstract class AbstractEvent extends Event
+    {
+    }
+}

--- a/src/Event/IndexEvent.php
+++ b/src/Event/IndexEvent.php
@@ -11,9 +11,7 @@
 
 namespace FOS\ElasticaBundle\Event;
 
-use Symfony\Component\EventDispatcher\Event;
-
-class IndexEvent extends Event
+class IndexEvent extends AbstractEvent
 {
     /**
      * @var string

--- a/src/Event/IndexPopulateEvent.php
+++ b/src/Event/IndexPopulateEvent.php
@@ -11,92 +11,189 @@
 
 namespace FOS\ElasticaBundle\Event;
 
-/**
- * Index Populate Event.
- *
- * @author Oleg Andreyev <oleg.andreyev@intexsys.lv>
- */
-class IndexPopulateEvent extends IndexEvent
-{
+use Symfony\Component\EventDispatcher\Event as LegacyEvent;
+use Symfony\Contracts\EventDispatcher\Event;
+
+if (!class_exists(Event::class)) {
     /**
-     * @Event("FOS\ElasticaBundle\Event\IndexPopulateEvent")
+     * Symfony 3.4
      */
-    const PRE_INDEX_POPULATE = 'elastica.index.index_pre_populate';
 
     /**
-     * @Event("FOS\ElasticaBundle\Event\IndexPopulateEvent")
-     */
-    const POST_INDEX_POPULATE = 'elastica.index.index_post_populate';
-
-    /**
-     * @var bool
-     */
-    private $reset;
-
-    /**
-     * @var array
-     */
-    private $options;
-
-    /**
-     * @param string $index
-     * @param bool   $reset
-     * @param array  $options
-     */
-    public function __construct($index, $reset, $options)
-    {
-        parent::__construct($index);
-
-        $this->reset = $reset;
-        $this->options = $options;
-    }
-
-    /**
-     * @return bool
-     */
-    public function isReset()
-    {
-        return $this->reset;
-    }
-
-    /**
-     * @return array
-     */
-    public function getOptions()
-    {
-        return $this->options;
-    }
-
-    /**
-     * @param bool $reset
-     */
-    public function setReset($reset)
-    {
-        $this->reset = $reset;
-    }
-
-    /**
-     * @param string $name
+     * Index Populate Event.
      *
-     * @return mixed
-     *
-     * @throws \InvalidArgumentException if option does not exist
+     * @author Oleg Andreyev <oleg.andreyev@intexsys.lv>
      */
-    public function getOption($name)
+    class IndexPopulateEvent extends IndexEvent
     {
-        if (!isset($this->options[$name])) {
-            throw new \InvalidArgumentException(sprintf('The "%s" option does not exist.', $name));
+        /**
+         * @LegacyEvent("FOS\ElasticaBundle\Event\IndexPopulateEvent")
+         */
+        const PRE_INDEX_POPULATE = 'elastica.index.index_pre_populate';
+        /**
+         * @LegacyEvent("FOS\ElasticaBundle\Event\IndexPopulateEvent")
+         */
+        const POST_INDEX_POPULATE = 'elastica.index.index_post_populate';
+        /**
+         * @var bool
+         */
+        private $reset;
+        /**
+         * @var array
+         */
+        private $options;
+
+        /**
+         * @param string $index
+         * @param bool   $reset
+         * @param array  $options
+         */
+        public function __construct($index, $reset, $options)
+        {
+            parent::__construct($index);
+
+            $this->reset = $reset;
+            $this->options = $options;
         }
 
-        return $this->options[$name];
+        /**
+         * @return bool
+         */
+        public function isReset()
+        {
+            return $this->reset;
+        }
+
+        /**
+         * @return array
+         */
+        public function getOptions()
+        {
+            return $this->options;
+        }
+
+        /**
+         * @param bool $reset
+         */
+        public function setReset($reset)
+        {
+            $this->reset = $reset;
+        }
+
+        /**
+         * @param string $name
+         *
+         * @return mixed
+         *
+         * @throws \InvalidArgumentException if option does not exist
+         */
+        public function getOption($name)
+        {
+            if (!isset($this->options[$name])) {
+                throw new \InvalidArgumentException(sprintf('The "%s" option does not exist.', $name));
+            }
+
+            return $this->options[$name];
+        }
+
+        /**
+         * @param string $name
+         * @param mixed  $value
+         */
+        public function setOption($name, $value)
+        {
+            $this->options[$name] = $value;
+        }
     }
+} else {
+    /**
+     * Symfony >= 4.3
+     */
 
     /**
-     * @param string $name
-     * @param mixed  $value
+     * Index Populate Event.
+     *
+     * @author Oleg Andreyev <oleg.andreyev@intexsys.lv>
      */
-    public function setOption($name, $value)
+    class IndexPopulateEvent extends IndexEvent
     {
-        $this->options[$name] = $value;
+        /**
+         * @Event("FOS\ElasticaBundle\Event\IndexPopulateEvent")
+         */
+        const PRE_INDEX_POPULATE = 'elastica.index.index_pre_populate';
+        /**
+         * @Event("FOS\ElasticaBundle\Event\IndexPopulateEvent")
+         */
+        const POST_INDEX_POPULATE = 'elastica.index.index_post_populate';
+        /**
+         * @var bool
+         */
+        private $reset;
+        /**
+         * @var array
+         */
+        private $options;
+
+        /**
+         * @param string $index
+         * @param bool   $reset
+         * @param array  $options
+         */
+        public function __construct($index, $reset, $options)
+        {
+            parent::__construct($index);
+
+            $this->reset = $reset;
+            $this->options = $options;
+        }
+
+        /**
+         * @return bool
+         */
+        public function isReset()
+        {
+            return $this->reset;
+        }
+
+        /**
+         * @return array
+         */
+        public function getOptions()
+        {
+            return $this->options;
+        }
+
+        /**
+         * @param bool $reset
+         */
+        public function setReset($reset)
+        {
+            $this->reset = $reset;
+        }
+
+        /**
+         * @param string $name
+         *
+         * @return mixed
+         *
+         * @throws \InvalidArgumentException if option does not exist
+         */
+        public function getOption($name)
+        {
+            if (!isset($this->options[$name])) {
+                throw new \InvalidArgumentException(sprintf('The "%s" option does not exist.', $name));
+            }
+
+            return $this->options[$name];
+        }
+
+        /**
+         * @param string $name
+         * @param mixed  $value
+         */
+        public function setOption($name, $value)
+        {
+            $this->options[$name] = $value;
+        }
     }
 }

--- a/src/Event/IndexResetEvent.php
+++ b/src/Event/IndexResetEvent.php
@@ -11,67 +11,142 @@
 
 namespace FOS\ElasticaBundle\Event;
 
-/**
- * Index ResetEvent.
- *
- * @author Oleg Andreyev <oleg.andreyev@intexsys.lv>
- */
-class IndexResetEvent extends IndexEvent
-{
+use Symfony\Component\EventDispatcher\Event as LegacyEvent;
+use Symfony\Contracts\EventDispatcher\Event;
+
+if (!class_exists(Event::class)) {
     /**
-     * @Event("FOS\ElasticaBundle\Event\IndexResetEvent")
+     * Symfony 3.4
      */
-    const PRE_INDEX_RESET = 'elastica.index.pre_reset';
 
     /**
-     * @Event("FOS\ElasticaBundle\Event\IndexResetEvent")
+     * Index ResetEvent.
+     *
+     * @author Oleg Andreyev <oleg.andreyev@intexsys.lv>
      */
-    const POST_INDEX_RESET = 'elastica.index.post_reset';
-
-    /**
-     * @var bool
-     */
-    private $force;
-
-    /**
-     * @var bool
-     */
-    private $populating;
-
-    /**
-     * @param string $index
-     * @param bool   $populating
-     * @param bool   $force
-     */
-    public function __construct($index, $populating, $force)
+    class IndexResetEvent extends IndexEvent
     {
-        parent::__construct($index);
+        /**
+         * @LegacyEvent("FOS\ElasticaBundle\Event\IndexResetEvent")
+         */
+        const PRE_INDEX_RESET = 'elastica.index.pre_reset';
+        /**
+         * @LegacyEvent("FOS\ElasticaBundle\Event\IndexResetEvent")
+         */
+        const POST_INDEX_RESET = 'elastica.index.post_reset';
+        /**
+         * @var bool
+         */
+        private $force;
+        /**
+         * @var bool
+         */
+        private $populating;
 
-        $this->force = $force;
-        $this->populating = $populating;
+        /**
+         * @param string $index
+         * @param bool   $populating
+         * @param bool   $force
+         */
+        public function __construct($index, $populating, $force)
+        {
+            parent::__construct($index);
+
+            $this->force = $force;
+            $this->populating = $populating;
+        }
+
+        /**
+         * @return bool
+         */
+        public function isForce()
+        {
+            return $this->force;
+        }
+
+        /**
+         * @return bool
+         */
+        public function isPopulating()
+        {
+            return $this->populating;
+        }
+
+        /**
+         * @param bool $force
+         */
+        public function setForce($force)
+        {
+            $this->force = $force;
+        }
     }
+} else {
+    /**
+     * Symfony >= 4.3
+     */
 
     /**
-     * @return bool
+     * Index ResetEvent.
+     *
+     * @author Oleg Andreyev <oleg.andreyev@intexsys.lv>
      */
-    public function isForce()
+    class IndexResetEvent extends IndexEvent
     {
-        return $this->force;
-    }
+        /**
+         * @Event("FOS\ElasticaBundle\Event\IndexResetEvent")
+         */
+        const PRE_INDEX_RESET = 'elastica.index.pre_reset';
 
-    /**
-     * @return bool
-     */
-    public function isPopulating()
-    {
-        return $this->populating;
-    }
+        /**
+         * @Event("FOS\ElasticaBundle\Event\IndexResetEvent")
+         */
+        const POST_INDEX_RESET = 'elastica.index.post_reset';
 
-    /**
-     * @param bool $force
-     */
-    public function setForce($force)
-    {
-        $this->force = $force;
+        /**
+         * @var bool
+         */
+        private $force;
+
+        /**
+         * @var bool
+         */
+        private $populating;
+
+        /**
+         * @param string $index
+         * @param bool   $populating
+         * @param bool   $force
+         */
+        public function __construct($index, $populating, $force)
+        {
+            parent::__construct($index);
+
+            $this->force = $force;
+            $this->populating = $populating;
+        }
+
+        /**
+         * @return bool
+         */
+        public function isForce()
+        {
+            return $this->force;
+        }
+
+        /**
+         * @return bool
+         */
+        public function isPopulating()
+        {
+            return $this->populating;
+        }
+
+        /**
+         * @param bool $force
+         */
+        public function setForce($force)
+        {
+            $this->force = $force;
+        }
     }
 }

--- a/src/Event/TransformEvent.php
+++ b/src/Event/TransformEvent.php
@@ -12,76 +12,149 @@
 namespace FOS\ElasticaBundle\Event;
 
 use Elastica\Document;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\EventDispatcher\Event as LegacyEvent;
+use Symfony\Contracts\EventDispatcher\Event;
 
-class TransformEvent extends Event
-{
+if (!class_exists(Event::class)) {
     /**
-     * @Event("FOS\ElasticaBundle\Event\TransformEvent")
+     * Symfony 3.4
      */
-    const PRE_TRANSFORM = 'fos_elastica.pre_transform';
-
-    /**
-     * @Event("FOS\ElasticaBundle\Event\TransformEvent")
-     */
-    const POST_TRANSFORM = 'fos_elastica.post_transform';
-
-    /**
-     * @var Document
-     */
-    private $document;
-
-    /**
-     * @var array
-     */
-    private $fields;
-
-    /**
-     * @var object
-     */
-    private $object;
-
-    /**
-     * @param mixed $document
-     * @param array $fields
-     * @param object $object
-     */
-    public function __construct($document, array $fields, $object)
+    class TransformEvent extends LegacyEvent
     {
-        $this->document = $document;
-        $this->fields = $fields;
-        $this->object = $object;
+        /**
+         * @LegacyEvent("FOS\ElasticaBundle\Event\TransformEvent")
+         */
+        const PRE_TRANSFORM = 'fos_elastica.pre_transform';
+        /**
+         * @LegacyEvent("FOS\ElasticaBundle\Event\TransformEvent")
+         */
+        const POST_TRANSFORM = 'fos_elastica.post_transform';
+        /**
+         * @var Document
+         */
+        private $document;
+        /**
+         * @var array
+         */
+        private $fields;
+        /**
+         * @var object
+         */
+        private $object;
+
+        /**
+         * @param mixed  $document
+         * @param array  $fields
+         * @param object $object
+         */
+        public function __construct($document, array $fields, $object)
+        {
+            $this->document = $document;
+            $this->fields = $fields;
+            $this->object = $object;
+        }
+
+        /**
+         * @return Document
+         */
+        public function getDocument()
+        {
+            return $this->document;
+        }
+
+        /**
+         * @return array
+         */
+        public function getFields()
+        {
+            return $this->fields;
+        }
+
+        /**
+         * @return object
+         */
+        public function getObject()
+        {
+            return $this->object;
+        }
+
+        /**
+         * @param Document $document
+         */
+        public function setDocument($document)
+        {
+            $this->document = $document;
+        }
     }
-
+} else {
     /**
-     * @return Document
+     * Symfony >= 4.3
      */
-    public function getDocument()
+    class TransformEvent extends Event
     {
-        return $this->document;
-    }
+        /**
+         * @Event("FOS\ElasticaBundle\Event\TransformEvent")
+         */
+        const PRE_TRANSFORM = 'fos_elastica.pre_transform';
+        /**
+         * @Event("FOS\ElasticaBundle\Event\TransformEvent")
+         */
+        const POST_TRANSFORM = 'fos_elastica.post_transform';
+        /**
+         * @var Document
+         */
+        private $document;
+        /**
+         * @var array
+         */
+        private $fields;
+        /**
+         * @var object
+         */
+        private $object;
 
-    /**
-     * @return array
-     */
-    public function getFields()
-    {
-        return $this->fields;
-    }
+        /**
+         * @param mixed  $document
+         * @param array  $fields
+         * @param object $object
+         */
+        public function __construct($document, array $fields, $object)
+        {
+            $this->document = $document;
+            $this->fields = $fields;
+            $this->object = $object;
+        }
 
-    /**
-     * @return object
-     */
-    public function getObject()
-    {
-        return $this->object;
-    }
+        /**
+         * @return Document
+         */
+        public function getDocument()
+        {
+            return $this->document;
+        }
 
-    /**
-     * @param Document $document
-     */
-    public function setDocument($document)
-    {
-        $this->document = $document;
+        /**
+         * @return array
+         */
+        public function getFields()
+        {
+            return $this->fields;
+        }
+
+        /**
+         * @return object
+         */
+        public function getObject()
+        {
+            return $this->object;
+        }
+
+        /**
+         * @param Document $document
+         */
+        public function setDocument($document)
+        {
+            $this->document = $document;
+        }
     }
 }

--- a/src/Event/TypePopulateEvent.php
+++ b/src/Event/TypePopulateEvent.php
@@ -11,48 +11,101 @@
 
 namespace FOS\ElasticaBundle\Event;
 
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\EventDispatcher\Event as LegacyEvent;
+use Symfony\Contracts\EventDispatcher\Event;
 
-/**
- * Type Populate Event.
- *
- * @author Oleg Andreyev <oleg.andreyev@intexsys.lv>
- */
-class TypePopulateEvent extends IndexPopulateEvent
-{
+if (!class_exists(Event::class)) {
     /**
-     * @Event("FOS\ElasticaBundle\Event\TypePopulateEvent")
+     * Symfony 3.4
      */
-    const PRE_TYPE_POPULATE = 'elastica.index.type_pre_populate';
 
     /**
-     * @Event("FOS\ElasticaBundle\Event\TypePopulateEvent")
+     * Type Populate Event.
+     *
+     * @author Oleg Andreyev <oleg.andreyev@intexsys.lv>
      */
-    const POST_TYPE_POPULATE = 'elastica.index.type_post_populate';
-
-    /**
-     * @var string
-     */
-    private $type;
-
-    /**
-     * @param string $index
-     * @param string $type
-     * @param bool   $reset
-     * @param array  $options
-     */
-    public function __construct($index, $type, $reset, $options)
+    class TypePopulateEvent extends IndexPopulateEvent
     {
-        parent::__construct($index, $reset, $options);
+        /**
+         * @LegacyEvent("FOS\ElasticaBundle\Event\TypePopulateEvent")
+         */
+        const PRE_TYPE_POPULATE = 'elastica.index.type_pre_populate';
+        /**
+         * @LegacyEvent("FOS\ElasticaBundle\Event\TypePopulateEvent")
+         */
+        const POST_TYPE_POPULATE = 'elastica.index.type_post_populate';
+        /**
+         * @var string
+         */
+        private $type;
 
-        $this->type = $type;
+        /**
+         * @param string $index
+         * @param string $type
+         * @param bool   $reset
+         * @param array  $options
+         */
+        public function __construct($index, $type, $reset, $options)
+        {
+            parent::__construct($index, $reset, $options);
+
+            $this->type = $type;
+        }
+
+        /**
+         * @return string
+         */
+        public function getType()
+        {
+            return $this->type;
+        }
     }
+} else {
+    /**
+     * Symfony >= 4.3
+     */
 
     /**
-     * @return string
+     * Type Populate Event.
+     *
+     * @author Oleg Andreyev <oleg.andreyev@intexsys.lv>
      */
-    public function getType()
+    class TypePopulateEvent extends IndexPopulateEvent
     {
-        return $this->type;
+        /**
+         * @LegacyEvent("FOS\ElasticaBundle\Event\TypePopulateEvent")
+         */
+        const PRE_TYPE_POPULATE = 'elastica.index.type_pre_populate';
+
+        /**
+         * @LegacyEvent("FOS\ElasticaBundle\Event\TypePopulateEvent")
+         */
+        const POST_TYPE_POPULATE = 'elastica.index.type_post_populate';
+
+        /**
+         * @var string
+         */
+        private $type;
+
+        /**
+         * @param string $index
+         * @param string $type
+         * @param bool   $reset
+         * @param array  $options
+         */
+        public function __construct($index, $type, $reset, $options)
+        {
+            parent::__construct($index, $reset, $options);
+
+            $this->type = $type;
+        }
+
+        /**
+         * @return string
+         */
+        public function getType()
+        {
+            return $this->type;
+        }
     }
 }

--- a/src/Event/TypeResetEvent.php
+++ b/src/Event/TypeResetEvent.php
@@ -11,46 +11,95 @@
 
 namespace FOS\ElasticaBundle\Event;
 
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\EventDispatcher\Event as LegacyEvent;
+use Symfony\Contracts\EventDispatcher\Event;
 
-/**
- * Type ResetEvent.
- *
- * @author Oleg Andreyev <oleg.andreyev@intexsys.lv>
- */
-class TypeResetEvent extends IndexEvent
-{
+if (!class_exists(Event::class)) {
     /**
-     * @Event("FOS\ElasticaBundle\Event\TypeResetEvent")
+     * Symfony 3.4
      */
-    const PRE_TYPE_RESET = 'elastica.index.type_pre_reset';
 
     /**
-     * @Event("FOS\ElasticaBundle\Event\TypeResetEvent")
+     * Type ResetEvent.
+     *
+     * @author Oleg Andreyev <oleg.andreyev@intexsys.lv>
      */
-    const POST_TYPE_RESET = 'elastica.index.type_post_reset';
-
-    /**
-     * @var string
-     */
-    private $type;
-
-    /**
-     * @param string $index
-     * @param string $type
-     */
-    public function __construct($index, $type)
+    class TypeResetEvent extends IndexEvent
     {
-        parent::__construct($index);
+        /**
+         * @LegacyEvent("FOS\ElasticaBundle\Event\TypeResetEvent")
+         */
+        const PRE_TYPE_RESET = 'elastica.index.type_pre_reset';
+        /**
+         * @LegacyEvent("FOS\ElasticaBundle\Event\TypeResetEvent")
+         */
+        const POST_TYPE_RESET = 'elastica.index.type_post_reset';
+        /**
+         * @var string
+         */
+        private $type;
 
-        $this->type = $type;
+        /**
+         * @param string $index
+         * @param string $type
+         */
+        public function __construct($index, $type)
+        {
+            parent::__construct($index);
+
+            $this->type = $type;
+        }
+
+        /**
+         * @return string
+         */
+        public function getType()
+        {
+            return $this->type;
+        }
     }
+} else {
+    /**
+     * Symfony >= 4.3
+     */
 
     /**
-     * @return string
+     * Type ResetEvent.
+     *
+     * @author Oleg Andreyev <oleg.andreyev@intexsys.lv>
      */
-    public function getType()
+    class TypeResetEvent extends IndexEvent
     {
-        return $this->type;
+        /**
+         * @Event("FOS\ElasticaBundle\Event\TypeResetEvent")
+         */
+        const PRE_TYPE_RESET = 'elastica.index.type_pre_reset';
+        /**
+         * @Event("FOS\ElasticaBundle\Event\TypeResetEvent")
+         */
+        const POST_TYPE_RESET = 'elastica.index.type_post_reset';
+        /**
+         * @var string
+         */
+        private $type;
+
+        /**
+         * @param string $index
+         * @param string $type
+         */
+        public function __construct($index, $type)
+        {
+            parent::__construct($index);
+
+            $this->type = $type;
+        }
+
+        /**
+         * @return string
+         */
+        public function getType()
+        {
+            return $this->type;
+        }
     }
 }

--- a/src/Persister/Event/OnExceptionEvent.php
+++ b/src/Persister/Event/OnExceptionEvent.php
@@ -1,11 +1,11 @@
 <?php
 namespace FOS\ElasticaBundle\Persister\Event;
 
+use FOS\ElasticaBundle\Event\AbstractEvent;
 use FOS\ElasticaBundle\Persister\ObjectPersisterInterface;
 use FOS\ElasticaBundle\Provider\PagerInterface;
-use Symfony\Component\EventDispatcher\Event;
 
-final class OnExceptionEvent extends Event implements PersistEvent
+final class OnExceptionEvent extends AbstractEvent implements PersistEvent
 {
     /**
      * @var PagerInterface

--- a/src/Persister/Event/PostAsyncInsertObjectsEvent.php
+++ b/src/Persister/Event/PostAsyncInsertObjectsEvent.php
@@ -1,11 +1,11 @@
 <?php
 namespace FOS\ElasticaBundle\Persister\Event;
 
+use FOS\ElasticaBundle\Event\AbstractEvent;
 use FOS\ElasticaBundle\Persister\ObjectPersisterInterface;
 use FOS\ElasticaBundle\Provider\PagerInterface;
-use Symfony\Component\EventDispatcher\Event;
 
-final class PostAsyncInsertObjectsEvent extends Event implements PersistEvent
+final class PostAsyncInsertObjectsEvent extends AbstractEvent implements PersistEvent
 {
     /**
      * @var PagerInterface

--- a/src/Persister/Event/PostInsertObjectsEvent.php
+++ b/src/Persister/Event/PostInsertObjectsEvent.php
@@ -1,11 +1,12 @@
 <?php
+
 namespace FOS\ElasticaBundle\Persister\Event;
 
+use FOS\ElasticaBundle\Event\AbstractEvent;
 use FOS\ElasticaBundle\Persister\ObjectPersisterInterface;
 use FOS\ElasticaBundle\Provider\PagerInterface;
-use Symfony\Component\EventDispatcher\Event;
 
-final class PostInsertObjectsEvent extends Event implements PersistEvent
+final class PostInsertObjectsEvent extends AbstractEvent implements PersistEvent
 {
     /**
      * @var PagerInterface

--- a/src/Persister/Event/PostPersistEvent.php
+++ b/src/Persister/Event/PostPersistEvent.php
@@ -1,11 +1,11 @@
 <?php
 namespace FOS\ElasticaBundle\Persister\Event;
 
+use FOS\ElasticaBundle\Event\AbstractEvent;
 use FOS\ElasticaBundle\Persister\ObjectPersisterInterface;
 use FOS\ElasticaBundle\Provider\PagerInterface;
-use Symfony\Component\EventDispatcher\Event;
 
-final class PostPersistEvent extends Event implements PersistEvent
+final class PostPersistEvent extends AbstractEvent implements PersistEvent
 {
     /**
      * @var PagerInterface

--- a/src/Persister/Event/PreFetchObjectsEvent.php
+++ b/src/Persister/Event/PreFetchObjectsEvent.php
@@ -1,11 +1,11 @@
 <?php
 namespace FOS\ElasticaBundle\Persister\Event;
 
+use FOS\ElasticaBundle\Event\AbstractEvent;
 use FOS\ElasticaBundle\Persister\ObjectPersisterInterface;
 use FOS\ElasticaBundle\Provider\PagerInterface;
-use Symfony\Component\EventDispatcher\Event;
 
-final class PreFetchObjectsEvent extends Event implements PersistEvent
+final class PreFetchObjectsEvent extends AbstractEvent implements PersistEvent
 {
     /**
      * @var PagerInterface

--- a/src/Persister/Event/PreInsertObjectsEvent.php
+++ b/src/Persister/Event/PreInsertObjectsEvent.php
@@ -1,11 +1,11 @@
 <?php
 namespace FOS\ElasticaBundle\Persister\Event;
 
+use FOS\ElasticaBundle\Event\AbstractEvent;
 use FOS\ElasticaBundle\Persister\ObjectPersisterInterface;
 use FOS\ElasticaBundle\Provider\PagerInterface;
-use Symfony\Component\EventDispatcher\Event;
 
-final class PreInsertObjectsEvent extends Event implements PersistEvent
+final class PreInsertObjectsEvent extends AbstractEvent implements PersistEvent
 {
     /**
      * @var PagerInterface

--- a/src/Persister/Event/PrePersistEvent.php
+++ b/src/Persister/Event/PrePersistEvent.php
@@ -1,11 +1,11 @@
 <?php
 namespace FOS\ElasticaBundle\Persister\Event;
 
+use FOS\ElasticaBundle\Event\AbstractEvent;
 use FOS\ElasticaBundle\Persister\ObjectPersisterInterface;
 use FOS\ElasticaBundle\Provider\PagerInterface;
-use Symfony\Component\EventDispatcher\Event;
 
-final class PrePersistEvent extends Event implements PersistEvent
+final class PrePersistEvent extends AbstractEvent implements PersistEvent
 {
     /**
      * @var PagerInterface

--- a/src/Subscriber/PaginateElasticaQuerySubscriber.php
+++ b/src/Subscriber/PaginateElasticaQuerySubscriber.php
@@ -74,7 +74,7 @@ class PaginateElasticaQuerySubscriber implements EventSubscriberInterface
     protected function setSorting(ItemsEvent $event)
     {
         $options = $event->options;
-        $sortField = $this->getFromRequest($options['sortFieldParameterName']);
+        $sortField = $this->getFromRequest($options['sortFieldParameterName'] ?? null);
 
         if (!$sortField && isset($options['defaultSortFieldName'])) {
             $sortField = $options['defaultSortFieldName'];

--- a/tests/Functional/ProfilerTest.php
+++ b/tests/Functional/ProfilerTest.php
@@ -20,6 +20,7 @@ use Symfony\Bridge\Twig\Extension\HttpKernelRuntime;
 use Symfony\Bridge\Twig\Extension\RoutingExtension;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Fragment\FragmentHandler;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Twig\Loader\FilesystemLoader;
 use Twig\Environment;
@@ -48,12 +49,18 @@ class ProfilerTest extends WebTestCase
         $twigLoaderFilesystem->addPath(__DIR__ . '/../../vendor/symfony/web-profiler-bundle/Resources/views', 'WebProfiler');
         $this->twig = new Environment($twigLoaderFilesystem, ['debug' => true, 'strict_variables' => true]);
 
+        $urlGenerator = $this->createMock(UrlGeneratorInterface::class);
+        $urlGenerator->method('generate')->willReturn('');
+        $fragmentHandler = $this->createMock(FragmentHandler::class);
+        $fragmentHandler->method('render')->willReturn('');
+
         $this->twig->addExtension(new CodeExtension('', '', ''));
-        $this->twig->addExtension(new RoutingExtension($this->getMockBuilder(UrlGeneratorInterface::class)->getMock()));
-        $this->twig->addExtension(new HttpKernelExtension($this->getMockBuilder(FragmentHandler::class)->disableOriginalConstructor()->getMock()));
+        $this->twig->addExtension(new RoutingExtension($urlGenerator));
+        $this->twig->addExtension(new HttpKernelExtension($fragmentHandler));
 
         $loader = $this->getMockBuilder(RuntimeLoaderInterface::class)->getMock();
-        $loader->method('load')->willReturn($this->getMockBuilder(HttpKernelRuntime::class)->disableOriginalConstructor()->getMock());
+
+        $loader->method('load')->willReturn(new HttpKernelRuntime($fragmentHandler));
         $this->twig->addRuntimeLoader($loader);
     }
 

--- a/tests/Functional/TypeObj.php
+++ b/tests/Functional/TypeObj.php
@@ -18,6 +18,11 @@ class TypeObj
     public $field1;
     public $field2;
 
+    public function __construct()
+    {
+        $this->coll = new \ArrayIterator();
+    }
+
     public function isIndexable()
     {
         return true;

--- a/tests/Functional/app/Serializer/TypeObj.yml
+++ b/tests/Functional/app/Serializer/TypeObj.yml
@@ -1,8 +1,9 @@
 FOS\ElasticaBundle\Tests\Functional\TypeObj:
+    exclusion_policy: ALL
     properties:
         field1:
             type: text
-    virtualProperties:
+    virtual_properties:
         getSerializableColl:
-            serializedName: coll
+            serialized_name: coll
             type: array

--- a/tests/Functional/app/Serializer/config.yml
+++ b/tests/Functional/app/Serializer/config.yml
@@ -19,7 +19,7 @@ jms_serializer:
         directories:
             type_obj:
                 namespace_prefix: "FOS\\ElasticaBundle\\Tests\\Functional"
-                path: "%kernel.root_dir%/Serializer"
+                path: "%kernel.project_dir%/tests/Functional/app/Serializer"
 
 fos_elastica:
     clients:

--- a/tests/Unit/Persister/Event/OnExceptionEventTest.php
+++ b/tests/Unit/Persister/Event/OnExceptionEventTest.php
@@ -6,7 +6,8 @@ use FOS\ElasticaBundle\Persister\Event\PersistEvent;
 use FOS\ElasticaBundle\Persister\ObjectPersisterInterface;
 use FOS\ElasticaBundle\Provider\PagerInterface;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\EventDispatcher\Event as LegacyEvent;
+use Symfony\Contracts\EventDispatcher\Event;
 
 final class OnExceptionEventTest extends TestCase
 {
@@ -14,7 +15,7 @@ final class OnExceptionEventTest extends TestCase
     {
         $rc = new \ReflectionClass(OnExceptionEvent::class);
 
-        $this->assertTrue($rc->isSubclassOf(Event::class));
+        $this->assertTrue($rc->isSubclassOf(class_exists(Event::class) ? Event::class : LegacyEvent::class));
     }
 
     public function testShouldImplementPersistEventInterface()

--- a/tests/Unit/Persister/Event/PostAsyncInsertObjectsEventTest.php
+++ b/tests/Unit/Persister/Event/PostAsyncInsertObjectsEventTest.php
@@ -6,7 +6,8 @@ use FOS\ElasticaBundle\Persister\Event\PostAsyncInsertObjectsEvent;
 use FOS\ElasticaBundle\Persister\ObjectPersisterInterface;
 use FOS\ElasticaBundle\Provider\PagerInterface;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\EventDispatcher\Event as LegacyEvent;
+use Symfony\Contracts\EventDispatcher\Event;
 
 final class PostAsyncInsertObjectsEventTest extends TestCase
 {
@@ -14,7 +15,7 @@ final class PostAsyncInsertObjectsEventTest extends TestCase
     {
         $rc = new \ReflectionClass(PostAsyncInsertObjectsEvent::class);
 
-        $this->assertTrue($rc->isSubclassOf(Event::class));
+        $this->assertTrue($rc->isSubclassOf(class_exists(Event::class) ? Event::class : LegacyEvent::class));
     }
 
     public function testShouldImplementPersistEventInterface()

--- a/tests/Unit/Persister/Event/PostInsertObjectsEventTest.php
+++ b/tests/Unit/Persister/Event/PostInsertObjectsEventTest.php
@@ -6,7 +6,8 @@ use FOS\ElasticaBundle\Persister\Event\PostInsertObjectsEvent;
 use FOS\ElasticaBundle\Persister\ObjectPersisterInterface;
 use FOS\ElasticaBundle\Provider\PagerInterface;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\EventDispatcher\Event as LegacyEvent;
+use Symfony\Contracts\EventDispatcher\Event;
 
 final class PostInsertObjectsEventTest extends TestCase
 {
@@ -14,7 +15,7 @@ final class PostInsertObjectsEventTest extends TestCase
     {
         $rc = new \ReflectionClass(PostInsertObjectsEvent::class);
 
-        $this->assertTrue($rc->isSubclassOf(Event::class));
+        $this->assertTrue($rc->isSubclassOf(class_exists(Event::class) ? Event::class : LegacyEvent::class));
     }
 
     public function testShouldImplementPersistEventInterface()

--- a/tests/Unit/Persister/Event/PostPersistEventTest.php
+++ b/tests/Unit/Persister/Event/PostPersistEventTest.php
@@ -6,7 +6,8 @@ use FOS\ElasticaBundle\Persister\Event\PostPersistEvent;
 use FOS\ElasticaBundle\Persister\ObjectPersisterInterface;
 use FOS\ElasticaBundle\Provider\PagerInterface;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\EventDispatcher\Event as LegacyEvent;
+use Symfony\Contracts\EventDispatcher\Event;
 
 final class PostPersistEventTest extends TestCase
 {
@@ -14,7 +15,7 @@ final class PostPersistEventTest extends TestCase
     {
         $rc = new \ReflectionClass(PostPersistEvent::class);
 
-        $this->assertTrue($rc->isSubclassOf(Event::class));
+        $this->assertTrue($rc->isSubclassOf(class_exists(Event::class) ? Event::class : LegacyEvent::class));
     }
 
     public function testShouldImplementPersistEventInterface()

--- a/tests/Unit/Persister/Event/PreFetchObjectsEventTest.php
+++ b/tests/Unit/Persister/Event/PreFetchObjectsEventTest.php
@@ -6,7 +6,8 @@ use FOS\ElasticaBundle\Persister\Event\PreFetchObjectsEvent;
 use FOS\ElasticaBundle\Persister\ObjectPersisterInterface;
 use FOS\ElasticaBundle\Provider\PagerInterface;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\EventDispatcher\Event as LegacyEvent;
+use Symfony\Contracts\EventDispatcher\Event;
 
 final class PreFetchObjectsEventTest extends TestCase
 {
@@ -14,7 +15,7 @@ final class PreFetchObjectsEventTest extends TestCase
     {
         $rc = new \ReflectionClass(PreFetchObjectsEvent::class);
 
-        $this->assertTrue($rc->isSubclassOf(Event::class));
+        $this->assertTrue($rc->isSubclassOf(class_exists(Event::class) ? Event::class : LegacyEvent::class));
     }
 
     public function testShouldImplementPersistEventInterface()

--- a/tests/Unit/Persister/Event/PreInsertObjectsEventTest.php
+++ b/tests/Unit/Persister/Event/PreInsertObjectsEventTest.php
@@ -6,7 +6,8 @@ use FOS\ElasticaBundle\Persister\Event\PreInsertObjectsEvent;
 use FOS\ElasticaBundle\Persister\ObjectPersisterInterface;
 use FOS\ElasticaBundle\Provider\PagerInterface;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\EventDispatcher\Event as LegacyEvent;
+use Symfony\Contracts\EventDispatcher\Event;
 
 final class PreInsertObjectsEventTest extends TestCase
 {
@@ -14,7 +15,7 @@ final class PreInsertObjectsEventTest extends TestCase
     {
         $rc = new \ReflectionClass(PreInsertObjectsEvent::class);
 
-        $this->assertTrue($rc->isSubclassOf(Event::class));
+        $this->assertTrue($rc->isSubclassOf(class_exists(Event::class) ? Event::class : LegacyEvent::class));
     }
 
     public function testShouldImplementPersistEventInterface()

--- a/tests/Unit/Persister/Event/PrePersistEventTest.php
+++ b/tests/Unit/Persister/Event/PrePersistEventTest.php
@@ -6,7 +6,8 @@ use FOS\ElasticaBundle\Persister\Event\PrePersistEvent;
 use FOS\ElasticaBundle\Persister\ObjectPersisterInterface;
 use FOS\ElasticaBundle\Provider\PagerInterface;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\EventDispatcher\Event as LegacyEvent;
+use Symfony\Contracts\EventDispatcher\Event;
 
 final class PrePersistEventTest extends TestCase
 {
@@ -14,7 +15,7 @@ final class PrePersistEventTest extends TestCase
     {
         $rc = new \ReflectionClass(PrePersistEvent::class);
 
-        $this->assertTrue($rc->isSubclassOf(Event::class));
+        $this->assertTrue($rc->isSubclassOf(class_exists(Event::class) ? Event::class : LegacyEvent::class));
     }
 
     public function testShouldImplementPersistEventInterface()


### PR DESCRIPTION
This Pull Request enables the bundle to work with Symfony 5. This includes:
- Support for legacy EventDispatcher for Symfony 3.4 as well as new EventDispatcher (contracts, new param order for dispatch) for Symfony 4.3+
- Return values for commands (required, was optional before Symfony 5)
- Support for both legacy and new `DataCollector::collect()` method, which has switched from `Exception` to `Throwable` typehint
- Fix tests for mocked methods with not nullable return types (`UrlGeneratorInterface`, `FragmentHandler`) and class `HttpKernelRuntime` which became final
- Support for new versions of related bundles (`jms/serializer-bundle@^3`, `doctrine/doctrine-bundle@^2`, `knplabs/knp-components@^2`)

Fixes #1587 , also replaces #1583 , #1581 , #1573 , #1570 and #1566 .