### PR TITLE
Make PostMappingBuildEvent extends IndexEvent

### DIFF
--- a/src/Event/PostIndexMappingBuildEvent.php
+++ b/src/Event/PostIndexMappingBuildEvent.php
@@ -13,7 +13,7 @@ namespace FOS\ElasticaBundle\Event;
 
 use FOS\ElasticaBundle\Configuration\IndexConfigInterface;
 
-final class PostMappingBuildEvent extends IndexEvent
+final class PostIndexMappingBuildEvent extends IndexEvent
 {
     /**
      * @var IndexConfigInterface

--- a/src/Event/PostMappingBuildEvent.php
+++ b/src/Event/PostMappingBuildEvent.php
@@ -12,9 +12,8 @@
 namespace FOS\ElasticaBundle\Event;
 
 use FOS\ElasticaBundle\Configuration\IndexConfigInterface;
-use Symfony\Contracts\EventDispatcher\Event;
 
-final class PostMappingBuildEvent extends Event
+final class PostMappingBuildEvent extends IndexEvent
 {
     /**
      * @var IndexConfigInterface
@@ -30,6 +29,8 @@ final class PostMappingBuildEvent extends Event
     {
         $this->indexConfig = $indexConfig;
         $this->mapping = $mapping;
+
+        parent::__construct($indexConfig->getName());
     }
 
     public function getIndexConfig(): IndexConfigInterface

--- a/src/Index/MappingBuilder.php
+++ b/src/Index/MappingBuilder.php
@@ -13,7 +13,7 @@ namespace FOS\ElasticaBundle\Index;
 
 use FOS\ElasticaBundle\Configuration\IndexConfigInterface;
 use FOS\ElasticaBundle\Configuration\IndexTemplateConfig;
-use FOS\ElasticaBundle\Event\PostMappingBuildEvent;
+use FOS\ElasticaBundle\Event\PostIndexMappingBuildEvent;
 use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 class MappingBuilder
@@ -35,7 +35,7 @@ class MappingBuilder
     {
         $mappingIndex = [];
         $mapping = $this->buildMapping($indexConfig->getModel(), $indexConfig);
-        $this->dispatcher->dispatch($event = new PostMappingBuildEvent($indexConfig, $mapping));
+        $this->dispatcher->dispatch($event = new PostIndexMappingBuildEvent($indexConfig, $mapping));
 
         $mapping = $event->getMapping();
         $settings = $indexConfig->getSettings();


### PR DESCRIPTION
This would allow to easily check if event needs to be handled for a specific index, by using for example:

```php
if ('my_index' === $event->getIndex()) {
    // do stuff
}
```