### PR TITLE
Test on PHP 8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,11 +18,12 @@ jobs:
   include:
     # Latest supported dependencies with each PHP version
     - php: 7.2
+
     - php: 7.4
       env: COVERAGE=true PHPUNIT_FLAGS="-v --coverage-clover=coverage.clover"
 
-    # Install all SF components in the same major version, see https://github.com/dunglas/symfony-lock
     - php: 7.4
+    - php: 8.0
 
     # Try SF ^4
     - php: 7.2


### PR DESCRIPTION
- [x] PR on `ruflin/elastica` to add support for PHP 8.0 (See https://github.com/ruflin/Elastica/pull/1794)
- [x] PR on `elasticsearch/elasticsearch` to add support for PHP 8.0