### PR TITLE
Symfony deprecations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,6 @@ env:
 matrix:
   fast_finish: true
   include:
-    # Minimum supported dependencies with min and max PHP version
-    - php: 7.1
-      env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest"
-
     # Latest supported dependencies with each PHP version
     - php: 7.1
     - php: 7.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,11 @@ env:
 matrix:
   fast_finish: true
   include:
+    # Minimum supported dependencies with min and max PHP version
+    - php: 7.1
+      env:
+        - COMPOSER_FLAGS="--prefer-stable --prefer-lowest"
+
     # Latest supported dependencies with each PHP version
     - php: 7.1
     - php: 7.2

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ matrix:
 
     # Install all SF components in the same major version, see https://github.com/dunglas/symfony-lock
     - php: 7.3
-      env: SYMFONY_VERSION="^4"
+      env: SYMFONY_REQUIRE="^4"
 
 before_install:
   - if [[ $COVERAGE != true ]]; then phpenv config-rm xdebug.ini || true; fi
@@ -34,7 +34,7 @@ before_install:
 install:
   # To be removed when this issue will be resolved: https://github.com/composer/composer/issues/5355
   - if [[ "$COMPOSER_FLAGS" == *"--prefer-lowest"* ]]; then composer update --prefer-dist --no-interaction --prefer-stable --quiet; fi
-  - if [ "$SYMFONY_VERSION" != "" ]; then composer require --dev --no-update dunglas/symfony-lock=$SYMFONY_VERSION; fi;
+  - if [ "$SYMFONY_REQUIRE" != "" ]; then composer global require --no-progress --no-scripts --no-plugins symfony/flex; fi;
   - composer update ${COMPOSER_FLAGS} --prefer-dist --no-interaction
   - mkdir /tmp/elasticsearch
   - wget -O - https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ES_VERSION}.tar.gz | tar xz --directory=/tmp/elasticsearch --strip-components=1

--- a/src/Command/PopulateCommand.php
+++ b/src/Command/PopulateCommand.php
@@ -185,7 +185,7 @@ class PopulateCommand extends Command
     private function populateIndex(OutputInterface $output, $index, $reset, $options)
     {
         $event = new IndexPopulateEvent($index, $reset, $options);
-        $this->dispatcher->dispatch(IndexPopulateEvent::PRE_INDEX_POPULATE, $event);
+        $this->dispatcher->dispatch($event, IndexPopulateEvent::PRE_INDEX_POPULATE);
 
         if ($event->isReset()) {
             $output->writeln(sprintf('<info>Resetting</info> <comment>%s</comment>', $index));
@@ -197,7 +197,7 @@ class PopulateCommand extends Command
             $this->populateIndexType($output, $index, $type, false, $event->getOptions());
         }
 
-        $this->dispatcher->dispatch(IndexPopulateEvent::POST_INDEX_POPULATE, $event);
+        $this->dispatcher->dispatch($event, IndexPopulateEvent::POST_INDEX_POPULATE);
 
         $this->refreshIndex($output, $index);
     }
