### PR TITLE
Address deprecations from persistence

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "require-dev": {
         "doctrine/orm": "^2.5",
         "doctrine/doctrine-bundle": "^1.6",
-        "doctrine/persistence": "^1.3.3",
+        "doctrine/persistence": "^1.3.4",
         "doctrine/phpcr-bundle": "^1.3|^2.0",
         "doctrine/phpcr-odm": "^1.4",
         "jackalope/jackalope-doctrine-dbal": "^1.2",

--- a/src/Doctrine/AbstractElasticaToModelTransformer.php
+++ b/src/Doctrine/AbstractElasticaToModelTransformer.php
@@ -11,7 +11,7 @@
 
 namespace FOS\ElasticaBundle\Doctrine;
 
-use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ManagerRegistry;
 use FOS\ElasticaBundle\HybridResult;
 use FOS\ElasticaBundle\Transformer\AbstractElasticaToModelTransformer as BaseTransformer;
 use FOS\ElasticaBundle\Transformer\HighlightableModelInterface;

--- a/src/Doctrine/Listener.php
+++ b/src/Doctrine/Listener.php
@@ -11,7 +11,7 @@
 
 namespace FOS\ElasticaBundle\Doctrine;
 
-use Doctrine\Common\Persistence\Event\LifecycleEventArgs;
+use Doctrine\Persistence\Event\LifecycleEventArgs;
 use FOS\ElasticaBundle\Persister\ObjectPersister;
 use FOS\ElasticaBundle\Persister\ObjectPersisterInterface;
 use FOS\ElasticaBundle\Provider\IndexableInterface;
@@ -243,3 +243,5 @@ class Listener
         );
     }
 }
+
+class_exists(LifecycleEventArgs::class);

--- a/src/Doctrine/MongoDBPagerProvider.php
+++ b/src/Doctrine/MongoDBPagerProvider.php
@@ -11,7 +11,7 @@
 
 namespace FOS\ElasticaBundle\Doctrine;
 
-use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ManagerRegistry;
 use FOS\ElasticaBundle\Provider\PagerfantaPager;
 use FOS\ElasticaBundle\Provider\PagerProviderInterface;
 use Pagerfanta\Adapter\DoctrineODMMongoDBAdapter;

--- a/src/Doctrine/MongoDBPagerProvider.php
+++ b/src/Doctrine/MongoDBPagerProvider.php
@@ -28,7 +28,7 @@ final class MongoDBPagerProvider implements PagerProviderInterface
      * @var ManagerRegistry
      */
     private $doctrine;
-    
+
     /**
      * @var array
      */

--- a/src/Doctrine/ORMPagerProvider.php
+++ b/src/Doctrine/ORMPagerProvider.php
@@ -11,9 +11,9 @@
 
 namespace FOS\ElasticaBundle\Doctrine;
 
-use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\ORM\Query\Expr\From;
 use Doctrine\ORM\QueryBuilder;
+use Doctrine\Persistence\ManagerRegistry;
 use FOS\ElasticaBundle\Provider\PagerfantaPager;
 use FOS\ElasticaBundle\Provider\PagerProviderInterface;
 use Pagerfanta\Adapter\DoctrineORMAdapter;

--- a/src/Doctrine/PHPCRPagerProvider.php
+++ b/src/Doctrine/PHPCRPagerProvider.php
@@ -35,7 +35,7 @@ final class PHPCRPagerProvider implements PagerProviderInterface
      * @var array
      */
     private $baseOptions;
-    
+
     /**
      * @var RegisterListenersService
      */
@@ -64,13 +64,13 @@ final class PHPCRPagerProvider implements PagerProviderInterface
 
         $manager = $this->doctrine->getManagerForClass($this->objectClass);
         $repository = $manager->getRepository($this->objectClass);
-        
+
         $adapter = new DoctrineODMPhpcrAdapter(
             call_user_func([$repository, $options['query_builder_method']], static::ENTITY_ALIAS)
         );
-        
+
         $pager = new PagerfantaPager(new Pagerfanta($adapter));
-        
+
         $this->registerListenersService->register($manager, $pager, $options);
 
         return $pager;

--- a/src/Doctrine/PHPCRPagerProvider.php
+++ b/src/Doctrine/PHPCRPagerProvider.php
@@ -11,7 +11,7 @@
 
 namespace FOS\ElasticaBundle\Doctrine;
 
-use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ManagerRegistry;
 use FOS\ElasticaBundle\Provider\PagerfantaPager;
 use FOS\ElasticaBundle\Provider\PagerProviderInterface;
 use Pagerfanta\Adapter\DoctrineODMPhpcrAdapter;

--- a/src/Doctrine/RegisterListenersService.php
+++ b/src/Doctrine/RegisterListenersService.php
@@ -99,3 +99,5 @@ class RegisterListenersService
         });
     }
 }
+
+interface_exists(ObjectManager::class);

--- a/src/Doctrine/RepositoryManager.php
+++ b/src/Doctrine/RepositoryManager.php
@@ -11,7 +11,7 @@
 
 namespace FOS\ElasticaBundle\Doctrine;
 
-use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ManagerRegistry;
 use FOS\ElasticaBundle\Finder\FinderInterface;
 use FOS\ElasticaBundle\Manager\RepositoryManagerInterface;
 

