### PR TITLE
Remove deprecations using Symfony 5.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,8 @@
 {
     "name": "friendsofsymfony/elastica-bundle",
-    "type": "symfony-bundle",
     "description": "Elasticsearch PHP integration for your Symfony project using Elastica",
+    "license": "MIT",
+    "type": "symfony-bundle",
     "keywords": [
         "doctrine2",
         "elastica",
@@ -9,8 +10,6 @@
         "mongodb",
         "search"
     ],
-    "homepage": "https://github.com/FriendsOfSymfony/FOSElasticaBundle",
-    "license": "MIT",
     "authors": [
         {
             "name": "FriendsOfSymfony Community",
@@ -29,6 +28,7 @@
             "email": "jmikola@gmail.com"
         }
     ],
+    "homepage": "https://github.com/FriendsOfSymfony/FOSElasticaBundle",
     "require": {
         "php": "^7.4 || ^8.0",
         "pagerfanta/pagerfanta": "^2.4 || ^3.0",
@@ -66,11 +66,6 @@
         "enqueue/elastica-bundle": "For populating Elasticsearch indexes asynchronously and using significanly less resources. Uses Enqueue.",
         "symfony/messenger": "For populating Elasticsearch indexes asynchronously and using significanly less resources."
     },
-    "extra": {
-        "branch-alias": {
-            "dev-master": "6.0.x-dev"
-        }
-    },
     "autoload": {
         "psr-4": {
             "FOS\\ElasticaBundle\\": "src/"
@@ -79,6 +74,11 @@
     "autoload-dev": {
         "psr-4": {
             "FOS\\ElasticaBundle\\Tests\\": "tests/"
+        }
+    },
+    "extra": {
+        "branch-alias": {
+            "dev-master": "6.0.x-dev"
         }
     }
 }

--- a/src/Command/CreateCommand.php
+++ b/src/Command/CreateCommand.php
@@ -56,6 +56,9 @@ class CreateCommand extends Command
         ;
     }
 
+    /**
+     * @return int
+     */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $indexes = (null !== $index = $input->getOption('index')) ? [$index] : \array_keys($this->indexManager->getAllIndexes());

--- a/src/Command/DeleteCommand.php
+++ b/src/Command/DeleteCommand.php
@@ -48,6 +48,9 @@ class DeleteCommand extends Command
         ;
     }
 
+    /**
+     * @return int
+     */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $indexName = $input->getOption('index');

--- a/src/Command/PopulateCommand.php
+++ b/src/Command/PopulateCommand.php
@@ -117,6 +117,9 @@ class PopulateCommand extends Command
         }
     }
 
+    /**
+     * @return int
+     */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $indexes = (null !== $index = $input->getOption('index')) ? [$index] : \array_keys($this->indexManager->getAllIndexes());

--- a/src/Command/ResetCommand.php
+++ b/src/Command/ResetCommand.php
@@ -48,6 +48,9 @@ class ResetCommand extends Command
         ;
     }
 
+    /**
+     * @return int
+     */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $indexes = (null !== $index = $input->getOption('index')) ? [$index] : \array_keys($this->indexManager->getAllIndexes());

--- a/src/Command/ResetTemplatesCommand.php
+++ b/src/Command/ResetTemplatesCommand.php
@@ -61,7 +61,7 @@ final class ResetTemplatesCommand extends Command
     }
 
     /**
-     * {@inheritdoc}
+     * @return int
      */
     protected function execute(InputInterface $input, OutputInterface $output)
     {

--- a/src/Command/SearchCommand.php
+++ b/src/Command/SearchCommand.php
@@ -51,6 +51,9 @@ class SearchCommand extends Command
         ;
     }
 
+    /**
+     * @return int
+     */
     protected function execute(InputInterface $input, OutputInterface $output)
     {
         $indexName = $input->getOption('index');

--- a/src/DataCollector/ElasticaDataCollector.php
+++ b/src/DataCollector/ElasticaDataCollector.php
@@ -78,6 +78,9 @@ class ElasticaDataCollector extends DataCollector
         return $time;
     }
 
+    /**
+     * @return string
+     */
     public function getName()
     {
         return 'elastica';


### PR DESCRIPTION
This PR normalizes `composer.json` and adds phpdoc return types to avoid deprecation warnings using Symfony 5.4