@@ -214,7 +214,7 @@ class PopulateCommand extends Command
     private function populateIndexType(OutputInterface $output, $index, $type, $reset, $options)
     {
         $event = new TypePopulateEvent($index, $type, $reset, $options);
-        $this->dispatcher->dispatch(TypePopulateEvent::PRE_TYPE_POPULATE, $event);
+        $this->dispatcher->dispatch($event, TypePopulateEvent::PRE_TYPE_POPULATE);
 
         if ($event->isReset()) {
             $output->writeln(sprintf('<info>Resetting</info> <comment>%s/%s</comment>', $index, $type));
@@ -266,7 +266,7 @@ class PopulateCommand extends Command
 
         $this->pagerPersister->insert($pager, $options);
 
-        $this->dispatcher->dispatch(TypePopulateEvent::POST_TYPE_POPULATE, $event);
+        $this->dispatcher->dispatch($event, TypePopulateEvent::POST_TYPE_POPULATE);
 
         $this->refreshIndex($output, $index);
     }

--- a/src/Event/FOSElasticaEvent.php
+++ b/src/Event/FOSElasticaEvent.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace FOS\ElasticaBundle\Event;
+
+use Symfony\Component\EventDispatcher\Event as ComponentEvent;
+use Symfony\Contracts\EventDispatcher\Event as ContractsEvent;
+
+if (class_exists(ContractsEvent::class)) {
+    abstract class FOSElasticaEvent extends ContractsEvent
+    {
+
+    }
+} else {
+    abstract class FOSElasticaEvent extends ComponentEvent
+    {
+
+    }
+}

--- a/src/Event/IndexEvent.php
+++ b/src/Event/IndexEvent.php
@@ -11,9 +11,7 @@
 
 namespace FOS\ElasticaBundle\Event;
 
-use Symfony\Contracts\EventDispatcher\Event;
-
-class IndexEvent extends Event
+class IndexEvent extends FOSElasticaEvent
 {
     /**
      * @var string

--- a/src/Event/IndexEvent.php
+++ b/src/Event/IndexEvent.php
@@ -11,7 +11,7 @@
 
 namespace FOS\ElasticaBundle\Event;
 
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 class IndexEvent extends Event
 {

--- a/src/Event/TransformEvent.php
+++ b/src/Event/TransformEvent.php
@@ -12,7 +12,7 @@
 namespace FOS\ElasticaBundle\Event;
 
 use Elastica\Document;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 class TransformEvent extends Event
 {

--- a/src/Event/TransformEvent.php
+++ b/src/Event/TransformEvent.php
@@ -12,9 +12,8 @@
 namespace FOS\ElasticaBundle\Event;
 
 use Elastica\Document;
-use Symfony\Contracts\EventDispatcher\Event;
 
-class TransformEvent extends Event
+class TransformEvent extends FOSElasticaEvent
 {
     /**
      * @Event("FOS\ElasticaBundle\Event\TransformEvent")

--- a/src/Event/TypePopulateEvent.php
+++ b/src/Event/TypePopulateEvent.php
@@ -11,7 +11,7 @@
 
 namespace FOS\ElasticaBundle\Event;
 
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * Type Populate Event.

--- a/src/Event/TypePopulateEvent.php
+++ b/src/Event/TypePopulateEvent.php
@@ -11,7 +11,7 @@
 
 namespace FOS\ElasticaBundle\Event;
 
-use Symfony\Contracts\EventDispatcher\Event;
+use FOS\ElasticaBundle\Event\FOSElasticaEvent as Event;
 
 /**
  * Type Populate Event.

--- a/src/Event/TypeResetEvent.php
+++ b/src/Event/TypeResetEvent.php
@@ -11,7 +11,7 @@
 
 namespace FOS\ElasticaBundle\Event;
 
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 /**
  * Type ResetEvent.

--- a/src/Event/TypeResetEvent.php
+++ b/src/Event/TypeResetEvent.php
@@ -11,7 +11,7 @@
 
 namespace FOS\ElasticaBundle\Event;
 
-use Symfony\Contracts\EventDispatcher\Event;
+use FOS\ElasticaBundle\Event\FOSElasticaEvent as Event;
 
 /**
  * Type ResetEvent.

--- a/src/Index/Resetter.php
+++ b/src/Index/Resetter.php
@@ -110,7 +110,7 @@ class Resetter implements ResetterInterface
         }
 
         $event = new IndexResetEvent($indexName, $populating, $force);
-        $this->dispatcher->dispatch(IndexResetEvent::PRE_INDEX_RESET, $event);
+        $this->dispatcher->dispatch($event, IndexResetEvent::PRE_INDEX_RESET);
 
         $mapping = $this->mappingBuilder->buildIndexMapping($indexConfig);
         $index->create($mapping, true);
@@ -119,7 +119,7 @@ class Resetter implements ResetterInterface
             $this->aliasProcessor->switchIndexAlias($indexConfig, $index, $force);
         }
 
-        $this->dispatcher->dispatch(IndexResetEvent::POST_INDEX_RESET, $event);
+        $this->dispatcher->dispatch($event, IndexResetEvent::POST_INDEX_RESET);
     }
 
     /**
@@ -141,7 +141,7 @@ class Resetter implements ResetterInterface
         $type = $index->getType($typeName);
 
         $event = new TypeResetEvent($indexName, $typeName);
-        $this->dispatcher->dispatch(TypeResetEvent::PRE_TYPE_RESET, $event);
+        $this->dispatcher->dispatch($event, TypeResetEvent::PRE_TYPE_RESET);
 
         $mapping = new Mapping();
         foreach ($this->mappingBuilder->buildTypeMapping($typeConfig) as $name => $field) {
@@ -150,7 +150,7 @@ class Resetter implements ResetterInterface
 
         $type->setMapping($mapping);
 
-        $this->dispatcher->dispatch(TypeResetEvent::POST_TYPE_RESET, $event);
+        $this->dispatcher->dispatch($event, TypeResetEvent::POST_TYPE_RESET);
     }
 
     /**

--- a/src/Persister/Event/OnExceptionEvent.php
+++ b/src/Persister/Event/OnExceptionEvent.php
@@ -1,11 +1,11 @@
 <?php
 namespace FOS\ElasticaBundle\Persister\Event;
 
+use FOS\ElasticaBundle\Event\FOSElasticaEvent;
 use FOS\ElasticaBundle\Persister\ObjectPersisterInterface;
 use FOS\ElasticaBundle\Provider\PagerInterface;
-use Symfony\Component\EventDispatcher\Event;
 
-final class OnExceptionEvent extends Event implements PersistEvent
+final class OnExceptionEvent extends FOSElasticaEvent implements PersistEvent
 {
     /**
      * @var PagerInterface

--- a/src/Persister/Event/PostAsyncInsertObjectsEvent.php
+++ b/src/Persister/Event/PostAsyncInsertObjectsEvent.php
@@ -1,11 +1,11 @@
 <?php
 namespace FOS\ElasticaBundle\Persister\Event;
 
+use FOS\ElasticaBundle\Event\FOSElasticaEvent;
 use FOS\ElasticaBundle\Persister\ObjectPersisterInterface;
 use FOS\ElasticaBundle\Provider\PagerInterface;
-use Symfony\Component\EventDispatcher\Event;
 
-final class PostAsyncInsertObjectsEvent extends Event implements PersistEvent
+final class PostAsyncInsertObjectsEvent extends FOSElasticaEvent implements PersistEvent
 {
     /**
      * @var PagerInterface

--- a/src/Persister/Event/PostInsertObjectsEvent.php
+++ b/src/Persister/Event/PostInsertObjectsEvent.php
@@ -1,11 +1,11 @@
 <?php
 namespace FOS\ElasticaBundle\Persister\Event;
 
+use FOS\ElasticaBundle\Event\FOSElasticaEvent;
 use FOS\ElasticaBundle\Persister\ObjectPersisterInterface;
 use FOS\ElasticaBundle\Provider\PagerInterface;
-use Symfony\Component\EventDispatcher\Event;
 
-final class PostInsertObjectsEvent extends Event implements PersistEvent
+final class PostInsertObjectsEvent extends FOSElasticaEvent implements PersistEvent
 {
     /**
      * @var PagerInterface

--- a/src/Persister/Event/PostPersistEvent.php
+++ b/src/Persister/Event/PostPersistEvent.php
@@ -1,11 +1,11 @@
 <?php
 namespace FOS\ElasticaBundle\Persister\Event;
 
+use FOS\ElasticaBundle\Event\FOSElasticaEvent;
 use FOS\ElasticaBundle\Persister\ObjectPersisterInterface;
 use FOS\ElasticaBundle\Provider\PagerInterface;
-use Symfony\Component\EventDispatcher\Event;
 
-final class PostPersistEvent extends Event implements PersistEvent
+final class PostPersistEvent extends FOSElasticaEvent implements PersistEvent
 {
     /**
      * @var PagerInterface

--- a/src/Persister/Event/PreFetchObjectsEvent.php
+++ b/src/Persister/Event/PreFetchObjectsEvent.php
@@ -1,11 +1,11 @@
 <?php
 namespace FOS\ElasticaBundle\Persister\Event;
 
+use FOS\ElasticaBundle\Event\FOSElasticaEvent;
 use FOS\ElasticaBundle\Persister\ObjectPersisterInterface;
 use FOS\ElasticaBundle\Provider\PagerInterface;
-use Symfony\Component\EventDispatcher\Event;
 
-final class PreFetchObjectsEvent extends Event implements PersistEvent
+final class PreFetchObjectsEvent extends FOSElasticaEvent implements PersistEvent
 {
     /**
      * @var PagerInterface

--- a/src/Persister/Event/PreInsertObjectsEvent.php
+++ b/src/Persister/Event/PreInsertObjectsEvent.php
@@ -1,11 +1,11 @@
 <?php
 namespace FOS\ElasticaBundle\Persister\Event;
 
+use FOS\ElasticaBundle\Event\FOSElasticaEvent;
 use FOS\ElasticaBundle\Persister\ObjectPersisterInterface;
 use FOS\ElasticaBundle\Provider\PagerInterface;
-use Symfony\Component\EventDispatcher\Event;
 
-final class PreInsertObjectsEvent extends Event implements PersistEvent
+final class PreInsertObjectsEvent extends FOSElasticaEvent implements PersistEvent
 {
     /**
      * @var PagerInterface

--- a/src/Persister/Event/PrePersistEvent.php
+++ b/src/Persister/Event/PrePersistEvent.php
@@ -1,11 +1,11 @@
 <?php
 namespace FOS\ElasticaBundle\Persister\Event;
 
+use FOS\ElasticaBundle\Event\FOSElasticaEvent;
 use FOS\ElasticaBundle\Persister\ObjectPersisterInterface;
 use FOS\ElasticaBundle\Provider\PagerInterface;
-use Symfony\Component\EventDispatcher\Event;
 
-final class PrePersistEvent extends Event implements PersistEvent
+final class PrePersistEvent extends FOSElasticaEvent implements PersistEvent
 {
     /**
      * @var PagerInterface

--- a/src/Persister/InPlacePagerPersister.php
+++ b/src/Persister/InPlacePagerPersister.php
@@ -2,6 +2,7 @@
 
 namespace FOS\ElasticaBundle\Persister;
 
+use FOS\ElasticaBundle\Event\FOSElasticaEvent;
 use FOS\ElasticaBundle\Persister\Event\Events;
 use FOS\ElasticaBundle\Persister\Event\OnExceptionEvent;
 use FOS\ElasticaBundle\Persister\Event\PostInsertObjectsEvent;
@@ -12,6 +13,7 @@ use FOS\ElasticaBundle\Persister\Event\PrePersistEvent;
 use FOS\ElasticaBundle\Provider\PagerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\LegacyEventDispatcherProxy;
+use Symfony\Contracts\EventDispatcher\EventDispatcherInterface as ContractsEventDispatcherInterface;
 
 final class InPlacePagerPersister implements PagerPersisterInterface
 {
@@ -60,7 +62,7 @@ final class InPlacePagerPersister implements PagerPersisterInterface
 
         try {
             $event = new PrePersistEvent($pager, $objectPersister, $options);
-            $this->dispatcher->dispatch($event, Events::PRE_PERSIST);
+            $this->dispatchWithBC($event, Events::PRE_PERSIST);
             $pager = $event->getPager();
             $options = $event->getOptions();
 
@@ -75,7 +77,7 @@ final class InPlacePagerPersister implements PagerPersisterInterface
             } while ($page <= $lastPage);
         } finally {
             $event = new PostPersistEvent($pager, $objectPersister, $options);
-            $this->dispatcher->dispatch($event, Events::POST_PERSIST);
+            $this->dispatchWithBC($event, Events::POST_PERSIST);
         }
     }
 
@@ -92,7 +94,7 @@ final class InPlacePagerPersister implements PagerPersisterInterface
         $pager->setCurrentPage($page);
 
         $event = new PreFetchObjectsEvent($pager, $objectPersister, $options);
-        $this->dispatcher->dispatch($event, Events::PRE_FETCH_OBJECTS);
+        $this->dispatchWithBC($event, Events::PRE_FETCH_OBJECTS);
         $pager = $event->getPager();
         $options = $event->getOptions();
 
@@ -103,7 +105,7 @@ final class InPlacePagerPersister implements PagerPersisterInterface
         }
 
         $event = new PreInsertObjectsEvent($pager, $objectPersister, $objects, $options);
-        $this->dispatcher->dispatch($event, Events::PRE_INSERT_OBJECTS);
+        $this->dispatchWithBC($event, Events::PRE_INSERT_OBJECTS);
         $pager = $event->getPager();
         $options = $event->getOptions();
         $objects = $event->getObjects();
@@ -114,14 +116,14 @@ final class InPlacePagerPersister implements PagerPersisterInterface
             }
 
             $event = new PostInsertObjectsEvent($pager, $objectPersister, $objects, $options);
-            $this->dispatcher->dispatch($event, Events::POST_INSERT_OBJECTS);
+            $this->dispatchWithBC($event, Events::POST_INSERT_OBJECTS);
         } catch (\Exception $e) {
             $event = new OnExceptionEvent($pager, $objectPersister, $e, $objects, $options);
-            $this->dispatcher->dispatch($event, Events::ON_EXCEPTION);
+            $this->dispatchWithBC($event, Events::ON_EXCEPTION);
 
             if ($event->isIgnored()) {
                 $event = new PostInsertObjectsEvent($pager, $objectPersister, $objects, $options);
-                $this->dispatcher->dispatch($event, Events::POST_INSERT_OBJECTS);
+                $this->dispatchWithBC($event, Events::POST_INSERT_OBJECTS);
             } else {
                 $e = $event->getException();
 
@@ -130,4 +132,18 @@ final class InPlacePagerPersister implements PagerPersisterInterface
         }
     }
 
+    /**
+     * BC layer for Symfony < 4.3
+     *
+     * @param FOSElasticaEvent $event
+     * @param string $eventName
+     */
+    private function dispatchWithBC(FOSElasticaEvent $event, $eventName)
+    {
+        if ($this->dispatcher instanceof ContractsEventDispatcherInterface) {
+            $this->dispatcher->dispatch($event, $eventName);
+        } else {
+            $this->dispatcher->dispatch($eventName, $event);
+        }
+    }
 }

--- a/src/Persister/InPlacePagerPersister.php
+++ b/src/Persister/InPlacePagerPersister.php
@@ -60,7 +60,7 @@ final class InPlacePagerPersister implements PagerPersisterInterface
 
         try {
             $event = new PrePersistEvent($pager, $objectPersister, $options);
-            $this->dispatcher->dispatch(Events::PRE_PERSIST, $event);
+            $this->dispatcher->dispatch($event, Events::PRE_PERSIST);
             $pager = $event->getPager();
             $options = $event->getOptions();
 
@@ -75,7 +75,7 @@ final class InPlacePagerPersister implements PagerPersisterInterface
             } while ($page <= $lastPage);
         } finally {
             $event = new PostPersistEvent($pager, $objectPersister, $options);
-            $this->dispatcher->dispatch(Events::POST_PERSIST, $event);
+            $this->dispatcher->dispatch($event, Events::POST_PERSIST);
         }
     }
 