--- a/tests/Unit/Doctrine/AbstractElasticaToModelTransformerTest.php
+++ b/tests/Unit/Doctrine/AbstractElasticaToModelTransformerTest.php
@@ -11,7 +11,7 @@
 
 namespace FOS\ElasticaBundle\Tests\Unit\Doctrine;
 
-use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ManagerRegistry;
 use Elastica\Result;
 use FOS\ElasticaBundle\Doctrine\AbstractElasticaToModelTransformer;
 use FOS\ElasticaBundle\Doctrine\ORM\ElasticaToModelTransformer;

--- a/tests/Unit/Doctrine/ORM/ElasticaToModelTransformerTest.php
+++ b/tests/Unit/Doctrine/ORM/ElasticaToModelTransformerTest.php
@@ -11,12 +11,12 @@
 
 namespace FOS\ElasticaBundle\Tests\Unit\Doctrine\ORM;
 
-use Doctrine\Common\Persistence\ManagerRegistry;
-use Doctrine\Common\Persistence\ObjectManager;
-use Doctrine\Common\Persistence\ObjectRepository;
 use Doctrine\ORM\AbstractQuery;
 use Doctrine\ORM\Query\Expr;
 use Doctrine\ORM\QueryBuilder;
+use Doctrine\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectRepository;
 use FOS\ElasticaBundle\Doctrine\ORM\ElasticaToModelTransformer;
 use PHPUnit\Framework\TestCase;
 
@@ -25,7 +25,7 @@ class ElasticaToModelTransformerTest extends TestCase
     const OBJECT_CLASS = \stdClass::class;
 
     /**
-     * @var \Doctrine\Common\Persistence\ManagerRegistry|\PHPUnit_Framework_MockObject_MockObject
+     * @var \Doctrine\Persistence\ManagerRegistry|\PHPUnit_Framework_MockObject_MockObject
      */
     protected $registry;
 

--- a/tests/Unit/Doctrine/PHPCR/ElasticaToModelTransformerTest.php
+++ b/tests/Unit/Doctrine/PHPCR/ElasticaToModelTransformerTest.php
@@ -12,7 +12,7 @@
 namespace FOS\ElasticaBundle\Tests\Unit\Doctrine\PHPCR;
 
 use Doctrine\Common\Collections\ArrayCollection;
-use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ManagerRegistry;
 use FOS\ElasticaBundle\Doctrine\PHPCR\ElasticaToModelTransformer;
 use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\ODM\PHPCR\DocumentRepository;

--- a/tests/Unit/Doctrine/PHPCR/ListenerTest.php
+++ b/tests/Unit/Doctrine/PHPCR/ListenerTest.php
@@ -29,7 +29,7 @@ class ListenerTest extends BaseListenerTest
 
     protected function getLifecycleEventArgsClass()
     {
-        return \Doctrine\Common\Persistence\Event\LifecycleEventArgs::class;
+        return \Doctrine\Persistence\Event\LifecycleEventArgs::class;
     }
 
     protected function getListenerClass()

--- a/tests/Unit/Doctrine/PHPCRPagerProviderTest.php
+++ b/tests/Unit/Doctrine/PHPCRPagerProviderTest.php
@@ -2,10 +2,10 @@
 
 namespace FOS\ElasticaBundle\Tests\Unit\Doctrine;
 
-use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\ODM\PHPCR\DocumentRepository;
 use Doctrine\ODM\PHPCR\Query\Builder\QueryBuilder;
+use Doctrine\Persistence\ManagerRegistry;
 use FOS\ElasticaBundle\Doctrine\PHPCRPagerProvider;
 use FOS\ElasticaBundle\Doctrine\RegisterListenersService;
 use FOS\ElasticaBundle\Provider\PagerfantaPager;

--- a/tests/Unit/Doctrine/RegisterListenersServiceTest.php
+++ b/tests/Unit/Doctrine/RegisterListenersServiceTest.php
@@ -2,10 +2,10 @@
 
 namespace FOS\ElasticaBundle\Tests\Unit\Doctrine;
 
-use Doctrine\Common\Persistence\ObjectManager;
 use Doctrine\DBAL\Connection;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManagerInterface;
+use Doctrine\Persistence\ObjectManager;
 use FOS\ElasticaBundle\Doctrine\RegisterListenersService;
 use FOS\ElasticaBundle\Persister\Event\Events;
 use FOS\ElasticaBundle\Persister\Event\PostInsertObjectsEvent;

--- a/tests/Unit/Doctrine/RepositoryManagerTest.php
+++ b/tests/Unit/Doctrine/RepositoryManagerTest.php
@@ -11,7 +11,7 @@
 
 namespace FOS\ElasticaBundle\Tests\Unit\Doctrine;
 
-use Doctrine\Common\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ManagerRegistry;
 use FOS\ElasticaBundle\Doctrine\RepositoryManager;
 use FOS\ElasticaBundle\Finder\TransformedFinder;
 use FOS\ElasticaBundle\Manager\RepositoryManagerInterface;


### PR DESCRIPTION
A backwards-compatibility layer has been added to persistence to help
consumers move to the new namespacing. It is based on class aliases,
which means the type declaration changes should not be a BC-break: types
are the same.
See doctrine/persistence#71

This means:
- using the new namespaces
- adding autoload calls for new types to types that may be extended and
use persistence types in type declarations of non-constructor methods,
so that signature compatibility is recognized by old versions of php.
More details on this at
https://dev.to/greg0ire/how-to-deprecate-a-type-in-php-48cf