### PR TITLE
Fix deprecation with Symfony 5.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
         "doctrine/orm": "^2.8",
         "doctrine/phpcr-bundle": "^1.3 || ^2.0",
         "doctrine/phpcr-odm": "^1.4",
-        "friendsofphp/php-cs-fixer": "^2.2",
+        "friendsofphp/php-cs-fixer": "^3.0",
         "jackalope/jackalope-doctrine-dbal": "^1.2",
         "jms/serializer": "^3.8",
         "jms/serializer-bundle": "^3.5",

--- a/src/Resources/config/config.xml
+++ b/src/Resources/config/config.xml
@@ -6,7 +6,7 @@
 
     <parameters>
         <parameter key="fos_elastica.property_accessor.magicCall">0</parameter>
-        <parameter key="fos_elastica.property_accessor.throwExceptionOnInvalidIndex">false</parameter>
+        <parameter key="fos_elastica.property_accessor.throwExceptionOnInvalidIndex">0</parameter>
     </parameters>
 
     <services>


### PR DESCRIPTION
Since Symfony 5.3 is deprecated to construct PropertyAccessor with a `bool` value as second argument.

Ref: https://github.com/symfony/property-access/blob/8988399a556cffb0fba9bb3603f8d1ba4543eceb/CHANGELOG.md#530