@@ -92,7 +92,7 @@ final class InPlacePagerPersister implements PagerPersisterInterface
         $pager->setCurrentPage($page);
 
         $event = new PreFetchObjectsEvent($pager, $objectPersister, $options);
-        $this->dispatcher->dispatch(Events::PRE_FETCH_OBJECTS, $event);
+        $this->dispatcher->dispatch($event, Events::PRE_FETCH_OBJECTS);
         $pager = $event->getPager();
         $options = $event->getOptions();
 
@@ -103,7 +103,7 @@ final class InPlacePagerPersister implements PagerPersisterInterface
         }
 
         $event = new PreInsertObjectsEvent($pager, $objectPersister, $objects, $options);
-        $this->dispatcher->dispatch(Events::PRE_INSERT_OBJECTS, $event);
+        $this->dispatcher->dispatch($event, Events::PRE_INSERT_OBJECTS);
         $pager = $event->getPager();
         $options = $event->getOptions();
         $objects = $event->getObjects();
@@ -114,14 +114,14 @@ final class InPlacePagerPersister implements PagerPersisterInterface
             }
 
             $event = new PostInsertObjectsEvent($pager, $objectPersister, $objects, $options);
-            $this->dispatcher->dispatch(Events::POST_INSERT_OBJECTS, $event);
+            $this->dispatcher->dispatch($event, Events::POST_INSERT_OBJECTS);
         } catch (\Exception $e) {
             $event = new OnExceptionEvent($pager, $objectPersister, $e, $objects, $options);
-            $this->dispatcher->dispatch(Events::ON_EXCEPTION, $event);
+            $this->dispatcher->dispatch($event, Events::ON_EXCEPTION);
 
             if ($event->isIgnored()) {
                 $event = new PostInsertObjectsEvent($pager, $objectPersister, $objects, $options);
-                $this->dispatcher->dispatch(Events::POST_INSERT_OBJECTS, $event);
+                $this->dispatcher->dispatch($event, Events::POST_INSERT_OBJECTS);
             } else {
                 $e = $event->getException();
 

--- a/src/Subscriber/PaginateElasticaQuerySubscriber.php
+++ b/src/Subscriber/PaginateElasticaQuerySubscriber.php
@@ -74,7 +74,7 @@ class PaginateElasticaQuerySubscriber implements EventSubscriberInterface
     protected function setSorting(ItemsEvent $event)
     {
         $options = $event->options;
-        $sortField = $this->getFromRequest($options['sortFieldParameterName']);
+        $sortField = $this->getFromRequest($options['sortFieldParameterName'] ?? null);
 
         if (!$sortField && isset($options['defaultSortFieldName'])) {
             $sortField = $options['defaultSortFieldName'];

--- a/src/Transformer/ModelToElasticaAutoTransformer.php
+++ b/src/Transformer/ModelToElasticaAutoTransformer.php
@@ -159,7 +159,7 @@ class ModelToElasticaAutoTransformer implements ModelToElasticaTransformerInterf
 
         if ($this->dispatcher) {
             $event = new TransformEvent($document, $fields, $object);
-            $this->dispatcher->dispatch(TransformEvent::PRE_TRANSFORM, $event);
+            $this->dispatcher->dispatch($event, TransformEvent::PRE_TRANSFORM);
 
             $document = $event->getDocument();
         }
@@ -209,7 +209,7 @@ class ModelToElasticaAutoTransformer implements ModelToElasticaTransformerInterf
 
         if ($this->dispatcher) {
             $event = new TransformEvent($document, $fields, $object);
-            $this->dispatcher->dispatch(TransformEvent::POST_TRANSFORM, $event);
+            $this->dispatcher->dispatch($event, TransformEvent::POST_TRANSFORM);
 
             $document = $event->getDocument();
         }

--- a/tests/Unit/Index/ResetterTest.php
+++ b/tests/Unit/Index/ResetterTest.php
@@ -69,8 +69,8 @@ class ResetterTest extends TestCase
             ->will($this->returnValue([$indexName]));
 
         $this->dispatcherExpects([
-            [IndexResetEvent::PRE_INDEX_RESET, $this->isInstanceOf(IndexResetEvent::class)],
-            [IndexResetEvent::POST_INDEX_RESET, $this->isInstanceOf(IndexResetEvent::class)],
+            [$this->isInstanceOf(IndexResetEvent::class), IndexResetEvent::PRE_INDEX_RESET],
+            [$this->isInstanceOf(IndexResetEvent::class), IndexResetEvent::POST_INDEX_RESET],
         ]);
 
         $this->elasticaClient->expects($this->exactly(2))
@@ -85,8 +85,8 @@ class ResetterTest extends TestCase
         $this->mockIndex('index1', $indexConfig);
 
         $this->dispatcherExpects([
-            [IndexResetEvent::PRE_INDEX_RESET, $this->isInstanceOf(IndexResetEvent::class)],
-            [IndexResetEvent::POST_INDEX_RESET, $this->isInstanceOf(IndexResetEvent::class)],
+            [$this->isInstanceOf(IndexResetEvent::class), IndexResetEvent::PRE_INDEX_RESET],
+            [$this->isInstanceOf(IndexResetEvent::class), IndexResetEvent::POST_INDEX_RESET],
         ]);
 
         $this->elasticaClient->expects($this->exactly(2))
@@ -102,8 +102,8 @@ class ResetterTest extends TestCase
         ]);
         $this->mockIndex('index1', $indexConfig);
         $this->dispatcherExpects([
-            [IndexResetEvent::PRE_INDEX_RESET, $this->isInstanceOf(IndexResetEvent::class)],
-            [IndexResetEvent::POST_INDEX_RESET, $this->isInstanceOf(IndexResetEvent::class)],
+            [$this->isInstanceOf(IndexResetEvent::class), IndexResetEvent::PRE_INDEX_RESET],
+            [$this->isInstanceOf(IndexResetEvent::class), IndexResetEvent::POST_INDEX_RESET],
         ]);
 
         $this->elasticaClient->expects($this->exactly(2))
@@ -120,8 +120,8 @@ class ResetterTest extends TestCase
         ]);
         $index = $this->mockIndex('index1', $indexConfig);
         $this->dispatcherExpects([
-            [IndexResetEvent::PRE_INDEX_RESET, $this->isInstanceOf(IndexResetEvent::class)],
-            [IndexResetEvent::POST_INDEX_RESET, $this->isInstanceOf(IndexResetEvent::class)],
+            [$this->isInstanceOf(IndexResetEvent::class), IndexResetEvent::PRE_INDEX_RESET],
+            [$this->isInstanceOf(IndexResetEvent::class), IndexResetEvent::POST_INDEX_RESET],
         ]);
 
         $this->aliasProcessor->expects($this->once())
