### PR TITLE
fix symfony/property-access magicCall deprecation

### DIFF
--- a/src/Resources/config/config.xml
+++ b/src/Resources/config/config.xml
@@ -5,7 +5,7 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <parameters>
-        <parameter key="fos_elastica.property_accessor.magicCall">false</parameter>
+        <parameter key="fos_elastica.property_accessor.magicCall">0</parameter>
         <parameter key="fos_elastica.property_accessor.throwExceptionOnInvalidIndex">false</parameter>
     </parameters>
 


### PR DESCRIPTION
Supersedes https://github.com/FriendsOfSymfony/FOSElasticaBundle/pull/1750
Closes #1737

```
User Deprecated: Since symfony/property-access 5.2: Passing a boolean as the first argument to "Symfony\Component\PropertyAccess\PropertyAccessor::__construct()" is deprecated. Pass a combination of bitwise flags instead (i.e an integer).
```

PR changes `false`  to `0`

From https://github.com/symfony/property-access/blob/5.x/PropertyAccessor.php#L94
```php
$magicMethods = ($magicMethods ? self::MAGIC_CALL : 0) | self::MAGIC_GET | self::MAGIC_SET;
```