### PR TITLE
Dependency change to add Content-Type Fix

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "symfony/property-access": "^3.4|^4.3|^5",
         "pagerfanta/pagerfanta": "^1.0.5|^2.0",
         "psr/log": "^1.0",
-        "ruflin/elastica": "^5.3.5|^6.1.1"
+        "ruflin/elastica": "^5.3.5|^6.1.1|^6.1.2"
     },
     "require-dev": {
         "doctrine/orm": "^2.5",


### PR DESCRIPTION
Sorry in advance for my english.

Version 6.1.2 of ruflin elastica fixes an  issues  where when re using conenctions to ElasticSearch with the Aws Transport, the content type gets stored from the first request and re used on future requests. This leads to the possible error of having the first request done with content type  `application/x-ndjson` when doing for example an msearch and then on the next request doing a normal query that must use `application/json` but gets sent with the first requests content type header and so rejected.


Here is a comparison between both versions of ruflin https://github.com/ruflin/Elastica/compare/6.1.1...6.1.2

And here is a screenshot of the particular change solving the content type issue.
![image](https://user-images.githubusercontent.com/9084141/112532134-38eba200-8d87-11eb-8cac-df99a2990074.png)

Is it possible to make this change on https://github.com/FriendsOfSymfony/FOSElasticaBundle/blob/v5.2.1/composer.json and have a new version 5.2.2 ?