### PR TITLE
Replaced old symfony event with contract event

### DIFF
--- a/src/Event/IndexEvent.php
+++ b/src/Event/IndexEvent.php
@@ -11,7 +11,8 @@
 
 namespace FOS\ElasticaBundle\Event;
 
-use Symfony\Component\EventDispatcher\Event;
+
+use Symfony\Contracts\EventDispatcher\Event;
 
 class IndexEvent extends Event
 {

--- a/src/Event/TransformEvent.php
+++ b/src/Event/TransformEvent.php
@@ -12,7 +12,7 @@
 namespace FOS\ElasticaBundle\Event;
 
 use Elastica\Document;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 class TransformEvent extends Event
 {

--- a/src/Event/TypePopulateEvent.php
+++ b/src/Event/TypePopulateEvent.php
@@ -11,7 +11,7 @@
 
 namespace FOS\ElasticaBundle\Event;
 
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * Type Populate Event.

--- a/src/Event/TypeResetEvent.php
+++ b/src/Event/TypeResetEvent.php
@@ -11,7 +11,7 @@
 
 namespace FOS\ElasticaBundle\Event;
 
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * Type ResetEvent.

--- a/src/Persister/Event/OnExceptionEvent.php
+++ b/src/Persister/Event/OnExceptionEvent.php
@@ -3,7 +3,7 @@ namespace FOS\ElasticaBundle\Persister\Event;
 
 use FOS\ElasticaBundle\Persister\ObjectPersisterInterface;
 use FOS\ElasticaBundle\Provider\PagerInterface;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 final class OnExceptionEvent extends Event implements PersistEvent
 {

--- a/src/Persister/Event/PostAsyncInsertObjectsEvent.php
+++ b/src/Persister/Event/PostAsyncInsertObjectsEvent.php
@@ -3,7 +3,7 @@ namespace FOS\ElasticaBundle\Persister\Event;
 
 use FOS\ElasticaBundle\Persister\ObjectPersisterInterface;
 use FOS\ElasticaBundle\Provider\PagerInterface;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 final class PostAsyncInsertObjectsEvent extends Event implements PersistEvent
 {

--- a/src/Persister/Event/PostInsertObjectsEvent.php
+++ b/src/Persister/Event/PostInsertObjectsEvent.php
@@ -3,7 +3,7 @@ namespace FOS\ElasticaBundle\Persister\Event;
 
 use FOS\ElasticaBundle\Persister\ObjectPersisterInterface;
 use FOS\ElasticaBundle\Provider\PagerInterface;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 final class PostInsertObjectsEvent extends Event implements PersistEvent
 {

--- a/src/Persister/Event/PostPersistEvent.php
+++ b/src/Persister/Event/PostPersistEvent.php
@@ -3,7 +3,7 @@ namespace FOS\ElasticaBundle\Persister\Event;
 
 use FOS\ElasticaBundle\Persister\ObjectPersisterInterface;
 use FOS\ElasticaBundle\Provider\PagerInterface;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 final class PostPersistEvent extends Event implements PersistEvent
 {

--- a/src/Persister/Event/PreFetchObjectsEvent.php
+++ b/src/Persister/Event/PreFetchObjectsEvent.php
@@ -3,7 +3,7 @@ namespace FOS\ElasticaBundle\Persister\Event;
 
 use FOS\ElasticaBundle\Persister\ObjectPersisterInterface;
 use FOS\ElasticaBundle\Provider\PagerInterface;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 final class PreFetchObjectsEvent extends Event implements PersistEvent
 {

--- a/src/Persister/Event/PreInsertObjectsEvent.php
+++ b/src/Persister/Event/PreInsertObjectsEvent.php
@@ -3,7 +3,7 @@ namespace FOS\ElasticaBundle\Persister\Event;
 
 use FOS\ElasticaBundle\Persister\ObjectPersisterInterface;
 use FOS\ElasticaBundle\Provider\PagerInterface;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 final class PreInsertObjectsEvent extends Event implements PersistEvent
 {

--- a/src/Persister/Event/PrePersistEvent.php
+++ b/src/Persister/Event/PrePersistEvent.php
@@ -3,7 +3,7 @@ namespace FOS\ElasticaBundle\Persister\Event;
 
 use FOS\ElasticaBundle\Persister\ObjectPersisterInterface;
 use FOS\ElasticaBundle\Provider\PagerInterface;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 final class PrePersistEvent extends Event implements PersistEvent
 {

--- a/tests/Unit/Persister/Event/OnExceptionEventTest.php
+++ b/tests/Unit/Persister/Event/OnExceptionEventTest.php
@@ -6,7 +6,7 @@ use FOS\ElasticaBundle\Persister\Event\PersistEvent;
 use FOS\ElasticaBundle\Persister\ObjectPersisterInterface;
 use FOS\ElasticaBundle\Provider\PagerInterface;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 final class OnExceptionEventTest extends TestCase
 {

--- a/tests/Unit/Persister/Event/PostAsyncInsertObjectsEventTest.php
+++ b/tests/Unit/Persister/Event/PostAsyncInsertObjectsEventTest.php
@@ -6,7 +6,7 @@ use FOS\ElasticaBundle\Persister\Event\PostAsyncInsertObjectsEvent;
 use FOS\ElasticaBundle\Persister\ObjectPersisterInterface;
 use FOS\ElasticaBundle\Provider\PagerInterface;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 final class PostAsyncInsertObjectsEventTest extends TestCase
 {

--- a/tests/Unit/Persister/Event/PostInsertObjectsEventTest.php
+++ b/tests/Unit/Persister/Event/PostInsertObjectsEventTest.php
@@ -6,7 +6,7 @@ use FOS\ElasticaBundle\Persister\Event\PostInsertObjectsEvent;
 use FOS\ElasticaBundle\Persister\ObjectPersisterInterface;
 use FOS\ElasticaBundle\Provider\PagerInterface;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 final class PostInsertObjectsEventTest extends TestCase
 {

--- a/tests/Unit/Persister/Event/PostPersistEventTest.php
+++ b/tests/Unit/Persister/Event/PostPersistEventTest.php
@@ -6,7 +6,7 @@ use FOS\ElasticaBundle\Persister\Event\PostPersistEvent;
 use FOS\ElasticaBundle\Persister\ObjectPersisterInterface;
 use FOS\ElasticaBundle\Provider\PagerInterface;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 final class PostPersistEventTest extends TestCase
 {

--- a/tests/Unit/Persister/Event/PreFetchObjectsEventTest.php
+++ b/tests/Unit/Persister/Event/PreFetchObjectsEventTest.php
@@ -6,7 +6,7 @@ use FOS\ElasticaBundle\Persister\Event\PreFetchObjectsEvent;
 use FOS\ElasticaBundle\Persister\ObjectPersisterInterface;
 use FOS\ElasticaBundle\Provider\PagerInterface;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 final class PreFetchObjectsEventTest extends TestCase
 {

--- a/tests/Unit/Persister/Event/PreInsertObjectsEventTest.php
+++ b/tests/Unit/Persister/Event/PreInsertObjectsEventTest.php
@@ -6,7 +6,7 @@ use FOS\ElasticaBundle\Persister\Event\PreInsertObjectsEvent;
 use FOS\ElasticaBundle\Persister\ObjectPersisterInterface;
 use FOS\ElasticaBundle\Provider\PagerInterface;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 final class PreInsertObjectsEventTest extends TestCase
 {

--- a/tests/Unit/Persister/Event/PrePersistEventTest.php
+++ b/tests/Unit/Persister/Event/PrePersistEventTest.php
@@ -6,7 +6,7 @@ use FOS\ElasticaBundle\Persister\Event\PrePersistEvent;
 use FOS\ElasticaBundle\Persister\ObjectPersisterInterface;
 use FOS\ElasticaBundle\Provider\PagerInterface;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 final class PrePersistEventTest extends TestCase
 {


### PR DESCRIPTION
Just replace `Symfony\Component\EventDispatcher\Event` (deprecated) wiith `Symfony\Contracts\EventDispatcher\Event`. 