### PR TITLE
Support pagerfanta 2.x and 3.x

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -37,13 +37,17 @@ jobs:
         include:
           - php: '7.2'
             elasticsearch: '7.0.0'
-            composer_flags: '--prefer-lowest'
+            composer_flags: '--prefer-lowest --prefer-stable'
+            symfony_require: '4.4.*'
           - php: '7.3'
             elasticsearch: '7.4.0'
+            composer_flags: '--prefer-stable'
           - php: '7.4'
             elasticsearch: '7.9.0'
+            composer_flags: '--prefer-stable'
           - php: '8.0'
             elasticsearch: '7.11.0'
+            composer_flags: '--prefer-stable'
       fail-fast: false
     steps:
       - name: 'Checkout'
@@ -72,6 +76,8 @@ jobs:
             ${{ runner.os }}-composer-
 
       - name: 'Update dependencies'
+        env:
+          SYMFONY_REQUIRE: "${{ matrix.symfony_require }}"
         run: |
           composer global require --no-progress --no-scripts --no-plugins symfony/flex
           composer update --prefer-dist --no-interaction --no-progress --ansi ${{ matrix.composer_flags }}

--- a/CHANGELOG-6.0.md
+++ b/CHANGELOG-6.0.md
@@ -9,12 +9,15 @@ in 6.0 versions.
 * Added PHP 8 support,
 * Added `auth_type` client parameter [Elastica#1790](https://github.com/ruflin/Elastica/pull/1790).
 * Added a post mapping builder event.
+* Upgraded `pagerfanta/pagerfanta` to v3.
 * Fixed deprecations for `Elastica\Index::create()` [Elastica#1828](https://github.com/ruflin/Elastica/pull/1828).
 * **[BC break]** Marked all `fos_elastica.finder.*` services as private.
 * **[BC break]** Marked the `fos_elastica.client` alias as private.
 * **[BC break]** Marked the `fos_elastica.client_prototype` service as private.
 * **[BC break]** Marked the `fos_elastica.index_template_prototype` service as private.
 * **[BC break]** Marked all events final and introduced several abstract classes.
+* **[BC break]** Signature of `FantaPaginatorAdapter::getNbResults()` has changed.
+* **[BC break]** Signature of `FantaPaginatorAdapter::getSlice()` has changed.
 
 ### 6.0.0-BETA3 (2020-09-28)
 

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     ],
     "require": {
         "php": "^7.2 || ^8.0",
-        "pagerfanta/pagerfanta": "^2.0",
+        "pagerfanta/pagerfanta": "^3.0",
         "psr/log": "^1.0",
         "ruflin/elastica": "^7.1",
         "symfony/console": "^4.4 || ^5.1",

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     ],
     "require": {
         "php": "^7.2 || ^8.0",
-        "pagerfanta/pagerfanta": "^3.0",
+        "pagerfanta/pagerfanta": "^2.4 || ^3.0",
         "psr/log": "^1.0",
         "ruflin/elastica": "^7.1",
         "symfony/console": "^4.4 || ^5.1",
@@ -50,6 +50,9 @@
         "jms/serializer": "^3.8",
         "jms/serializer-bundle": "^3.5",
         "knplabs/knp-components": "^2.3 || ^3.0",
+        "pagerfanta/doctrine-mongodb-odm-adapter": "^2.4 || ^3.0",
+        "pagerfanta/doctrine-orm-adapter": "^2.4 || ^3.0",
+        "pagerfanta/doctrine-phpcr-odm-adapter": "^2.4 || ^3.0",
         "phpspec/prophecy-phpunit": "^1.1 || ^2.0",
         "phpunit/phpunit": "^8.5 || ^9.3",
         "symfony/expression-language": "^4.4 || ^5.1",

--- a/src/Doctrine/MongoDBPagerProvider.php
+++ b/src/Doctrine/MongoDBPagerProvider.php
@@ -15,7 +15,7 @@ use Doctrine\Persistence\ManagerRegistry;
 use FOS\ElasticaBundle\Provider\PagerfantaPager;
 use FOS\ElasticaBundle\Provider\PagerInterface;
 use FOS\ElasticaBundle\Provider\PagerProviderInterface;
-use Pagerfanta\Adapter\DoctrineODMMongoDBAdapter;
+use Pagerfanta\Doctrine\MongoDBODM\QueryAdapter;
 use Pagerfanta\Pagerfanta;
 
 final class MongoDBPagerProvider implements PagerProviderInterface
@@ -62,7 +62,7 @@ final class MongoDBPagerProvider implements PagerProviderInterface
         $repository = $manager->getRepository($this->objectClass);
 
         $pager = new PagerfantaPager(new Pagerfanta(
-            new DoctrineODMMongoDBAdapter(\call_user_func([$repository, $options['query_builder_method']]))
+            new QueryAdapter(\call_user_func([$repository, $options['query_builder_method']]))
         ));
 
         $this->registerListenersService->register($manager, $pager, $options);

--- a/src/Doctrine/ORMPagerProvider.php
+++ b/src/Doctrine/ORMPagerProvider.php
@@ -17,7 +17,7 @@ use Doctrine\Persistence\ManagerRegistry;
 use FOS\ElasticaBundle\Provider\PagerfantaPager;
 use FOS\ElasticaBundle\Provider\PagerInterface;
 use FOS\ElasticaBundle\Provider\PagerProviderInterface;
-use Pagerfanta\Adapter\DoctrineORMAdapter;
+use Pagerfanta\Doctrine\ORM\QueryAdapter;
 use Pagerfanta\Pagerfanta;
 
 final class ORMPagerProvider implements PagerProviderInterface
@@ -90,7 +90,7 @@ final class ORMPagerProvider implements PagerProviderInterface
             }
         }
 
