### PR TITLE
Fix deprecated knp_paginator.subscriber

### DIFF
--- a/src/Resources/config/config.xml
+++ b/src/Resources/config/config.xml
@@ -34,7 +34,7 @@
         </service>
 
         <service id="fos_elastica.paginator.subscriber" class="FOS\ElasticaBundle\Subscriber\PaginateElasticaQuerySubscriber">
-            <tag name="knp_paginator.subscriber" />
+            <tag name="kernel.event_subscriber" />
             <argument type="service" id="request_stack" />
         </service>
 


### PR DESCRIPTION
Closes #1816 

KnpPaginatorBundle does not use that tag anymore.

See https://github.com/KnpLabs/KnpPaginatorBundle/pull/703/files