### PR TITLE
Add missing cast to string for object identifiers in ModelToElasticaldentifierTransformer

### DIFF
--- a/src/Transformer/ModelToElasticaIdentifierTransformer.php
+++ b/src/Transformer/ModelToElasticaIdentifierTransformer.php
@@ -30,6 +30,9 @@ class ModelToElasticaIdentifierTransformer extends ModelToElasticaAutoTransforme
     public function transform($object, array $fields)
     {
         $identifier = $this->propertyAccessor->getValue($object, $this->options['identifier']);
+        if ($identifier && !is_scalar($identifier)) {
+            $identifier = (string) $identifier;
+        }
 
         return new Document($identifier);
     }

--- a/tests/Unit/Transformer/ModelToElasticaIdentifierTransformerTest.php
+++ b/tests/Unit/Transformer/ModelToElasticaIdentifierTransformerTest.php
@@ -34,6 +34,20 @@ class POPO4
 
 class ModelToElasticaIdentifierTransformerTest extends TestCase
 {
+    public function testIdentifierIsCastedToString()
+    {
+        $idObject = new CastableObject();;
+        $idObject->foo = '00000000-0000-0000-0000-000000000000';
+
+        $object = new \stdClass();
+        $object->id = $idObject;
+
+        $transformer = $this->getTransformer();
+        $document = $transformer->transform($object, []);
+
+        $this->assertSame('00000000-0000-0000-0000-000000000000', $document->getId());
+    }
+
     public function testGetDocumentWithIdentifierOnly()
     {
         $transformer = $this->getTransformer();


### PR DESCRIPTION
A while back the casting of the identifier to object was reworked so that it happened only if the object was not a scalar. (PR: #1357)

However when that rework happened this was not implemented in the ModelToElasticaIdentifierTransformer.

This pull requests implements the same logic there as well.