-        $pager = new PagerfantaPager(new Pagerfanta(new DoctrineORMAdapter($qb)));
+        $pager = new PagerfantaPager(new Pagerfanta(new QueryAdapter($qb)));
 
         $this->registerListenersService->register($manager, $pager, $options);
 

--- a/src/Doctrine/PHPCRPagerProvider.php
+++ b/src/Doctrine/PHPCRPagerProvider.php
@@ -15,7 +15,7 @@ use Doctrine\Persistence\ManagerRegistry;
 use FOS\ElasticaBundle\Provider\PagerfantaPager;
 use FOS\ElasticaBundle\Provider\PagerInterface;
 use FOS\ElasticaBundle\Provider\PagerProviderInterface;
-use Pagerfanta\Adapter\DoctrineODMPhpcrAdapter;
+use Pagerfanta\Doctrine\PHPCRODM\QueryAdapter;
 use Pagerfanta\Pagerfanta;
 
 final class PHPCRPagerProvider implements PagerProviderInterface
@@ -63,7 +63,7 @@ final class PHPCRPagerProvider implements PagerProviderInterface
         $manager = $this->doctrine->getManagerForClass($this->objectClass);
         $repository = $manager->getRepository($this->objectClass);
 
-        $adapter = new DoctrineODMPhpcrAdapter(
+        $adapter = new QueryAdapter(
             \call_user_func([$repository, $options['query_builder_method']], static::ENTITY_ALIAS)
         );
 

--- a/src/Paginator/FantaPaginatorAdapter.php
+++ b/src/Paginator/FantaPaginatorAdapter.php
@@ -24,8 +24,6 @@ class FantaPaginatorAdapter implements AdapterInterface
 
     /**
      * Returns the number of results.
-     *
-     * @return int The number of results
      */
     public function getNbResults(): int
     {
@@ -59,9 +57,10 @@ class FantaPaginatorAdapter implements AdapterInterface
     /**
      * Returns a slice of the results.
      *
-     * @return iterable The slice
+     * @param int $offset The offset
+     * @param int $length The length
      */
-    public function getSlice(int $offset, int $length): iterable
+    public function getSlice($offset, $length): iterable
     {
         return $this->adapter->getResults($offset, $length)->toArray();
     }

--- a/src/Paginator/FantaPaginatorAdapter.php
+++ b/src/Paginator/FantaPaginatorAdapter.php
@@ -27,7 +27,7 @@ class FantaPaginatorAdapter implements AdapterInterface
      *
      * @return int The number of results
      */
-    public function getNbResults()
+    public function getNbResults(): int
     {
         return $this->adapter->getTotalHits();
     }
@@ -59,12 +59,9 @@ class FantaPaginatorAdapter implements AdapterInterface
     /**
      * Returns a slice of the results.
      *
-     * @param int $offset The offset
-     * @param int $length The length
-     *
-     * @return array|\Traversable The slice
+     * @return iterable The slice
      */
-    public function getSlice($offset, $length)
+    public function getSlice(int $offset, int $length): iterable
     {
         return $this->adapter->getResults($offset, $length)->toArray();
     }

--- a/tests/Unit/Doctrine/MongoDBPagerProviderTest.php
+++ b/tests/Unit/Doctrine/MongoDBPagerProviderTest.php
@@ -20,7 +20,7 @@ use FOS\ElasticaBundle\Provider\PagerfantaPager;
 use FOS\ElasticaBundle\Provider\PagerInterface;
 use FOS\ElasticaBundle\Provider\PagerProviderInterface;
 use FOS\ElasticaBundle\Tests\Unit\Mocks\DoctrineMongoDBCustomRepositoryMock;
-use Pagerfanta\Adapter\DoctrineODMMongoDBAdapter;
+use Pagerfanta\Doctrine\MongoDBODM\QueryAdapter;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Doctrine\ManagerRegistry;
 
@@ -83,7 +83,7 @@ class MongoDBPagerProviderTest extends TestCase
         $this->assertInstanceOf(PagerfantaPager::class, $pager);
 
         $adapter = $pager->getPagerfanta()->getAdapter();
-        $this->assertInstanceOf(DoctrineODMMongoDBAdapter::class, $adapter);
+        $this->assertInstanceOf(QueryAdapter::class, $adapter);
         $this->assertSame($expectedBuilder, $adapter->getQueryBuilder());
     }
 

--- a/tests/Unit/Doctrine/ORMPagerProviderTest.php
+++ b/tests/Unit/Doctrine/ORMPagerProviderTest.php
@@ -21,7 +21,7 @@ use FOS\ElasticaBundle\Provider\PagerfantaPager;
 use FOS\ElasticaBundle\Provider\PagerInterface;
 use FOS\ElasticaBundle\Provider\PagerProviderInterface;
 use FOS\ElasticaBundle\Tests\Unit\Mocks\DoctrineORMCustomRepositoryMock;
-use Pagerfanta\Adapter\DoctrineORMAdapter;
+use Pagerfanta\Doctrine\ORM\QueryAdapter;
 use PHPUnit\Framework\TestCase;
 use Symfony\Bridge\Doctrine\ManagerRegistry;
 
@@ -80,7 +80,7 @@ class ORMPagerProviderTest extends TestCase
         $this->assertInstanceOf(PagerfantaPager::class, $pager);
 
         $adapter = $pager->getPagerfanta()->getAdapter();
-        $this->assertInstanceOf(DoctrineORMAdapter::class, $adapter);
+        $this->assertInstanceOf(QueryAdapter::class, $adapter);
     }
 
     public function testShouldAllowCallCustomRepositoryMethod()

