### PR TITLE
Removed support for Elasticsearch 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "symfony/property-access": "^3.4|^4",
         "pagerfanta/pagerfanta": "^1.0.5|^2.0",
         "psr/log": "^1.0",
-        "ruflin/elastica": "^5.3.5|^6.1.1|^7.0"
+        "ruflin/elastica": "^5.3.5|^6.1.1"
     },
     "require-dev": {
         "doctrine/orm": "^2.5",


### PR DESCRIPTION
Elasticsearch 7 and corresponding `ruflin/elastica` library will only be available in next major version. 