### PR TITLE
Use spaceship operator within usort callback

### DIFF
--- a/src/Doctrine/AbstractElasticaToModelTransformer.php
+++ b/src/Doctrine/AbstractElasticaToModelTransformer.php
@@ -115,10 +115,10 @@ abstract class AbstractElasticaToModelTransformer extends BaseTransformer
                     return $idPos[(string) $propertyAccessor->getValue(
                         $a,
                         $identifier
-                    )] > $idPos[(string) $propertyAccessor->getValue($b, $identifier)];
+                    )] <=> $idPos[(string) $propertyAccessor->getValue($b, $identifier)];
                 }
 
-                return $idPos[$a[$identifier]] > $idPos[$b[$identifier]];
+                return $idPos[$a[$identifier]] <=> $idPos[$b[$identifier]];
             }
         );
 


### PR DESCRIPTION
Since PHP 8 returning `bool` from `usort` callback function is deprecated. This small change migrates to using spaceship operator, which is available since PHP 7.0.