### PR TITLE
Explicitly mark public services as public for Symfony 5.2 compatibility

### DIFF
--- a/src/DependencyInjection/Compiler/RegisterPagerProvidersPass.php
+++ b/src/DependencyInjection/Compiler/RegisterPagerProvidersPass.php
@@ -57,7 +57,7 @@ final class RegisterPagerProvidersPass implements CompilerPassInterface
                 }
 
                 if (!$providerDef->isPublic()) {
-                    throw new \InvalidArgumentException(sprintf('Elastica persister "%s" must be a public service', $id));
+                    throw new \InvalidArgumentException(sprintf('Elastica pager provider "%s" must be a public service', $id));
                 }
 
                 $registeredProviders[$index][$type] = $id;

--- a/src/DependencyInjection/FOSElasticaExtension.php
+++ b/src/DependencyInjection/FOSElasticaExtension.php
@@ -562,6 +562,7 @@ class FOSElasticaExtension extends Extension
         }
 
         $serviceDef->addTag('fos_elastica.persister', ['index' => $indexName, 'type' => $typeName]);
+        $serviceDef->setPublic(true);
 
         $container->setDefinition($serviceId, $serviceDef);
 
@@ -617,6 +618,7 @@ class FOSElasticaExtension extends Extension
          */
         $providerId = sprintf('fos_elastica.pager_provider.%s.%s', $indexName, $typeName);
         $providerDef->addTag('fos_elastica.pager_provider', ['index' => $indexName, 'type' => $typeName]);
+        $providerDef->setPublic(true);
 
         $container->setDefinition($providerId, $providerDef);
 

--- a/tests/Unit/DependencyInjection/Compiler/RegisterPagerPersistersPassTest.php
+++ b/tests/Unit/DependencyInjection/Compiler/RegisterPagerPersistersPassTest.php
@@ -136,6 +136,7 @@ class RegisterPagerPersistersPassTest extends TestCase
     {
         $definition = new Definition(PagerPersisterInterface::class);
         $definition->addTag('fos_elastica.pager_persister', $attributes);
+        $definition->setPublic(true);
 
         return $definition;
     }

--- a/tests/Unit/DependencyInjection/Compiler/RegisterPagerProvidersPassTest.php
+++ b/tests/Unit/DependencyInjection/Compiler/RegisterPagerProvidersPassTest.php
@@ -129,6 +129,7 @@ class RegisterPagerProvidersPassTest extends TestCase
         $provider = $this->createProviderDefinition(['index' => 'foo', 'type' => 'bar']);
         $provider->setClass(\stdClass::class);
         $provider->setFactory('a_factory_function');
+        $provider->setPublic(true);
 
         $container->setDefinition('a_foo_provider', $provider);
 
@@ -146,6 +147,7 @@ class RegisterPagerProvidersPassTest extends TestCase
     {
         $definition = new Definition(PagerProviderInterface::class);
         $definition->addTag('fos_elastica.pager_provider', $attributes);
+        $definition->setPublic(true);
 
         return $definition;
     }

--- a/tests/Unit/DependencyInjection/Compiler/RegisterPersistersPassTest.php
+++ b/tests/Unit/DependencyInjection/Compiler/RegisterPersistersPassTest.php
@@ -147,6 +147,7 @@ class RegisterPersistersPassTest extends TestCase
     {
         $definition = new Definition(ObjectPersisterInterface::class);
         $definition->addTag('fos_elastica.persister', $attributes);
+        $definition->setPublic(true);
 
         return $definition;
     }


### PR DESCRIPTION
Symfony 5.2 removed the `setPrivate(false)` call from the `ChildDefinition` class (https://github.com/symfony/dependency-injection/commit/93123c0f564828ee0df027fbf98ad0b084f0966d#diff-053e10444fda1f5cfb6c16eee77d265e49962ec674d505e036a7238b78af8eb4), causing this bundle to throw exception on own registered services during its compiler passes. 

I know that with version 6 of this bundle most services are marked as private, but for the people not wanting to upgrade to v6 (yet), this can be a small service release of the 5.2 version.