### PR TITLE
Reverted bc break

### DIFF
--- a/src/Finder/PaginatedFinderInterface.php
+++ b/src/Finder/PaginatedFinderInterface.php
@@ -15,6 +15,9 @@ use Elastica\Query;
 use FOS\ElasticaBundle\Paginator\PaginatorAdapterInterface;
 use Pagerfanta\Pagerfanta;
 
+/**
+ * @method Pagerfanta findHybridPaginated($query) Searches for query hybrid results.
+ */
 interface PaginatedFinderInterface extends FinderInterface
 {
     /**
@@ -26,15 +29,6 @@ interface PaginatedFinderInterface extends FinderInterface
      * @return Pagerfanta paginated results
      */
     public function findPaginated($query, $options = []);
-
-    /**
-     * Searches for query hybrid results and returns them wrapped in a paginator.
-     *
-     * @param mixed $query Can be a string, an array or an \Elastica\Query object
-     *
-     * @return Pagerfanta paginated hybrid results
-     */
-    public function findHybridPaginated($query);
 
     /**
      * Creates a paginator adapter for this query.

--- a/src/Finder/TransformedFinder.php
+++ b/src/Finder/TransformedFinder.php
@@ -80,7 +80,11 @@ class TransformedFinder implements PaginatedFinderInterface
     }
 
     /**
-     * {@inheritdoc}
+     * Searches for query hybrid results and returns them wrapped in a paginator.
+     *
+     * @param mixed $query Can be a string, an array or an \Elastica\Query object
+     *
+     * @return Pagerfanta paginated hybrid results
      */
     public function findHybridPaginated($query)
     {


### PR DESCRIPTION
stof : the only BC break in it currently (making it a 6.x-dev) is the findHybridPaginated method in PaginatedFinderInterface. This could be added first as a @method in 5.x (as Symfony does)