### PR TITLE
Add autowiring alias for named clients

### DIFF
--- a/src/DependencyInjection/FOSElasticaExtension.php
+++ b/src/DependencyInjection/FOSElasticaExtension.php
@@ -152,6 +152,8 @@ class FOSElasticaExtension extends Extension
             $clientDef->addTag('fos_elastica.client');
 
             $container->setDefinition($clientId, $clientDef);
+            $container->registerAliasForArgument($clientId, Client::class, $name.'.client');
+            $container->registerAliasForArgument($clientId, ElasticaClient::class, $name.'.client');
 
             $this->clients[$name] = [
                 'id' => $clientId,


### PR DESCRIPTION
With this PR you should be able to automatically get the right service injected when using the good type-hint and client name suffixed with `client`