@@ -157,10 +157,10 @@ class ResetterTest extends TestCase
         $this->mockType('type', 'index', $typeConfig, $indexConfig);
 
         $this->dispatcherExpects([
-            [IndexResetEvent::PRE_INDEX_RESET, $this->isInstanceOf(IndexResetEvent::class)],
-            [IndexResetEvent::POST_INDEX_RESET, $this->isInstanceOf(IndexResetEvent::class)],
-            [TypeResetEvent::PRE_TYPE_RESET, $this->isInstanceOf(TypeResetEvent::class)],
-            [TypeResetEvent::POST_TYPE_RESET, $this->isInstanceOf(TypeResetEvent::class)],
+            [$this->isInstanceOf(IndexResetEvent::class), IndexResetEvent::PRE_INDEX_RESET],
+            [$this->isInstanceOf(IndexResetEvent::class), IndexResetEvent::POST_INDEX_RESET],
+            [$this->isInstanceOf(TypeResetEvent::class), TypeResetEvent::PRE_TYPE_RESET],
+            [$this->isInstanceOf(TypeResetEvent::class), TypeResetEvent::POST_TYPE_RESET],
         ]);
 
         $this->elasticaClient->expects($this->exactly(3))

--- a/tests/Unit/Persister/Event/OnExceptionEventTest.php
+++ b/tests/Unit/Persister/Event/OnExceptionEventTest.php
@@ -1,12 +1,12 @@
 <?php
 namespace FOS\ElasticaBundle\Tests\Unit\Persister\Event;
 
