### PR TITLE
Support for queued messages via Symfony Messenger

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,8 @@
         "symfony/web-profiler-bundle": "^3.4|^4.0"
     },
     "suggest": {
-        "enqueue/elastica-bundle": "The bundle adds extra features to FOSElasticaBundle bundle. Aimed to improve performance."
+        "symfony/messenger": "For populating Elasticsearch indexes asynchronously and using significanly less resources.",
+        "enqueue/elastica-bundle": "For populating Elasticsearch indexes asynchronously and using significanly less resources. Uses Enqueue."
     },
     "autoload": {
         "psr-4": { "FOS\\ElasticaBundle\\": "src/" }

--- a/src/Message/AsyncPersistPage.php
+++ b/src/Message/AsyncPersistPage.php
@@ -1,0 +1,33 @@
+<?php
+declare(strict_types=1);
+
+namespace FOS\ElasticaBundle\Message;
+
+class AsyncPersistPage
+{
+    /**
+     * @var int
+     */
+    private $page;
+
+    /**
+     * @var array
+     */
+    private $options;
+
+    public function __construct(int $page, array $options)
+    {
+        $this->page = $page;
+        $this->options = $options;
+    }
+
+    public function getPage(): int
+    {
+        return $this->page;
+    }
+
+    public function getOptions(): array
+    {
+        return $this->options;
+    }
+}

--- a/src/Message/Handler/AsyncPersistPageHandler.php
+++ b/src/Message/Handler/AsyncPersistPageHandler.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types=1);
+
+namespace FOS\ElasticaBundle\Message\Handler;
+
+use FOS\ElasticaBundle\Message\AsyncPersistPage;
+use FOS\ElasticaBundle\Persister\AsyncPagerPersister;
+use Symfony\Component\Messenger\Handler\MessageHandlerInterface;
+
+class AsyncPersistPageHandler implements MessageHandlerInterface
+{
+    /**
+     * var AsyncMessagePersister
+     */
+    private $persister;
+
+    public function __construct(AsyncPagerPersister $persister)
+    {
+        $this->persister = $persister;
+    }
+
+    public function __invoke(AsyncPersistPage $message): void
+    {
+        $this->persister->insertPage($message->getPage(), $message->getOptions());
+    }
+}

--- a/src/Persister/AsyncPagerPersister.php
+++ b/src/Persister/AsyncPagerPersister.php
@@ -1,0 +1,89 @@
+<?php
+declare(strict_types=1);
+
+namespace FOS\ElasticaBundle\Persister;
+
+use FOS\ElasticaBundle\Message\AsyncPersistPage;
+use FOS\ElasticaBundle\Provider\PagerInterface;
+use FOS\ElasticaBundle\Provider\PagerProviderRegistry;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+final class AsyncPagerPersister implements PagerPersisterInterface
+{
+    const NAME = 'async';
+    const DEFAULT_PAGE_SIZE = 100;
+
+    /**
+     * @var PagerPersisterRegistry
+     */
+    private $pagerPersisterRegistry;
+
+    /**
+     * @var PagerProviderRegistry
+     */
+    private $pagerProviderRegistry;
+
+    /**
+     * @var MessageBusInterface
+     */
+    private $messageBus;
+
+    public function __construct(
+        PagerPersisterRegistry $pagerPersisterRegistry,
+        PagerProviderRegistry $pagerProviderRegistry,
+        MessageBusInterface $messageBus
+    ) {
+        $this->pagerPersisterRegistry = $pagerPersisterRegistry;
+        $this->pagerProviderRegistry = $pagerProviderRegistry;
+        $this->messageBus = $messageBus;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function insert(PagerInterface $pager, array $options = array()): void
+    {
+        $pager->setMaxPerPage(empty($options['max_per_page']) ? self::DEFAULT_PAGE_SIZE : $options['max_per_page']);
+
+        $options = array_replace([
+            'max_per_page' => $pager->getMaxPerPage(),
+            'first_page' => $pager->getCurrentPage(),
+            'last_page' => $pager->getNbPages(),
+        ], $options);
+
+        $pager->setCurrentPage($options['first_page']);
+
+        $lastPage = min($options['last_page'], $pager->getNbPages());
+        $page = $pager->getCurrentPage();
+        do {
+            $this->messageBus->dispatch(new AsyncPersistPage($page, $options));
+
+            $page++;
+        } while ($page <= $lastPage);
+    }
+
+    public function insertPage(int $page, array $options = []): int
+    {
+        if (!isset($options['indexName'])) {
+            throw new \RuntimeException('Invalid call. $options is missing the indexName key.');
+        }
+        if (!isset($options['max_per_page'])) {
+            throw new \RuntimeException('Invalid call. $options is missing the max_per_page key.');
+        }
+
+        $options['first_page'] = $page;
+        $options['last_page'] = $page;
+
+        $provider = $this->pagerProviderRegistry->getProvider($options['indexName']);
+        $pager = $provider->provide($options);
+        $pager->setMaxPerPage($options['max_per_page']);
+        $pager->setCurrentPage($options['first_page']);
+
+        $objectCount = count($pager->getCurrentPageResults());
+
+        $pagerPersister = $this->pagerPersisterRegistry->getPagerPersister(InPlacePagerPersister::NAME);
+        $pagerPersister->insert($pager, $options);
+
+        return $objectCount;
+    }
+}

--- a/src/Resources/config/persister.xml
+++ b/src/Resources/config/persister.xml
@@ -14,6 +14,14 @@
             <tag name="fos_elastica.pager_persister" persisterName="in_place" />
         </service>
 
+        <service id="fos_elastica.async_pager_persister" class="FOS\ElasticaBundle\Persister\AsyncPagerPersister" public="true">
+            <argument type="service" id="fos_elastica.pager_persister_registry" />
+            <argument type="service" id="fos_elastica.pager_provider_registry" />
+            <argument type="service" id="message_bus" />
+
+            <tag name="fos_elastica.pager_persister" persisterName="async" />
+        </service>
+
         <service id="fos_elastica.pager_persister_registry" class="FOS\ElasticaBundle\Persister\PagerPersisterRegistry" public="true">
             <argument type="collection" /> <!-- nameToServiceIdMap -->
 


### PR DESCRIPTION
This kinda fixes #1586, but probably still needs tests and whatnot.

I'm using an ES7-compatible fork of your library at work, and I decided to give this feature a go since we needed to populate a large set of data into ES and are already using Symfony Messenger but not Enqueue. I'm currently using this very persister (with a different namespace) to seed our ES storage.

The way `AsyncPagerPersister` class works (deferrence to `InPlacePagerPersister` to do the actual persister work) was copied from EnqueueElasticaBundle. Basically, I just adapted their algorithm for Messenger and decided to place the `insertPage` method in the same class instead of a separate one.

If you feel like this is useful, feel free to use this PR as a starting ground for your implementation. (In other words, I can't promise I'll be willing to work on it further).