### PR TITLE
Add finder method to retrieve raw ElasticSearch documents

### DIFF
--- a/src/Finder/TransformedFinder.php
+++ b/src/Finder/TransformedFinder.php
@@ -70,6 +70,18 @@ class TransformedFinder implements PaginatedFinderInterface
     }
 
     /**
+     * @param $query
+     * @param null|int $limit
+     * @param array    $options
+     *
+     * @return array
+     */
+    public function findRaw($query, ?int $limit = null, array $options = []): array
+    {
+        return $this->search($query, $limit, $options);
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function findPaginated($query, $options = [])

--- a/tests/Unit/Finder/TransformedFinderTest.php
+++ b/tests/Unit/Finder/TransformedFinderTest.php
@@ -45,6 +45,19 @@ class TransformedFinderTest extends TestCase
         $finder->findHybrid($query, $limit);
     }
 
+    public function testFindRawMethodTransformsSearchResults()
+    {
+        $transformer = $this->createMock(ElasticaToModelTransformerInterface::class);
+        $transformer->expects($this->never())
+            ->method($this->anything());
+        $query = Query::create('');
+        $limit = 10;
+
+        $finder = $this->createMockFinderForSearch($transformer, $query, $limit);
+
+        $finder->findRaw($query, $limit);
+    }
+
     public function testSearchMethodCreatesAQueryAndReturnsResultsFromSearchableDependency()
     {
         $searchable = $this->createMock(SearchableInterface::class);


### PR DESCRIPTION
A simple method allowing the ease of use of Finder, and avoiding database calls when entities are not required.