+use FOS\ElasticaBundle\Event\FOSElasticaEvent;
 use FOS\ElasticaBundle\Persister\Event\OnExceptionEvent;
 use FOS\ElasticaBundle\Persister\Event\PersistEvent;
 use FOS\ElasticaBundle\Persister\ObjectPersisterInterface;
 use FOS\ElasticaBundle\Provider\PagerInterface;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\EventDispatcher\Event;
 
 final class OnExceptionEventTest extends TestCase
 {
@@ -14,7 +14,7 @@ final class OnExceptionEventTest extends TestCase
     {
         $rc = new \ReflectionClass(OnExceptionEvent::class);
 
-        $this->assertTrue($rc->isSubclassOf(Event::class));
+        $this->assertTrue($rc->isSubclassOf(FOSElasticaEvent::class));
     }
 
     public function testShouldImplementPersistEventInterface()

--- a/tests/Unit/Persister/Event/PostAsyncInsertObjectsEventTest.php
+++ b/tests/Unit/Persister/Event/PostAsyncInsertObjectsEventTest.php
@@ -1,12 +1,12 @@
 <?php
 namespace FOS\ElasticaBundle\Tests\Unit\Persister\Event;
 
+use FOS\ElasticaBundle\Event\FOSElasticaEvent;
 use FOS\ElasticaBundle\Persister\Event\PersistEvent;
 use FOS\ElasticaBundle\Persister\Event\PostAsyncInsertObjectsEvent;
 use FOS\ElasticaBundle\Persister\ObjectPersisterInterface;
 use FOS\ElasticaBundle\Provider\PagerInterface;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\EventDispatcher\Event;
 
 final class PostAsyncInsertObjectsEventTest extends TestCase
 {
@@ -14,7 +14,7 @@ final class PostAsyncInsertObjectsEventTest extends TestCase
     {
         $rc = new \ReflectionClass(PostAsyncInsertObjectsEvent::class);
 
-        $this->assertTrue($rc->isSubclassOf(Event::class));
+        $this->assertTrue($rc->isSubclassOf(FOSElasticaEvent::class));
     }
 
     public function testShouldImplementPersistEventInterface()

--- a/tests/Unit/Persister/Event/PostInsertObjectsEventTest.php
+++ b/tests/Unit/Persister/Event/PostInsertObjectsEventTest.php
@@ -1,12 +1,12 @@
 <?php
 namespace FOS\ElasticaBundle\Tests\Unit\Persister\Event;
 
+use FOS\ElasticaBundle\Event\FOSElasticaEvent;
 use FOS\ElasticaBundle\Persister\Event\PersistEvent;
 use FOS\ElasticaBundle\Persister\Event\PostInsertObjectsEvent;
 use FOS\ElasticaBundle\Persister\ObjectPersisterInterface;
 use FOS\ElasticaBundle\Provider\PagerInterface;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\EventDispatcher\Event;
 
 final class PostInsertObjectsEventTest extends TestCase
 {
@@ -14,7 +14,7 @@ final class PostInsertObjectsEventTest extends TestCase
     {
         $rc = new \ReflectionClass(PostInsertObjectsEvent::class);
 
-        $this->assertTrue($rc->isSubclassOf(Event::class));
+        $this->assertTrue($rc->isSubclassOf(FOSElasticaEvent::class));
     }
 
     public function testShouldImplementPersistEventInterface()

--- a/tests/Unit/Persister/Event/PostPersistEventTest.php
+++ b/tests/Unit/Persister/Event/PostPersistEventTest.php
@@ -1,12 +1,12 @@
 <?php
 namespace FOS\ElasticaBundle\Tests\Unit\Persister\Event;
 
+use FOS\ElasticaBundle\Event\FOSElasticaEvent;
 use FOS\ElasticaBundle\Persister\Event\PersistEvent;
 use FOS\ElasticaBundle\Persister\Event\PostPersistEvent;
 use FOS\ElasticaBundle\Persister\ObjectPersisterInterface;
 use FOS\ElasticaBundle\Provider\PagerInterface;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\EventDispatcher\Event;
 
 final class PostPersistEventTest extends TestCase
 {
@@ -14,7 +14,7 @@ final class PostPersistEventTest extends TestCase
     {
         $rc = new \ReflectionClass(PostPersistEvent::class);
 
-        $this->assertTrue($rc->isSubclassOf(Event::class));
+        $this->assertTrue($rc->isSubclassOf(FOSElasticaEvent::class));
     }
 
     public function testShouldImplementPersistEventInterface()

--- a/tests/Unit/Persister/Event/PreFetchObjectsEventTest.php
+++ b/tests/Unit/Persister/Event/PreFetchObjectsEventTest.php
@@ -1,12 +1,12 @@
 <?php
 namespace FOS\ElasticaBundle\Tests\Unit\Persister\Event;
 
+use FOS\ElasticaBundle\Event\FOSElasticaEvent;
 use FOS\ElasticaBundle\Persister\Event\PersistEvent;
 use FOS\ElasticaBundle\Persister\Event\PreFetchObjectsEvent;
 use FOS\ElasticaBundle\Persister\ObjectPersisterInterface;
 use FOS\ElasticaBundle\Provider\PagerInterface;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\EventDispatcher\Event;
 
 final class PreFetchObjectsEventTest extends TestCase
 {
@@ -14,7 +14,7 @@ final class PreFetchObjectsEventTest extends TestCase
     {
         $rc = new \ReflectionClass(PreFetchObjectsEvent::class);
 
-        $this->assertTrue($rc->isSubclassOf(Event::class));
+        $this->assertTrue($rc->isSubclassOf(FOSElasticaEvent::class));
     }
 
     public function testShouldImplementPersistEventInterface()

--- a/tests/Unit/Persister/Event/PreInsertObjectsEventTest.php
+++ b/tests/Unit/Persister/Event/PreInsertObjectsEventTest.php
@@ -1,12 +1,12 @@
 <?php
 namespace FOS\ElasticaBundle\Tests\Unit\Persister\Event;
 
+use FOS\ElasticaBundle\Event\FOSElasticaEvent;
 use FOS\ElasticaBundle\Persister\Event\PersistEvent;
 use FOS\ElasticaBundle\Persister\Event\PreInsertObjectsEvent;
 use FOS\ElasticaBundle\Persister\ObjectPersisterInterface;
 use FOS\ElasticaBundle\Provider\PagerInterface;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\EventDispatcher\Event;
 
 final class PreInsertObjectsEventTest extends TestCase
 {
@@ -14,7 +14,7 @@ final class PreInsertObjectsEventTest extends TestCase
     {
         $rc = new \ReflectionClass(PreInsertObjectsEvent::class);
 
-        $this->assertTrue($rc->isSubclassOf(Event::class));
+        $this->assertTrue($rc->isSubclassOf(FOSElasticaEvent::class));
     }
 
     public function testShouldImplementPersistEventInterface()

--- a/tests/Unit/Persister/Event/PrePersistEventTest.php
+++ b/tests/Unit/Persister/Event/PrePersistEventTest.php
@@ -1,12 +1,12 @@
 <?php
 namespace FOS\ElasticaBundle\Tests\Unit\Persister\Event;
 
+use FOS\ElasticaBundle\Event\FOSElasticaEvent;
 use FOS\ElasticaBundle\Persister\Event\PersistEvent;
 use FOS\ElasticaBundle\Persister\Event\PrePersistEvent;
 use FOS\ElasticaBundle\Persister\ObjectPersisterInterface;
 use FOS\ElasticaBundle\Provider\PagerInterface;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\EventDispatcher\Event;
 
 final class PrePersistEventTest extends TestCase
 {
@@ -14,7 +14,7 @@ final class PrePersistEventTest extends TestCase
     {
         $rc = new \ReflectionClass(PrePersistEvent::class);
 
-        $this->assertTrue($rc->isSubclassOf(Event::class));
+        $this->assertTrue($rc->isSubclassOf(FOSElasticaEvent::class));
     }
 
     public function testShouldImplementPersistEventInterface()

--- a/tests/Unit/Transformer/ModelToElasticaAutoTransformerTest.php
+++ b/tests/Unit/Transformer/ModelToElasticaAutoTransformerTest.php
@@ -173,12 +173,12 @@ class ModelToElasticaAutoTransformerTest extends TestCase
             ->method('dispatch')
             ->withConsecutive(
                 [
-                    TransformEvent::PRE_TRANSFORM,
                     $this->isInstanceOf(TransformEvent::class),
+                    TransformEvent::PRE_TRANSFORM,
                 ],
                 [
-                    TransformEvent::POST_TRANSFORM,
                     $this->isInstanceOf(TransformEvent::class),
+                    TransformEvent::POST_TRANSFORM,
                 ]
             );
 


### PR DESCRIPTION
This PR introduce:

* a new Event class that maintain BC to SF3.4
* dispatch method compliant to new method signature
* removed by travis dunglas/symfony-lock and added symfony/flex

finished what @giovannialbero1992 had started in #1613 , creds to him