### PR TITLE
fix: result count for Traversable

### DIFF
--- a/src/Persister/AsyncPagerPersister.php
+++ b/src/Persister/AsyncPagerPersister.php
@@ -87,7 +87,8 @@ final class AsyncPagerPersister implements PagerPersisterInterface
         $pager->setMaxPerPage($options['max_per_page']);
         $pager->setCurrentPage($options['first_page']);
 
-        $objectCount = \count($pager->getCurrentPageResults());
+        $results = $pager->getCurrentPageResults();
+        $objectCount = $results instanceof \Traversable ? \iterator_count($results): \count($results);
 
         $pagerPersister = $this->pagerPersisterRegistry->getPagerPersister(InPlacePagerPersister::NAME);
         $pagerPersister->insert($pager, $options);


### PR DESCRIPTION
I was getting this error with the latest version of Doctrine ODM Bundle:
```
(TypeError(code: 0): count(): Argument #1 ($value) must be of type Countable|array, Doctrine\\ODM\\MongoDB\\Iterator\\CachingIterator given at /app/vendor/friendsofsymfony/elastica-bundle/src/Persister/AsyncPagerPersister.php:90)"}
```

so this fixes that issue to be able to count a Traversable as well