### PR TITLE
Allow to disable aliasing when creating index

### DIFF
--- a/src/Command/CreateCommand.php
+++ b/src/Command/CreateCommand.php
@@ -51,6 +51,7 @@ class CreateCommand extends Command
         $this
             ->setName('fos:elastica:create')
             ->addOption('index', null, InputOption::VALUE_OPTIONAL, 'Index that needs to be created')
+            ->addOption('no-alias', null, InputOption::VALUE_NONE, 'Do not alias index')
             ->setDescription('Creating empty index with mapping')
         ;
     }
@@ -70,7 +71,7 @@ class CreateCommand extends Command
             $mapping = $this->mappingBuilder->buildIndexMapping($indexConfig);
             $index->create($mapping);
 
-            if ($indexConfig->isUseAlias()) {
+            if ($indexConfig->isUseAlias() && !$input->getOption('no-alias')) {
                 $index->addAlias($indexName);
             }
         }


### PR DESCRIPTION
This is complementary to https://github.com/FriendsOfSymfony/FOSElasticaBundle/pull/1577

Permit to disable automatic aliasing when creating a new index.
This is useful when creating a new index that will be switched later (once populate is done for example).