### PR TITLE
Use Doctrine Paginator, not Pagerfanta, to page data when populating it to ES

### DIFF
--- a/src/Doctrine/ORMPagerProvider.php
+++ b/src/Doctrine/ORMPagerProvider.php
@@ -14,10 +14,8 @@ namespace FOS\ElasticaBundle\Doctrine;
 use Doctrine\Common\Persistence\ManagerRegistry;
 use Doctrine\ORM\Query\Expr\From;
 use Doctrine\ORM\QueryBuilder;
-use FOS\ElasticaBundle\Provider\PagerfantaPager;
+use FOS\ElasticaBundle\Provider\DoctrinePaginatorPager;
 use FOS\ElasticaBundle\Provider\PagerProviderInterface;
-use Pagerfanta\Adapter\DoctrineORMAdapter;
-use Pagerfanta\Pagerfanta;
 
 final class ORMPagerProvider implements PagerProviderInterface
 {
@@ -92,7 +90,7 @@ final class ORMPagerProvider implements PagerProviderInterface
             }
         }
 
-        $pager = new PagerfantaPager(new Pagerfanta(new DoctrineORMAdapter($qb)));
+        $pager = new DoctrinePaginatorPager($qb->getQuery());
 
         $this->registerListenersService->register($manager, $pager, $options);
 

--- a/src/Provider/DoctrinePaginatorPager.php
+++ b/src/Provider/DoctrinePaginatorPager.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace FOS\ElasticaBundle\Provider;
+
+use Doctrine\ORM\Query;
+use Doctrine\ORM\Tools\Pagination\Paginator;
+
+class DoctrinePaginatorPager implements PagerInterface
+{
+    /**
+     * @var Query
+     */
+    private $query;
+
+    /**
+     * @var Paginator
+     */
+    private $paginator;
+
+    /**
+     * @var int
+     */
+    private $currentPage = 1;
+
+    /**
+     * @var int
+     */
+    private $maxPerPage = 100;
+
+    public function __construct(Query $query)
+    {
+        $this->query = $query;
+    }
+
+    public function getNbResults()
+    {
+        return $this->getPaginator()->count();
+    }
+
+    public function getNbPages()
+    {
+        return ceil($this->getPaginator()->count() / $this->getMaxPerPage());
+    }
+
+    public function getCurrentPage()
+    {
+        return $this->currentPage;
+    }
+
+    public function setCurrentPage($page)
+    {
+        $this->currentPage = (int) $page;
+    }
+
+    public function getMaxPerPage()
+    {
+        return $this->maxPerPage;
+    }
+
+    public function setMaxPerPage($perPage)
+    {
+        $this->maxPerPage = (int) $perPage;
+    }
+
+    public function getCurrentPageResults()
+    {
+        $firstResult = $this->maxPerPage * ($this->currentPage - 1);
+
+        $this->query
+            ->setFirstResult($firstResult)
+            ->setMaxResults($this->maxPerPage);
+
+        return $this->getPaginator()->getIterator();
+    }
+
+    private function getPaginator(): Paginator
+    {
+        if (! isset($this->paginator)) {
+            $this->paginator = new Paginator($this->query);
+        }
+
+        return $this->paginator;
+    }
+}


### PR DESCRIPTION
I'd say Pagerfanta is a heavily frontent-oriented library. There's no need to use it when paginating stuff in the backend.