--- a/tests/Unit/Doctrine/PHPCRPagerProviderTest.php
+++ b/tests/Unit/Doctrine/PHPCRPagerProviderTest.php
@@ -21,7 +21,7 @@ use FOS\ElasticaBundle\Provider\PagerfantaPager;
 use FOS\ElasticaBundle\Provider\PagerInterface;
 use FOS\ElasticaBundle\Provider\PagerProviderInterface;
 use FOS\ElasticaBundle\Tests\Unit\Mocks\DoctrinePHPCRCustomRepositoryMock;
-use Pagerfanta\Adapter\DoctrineODMPhpcrAdapter;
+use Pagerfanta\Doctrine\PHPCRODM\QueryAdapter;
 use PHPUnit\Framework\TestCase;
 
 class PHPCRPagerProviderTest extends TestCase
@@ -83,7 +83,7 @@ class PHPCRPagerProviderTest extends TestCase
         $this->assertInstanceOf(PagerfantaPager::class, $pager);
 
         $adapter = $pager->getPagerfanta()->getAdapter();
-        $this->assertInstanceOf(DoctrineODMPhpcrAdapter::class, $adapter);
+        $this->assertInstanceOf(QueryAdapter::class, $adapter);
         $this->assertSame($expectedBuilder, $adapter->getQueryBuilder());
     }
 


### PR DESCRIPTION
This follows #1764 in order to support version 2.x and 3.x of pagerfanta.
This allows to still be compatible with PHP versions anterior to 7.4