### PR TITLE
Allow Symfony 6

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -30,7 +30,7 @@ jobs:
 
   phpunit:
     runs-on: 'ubuntu-20.04'
-    name: 'PHPUnit (PHP ${{ matrix.php }}, ES ${{ matrix.elasticsearch }})'
+    name: 'PHPUnit (PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony_require }}, ES ${{ matrix.elasticsearch }})'
     timeout-minutes: 10
     env:
       SYMFONY_REQUIRE: "${{ matrix.symfony_require }}"
@@ -44,11 +44,15 @@ jobs:
           - php: '7.4'
             elasticsearch: '7.9.0'
             dependencies: 'highest'
-            symfony_require: '5.3.*'
+            symfony_require: '5.4.*'
           - php: '8.0'
             elasticsearch: '7.11.0'
             dependencies: 'highest'
-            symfony_require: '5.3.*'
+            symfony_require: '5.4.*'
+          - php: '8.0'
+            elasticsearch: '7.11.0'
+            dependencies: 'highest'
+            symfony_require: '6.0.*'
       fail-fast: false
     steps:
       - name: 'Checkout'
@@ -59,11 +63,8 @@ jobs:
         with:
           php-version: '${{ matrix.php }}'
           coverage: 'none'
-          tools: 'pecl, composer:v2'
+          tools: 'pecl, composer:v2, flex'
           extensions: 'curl, json, mbstring, mongodb-1.9.0, openssl'
-
-      - name: "Globally install symfony/flex"
-        run: "composer global require --no-progress --no-scripts --no-plugins symfony/flex"
 
       - name: "Install Composer dependencies (${{ matrix.dependencies }})"
         uses: "ramsey/composer-install@v1"

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -49,7 +49,7 @@ jobs:
             elasticsearch: '7.11.0'
             dependencies: 'highest'
             symfony_require: '5.4.*'
-          - php: '8.0'
+          - php: '8.1'
             elasticsearch: '7.11.0'
             dependencies: 'highest'
             symfony_require: '6.0.*'
@@ -64,7 +64,7 @@ jobs:
           php-version: '${{ matrix.php }}'
           coverage: 'none'
           tools: 'pecl, composer:v2, flex'
-          extensions: 'curl, json, mbstring, mongodb-1.9.0, openssl'
+          extensions: 'curl, json, mbstring, mongodb, openssl'
 
       - name: "Install Composer dependencies (${{ matrix.dependencies }})"
         uses: "ramsey/composer-install@v1"

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ The following table shows the compatibilities of different versions of the bundl
 
 | FOSElasticaBundle                                                                       | Elastica | Elasticsearch | Symfony    | PHP   |
 | --------------------------------------------------------------------------------------- | ---------| ------------- | ---------- | ----- |
-| [6.0] (master)                                                                          | ^7.1     | 7.\*          | ^4.4\|^5.3 | >=7.4 |
+| [6.0] (master)                                                                          | ^7.1     | 7.\*          | ^4.4\|^5.3\|^6.0 | >=7.4 |
 | [5.1] (5.1.x)                                                                           | ^5.3\|^6 | 5.\*\|6.\*    | ^3.4\|^4   | >=7.1 |
 | [5.0] (unmaintained)                                                                    | ^5.2\|^6 | 5.\*\|6.\*    | ^3.2\|^4   | >=5.6 |
 | [4.x] (unmaintained)                                                                    | 3.2.\*   | 2.\*          | ^2.8\|^3.2 | >=5.5 |

--- a/composer.json
+++ b/composer.json
@@ -34,10 +34,10 @@
         "pagerfanta/pagerfanta": "^2.4 || ^3.0",
         "psr/log": "^1.0",
         "ruflin/elastica": "^7.1",
-        "symfony/console": "^4.4 || ^5.3",
-        "symfony/dependency-injection": "^4.4 || ^5.3",
-        "symfony/framework-bundle": "^4.4 || ^5.3",
-        "symfony/property-access": "^4.4 || ^5.3"
+        "symfony/console": "^4.4 || ^5.4 || ^6.0",
+        "symfony/dependency-injection": "^4.4 || ^5.4 || ^6.0",
+        "symfony/framework-bundle": "^4.4 || ^5.4 || ^6.0",
+        "symfony/property-access": "^4.4 || ^5.4 || ^6.0"
     },
     "require-dev": {
         "doctrine/doctrine-bundle": "^2.1.1",
@@ -48,18 +48,18 @@
         "friendsofphp/php-cs-fixer": "^3.0",
         "jackalope/jackalope-doctrine-dbal": "^1.2",
         "jms/serializer": "^3.8",
-        "jms/serializer-bundle": "^3.5",
+        "jms/serializer-bundle": "^3.5 || ^4.0",
         "knplabs/knp-components": "^2.4 || ^3.0",
         "pagerfanta/doctrine-mongodb-odm-adapter": "^2.4 || ^3.0",
         "pagerfanta/doctrine-orm-adapter": "^2.4 || ^3.0",
         "pagerfanta/doctrine-phpcr-odm-adapter": "^2.4 || ^3.0",
         "phpunit/phpunit": "^9.5",
-        "symfony/expression-language": "^4.4 || ^5.3",
-        "symfony/messenger": "^4.4 || ^5.3",
-        "symfony/serializer": "^4.4 || ^5.3",
-        "symfony/twig-bundle": "^4.4 || ^5.3",
-        "symfony/web-profiler-bundle": "^4.4 || ^5.3",
-        "symfony/yaml": "^4.4 || ^5.3"
+        "symfony/expression-language": "^4.4 || ^5.4 || ^6.0",
+        "symfony/messenger": "^4.4 || ^5.4 || ^6.0",
+        "symfony/serializer": "^4.4 || ^5.4 || ^6.0",
+        "symfony/twig-bundle": "^4.4 || ^5.4 || ^6.0",
+        "symfony/web-profiler-bundle": "^4.4 || ^5.4 || ^6.0",
+        "symfony/yaml": "^4.4 || ^5.4 || ^6.0"
     },
     "suggest": {
         "enqueue/elastica-bundle": "For populating Elasticsearch indexes asynchronously and using significanly less resources. Uses Enqueue.",

--- a/src/Logger/ElasticaLogger.php
+++ b/src/Logger/ElasticaLogger.php
@@ -111,6 +111,8 @@ class ElasticaLogger extends AbstractLogger
 
     /**
      * {@inheritdoc}
+     *
+     * @return void
      */
     public function log($level, $message, array $context = [])
     {

--- a/src/Subscriber/PaginateElasticaQuerySubscriber.php
+++ b/src/Subscriber/PaginateElasticaQuerySubscriber.php
@@ -116,7 +116,7 @@ class PaginateElasticaQuerySubscriber implements EventSubscriberInterface
             $sortDirection = $options['defaultSortDirection'];
         }
 
-        if ('desc' === \strtolower($sortDirection)) {
+        if (null !== $sortDirection && 'desc' === \strtolower($sortDirection)) {
             $dir = 'desc';
         }
 

--- a/tests/Functional/ClientTest.php
+++ b/tests/Functional/ClientTest.php
@@ -27,15 +27,15 @@ class ClientTest extends WebTestCase
         self::bootKernel(['test_case' => 'Basic']);
 
         /** @var Client $es */
-        $es = $this->getContainerBC()->get('fos_elastica.client.default');
+        $es = self::getContainer()->get('fos_elastica.client.default');
         $this->assertInstanceOf(RoundRobin::class, $es->getConnectionStrategy());
 
         /** @var Client $es */
-        $es = $this->getContainerBC()->get('fos_elastica.client.second_server');
+        $es = self::getContainer()->get('fos_elastica.client.second_server');
         $this->assertInstanceOf(RoundRobin::class, $es->getConnectionStrategy());
 
         /** @var Client $es */
-        $es = $this->getContainerBC()->get('fos_elastica.client.third');
+        $es = self::getContainer()->get('fos_elastica.client.third');
         $this->assertInstanceOf(Simple::class, $es->getConnectionStrategy());
     }
 }

--- a/tests/Functional/ClientTest.php
+++ b/tests/Functional/ClientTest.php
@@ -27,15 +27,15 @@ class ClientTest extends WebTestCase
         self::bootKernel(['test_case' => 'Basic']);
 
         /** @var Client $es */
-        $es = self::$container->get('fos_elastica.client.default');
+        $es = $this->getContainerBC()->get('fos_elastica.client.default');
         $this->assertInstanceOf(RoundRobin::class, $es->getConnectionStrategy());
 
         /** @var Client $es */
-        $es = self::$container->get('fos_elastica.client.second_server');
+        $es = $this->getContainerBC()->get('fos_elastica.client.second_server');
         $this->assertInstanceOf(RoundRobin::class, $es->getConnectionStrategy());
 
         /** @var Client $es */
-        $es = self::$container->get('fos_elastica.client.third');
+        $es = $this->getContainerBC()->get('fos_elastica.client.third');
         $this->assertInstanceOf(Simple::class, $es->getConnectionStrategy());
     }
 }

--- a/tests/Functional/ConfigurationManagerTest.php
+++ b/tests/Functional/ConfigurationManagerTest.php
@@ -25,7 +25,7 @@ class ConfigurationManagerTest extends WebTestCase
     {
         static::bootKernel(['test_case' => 'Basic']);
         /** @var ConfigManager $manager */
-        $manager = self::$container->get('fos_elastica.config_manager');
+        $manager = $this->getContainerBC()->get('fos_elastica.config_manager');
 
         $index = $manager->getIndexConfiguration('index');
 

--- a/tests/Functional/ConfigurationManagerTest.php
+++ b/tests/Functional/ConfigurationManagerTest.php
@@ -25,7 +25,7 @@ class ConfigurationManagerTest extends WebTestCase
     {
         static::bootKernel(['test_case' => 'Basic']);
         /** @var ConfigManager $manager */
-        $manager = $this->getContainerBC()->get('fos_elastica.config_manager');
+        $manager = self::getContainer()->get('fos_elastica.config_manager');
 
         $index = $manager->getIndexConfiguration('index');
 

--- a/tests/Functional/IndexTemplatesTest.php
+++ b/tests/Functional/IndexTemplatesTest.php
@@ -30,17 +30,17 @@ class IndexTemplatesTest extends WebTestCase
     {
         self::bootKernel(['test_case' => 'Basic']);
 
-        $instance = $this->getContainerBC()->get('fos_elastica.index_template.index_template_example_1');
+        $instance = self::getContainer()->get('fos_elastica.index_template.index_template_example_1');
         $this->assertInstanceOf(IndexTemplate::class, $instance);
         $this->assertInstanceOf(OriginalIndexTemplate::class, $instance);
 
-        $instance = $this->getContainerBC()->get('fos_elastica.config_manager.index_templates');
+        $instance = self::getContainer()->get('fos_elastica.config_manager.index_templates');
         $this->assertInstanceOf(ConfigManager::class, $instance);
 
-        $instance = $this->getContainerBC()->get('fos_elastica.index_template_manager');
+        $instance = self::getContainer()->get('fos_elastica.index_template_manager');
         $this->assertInstanceOf(IndexTemplateManager::class, $instance);
 
-        $instance = $this->getContainerBC()->get('fos_elastica.template_resetter');
+        $instance = self::getContainer()->get('fos_elastica.template_resetter');
         $this->assertInstanceOf(TemplateResetter::class, $instance);
     }
 }

--- a/tests/Functional/IndexTemplatesTest.php
+++ b/tests/Functional/IndexTemplatesTest.php
@@ -30,17 +30,17 @@ class IndexTemplatesTest extends WebTestCase
     {
         self::bootKernel(['test_case' => 'Basic']);
 
-        $instance = self::$container->get('fos_elastica.index_template.index_template_example_1');
+        $instance = $this->getContainerBC()->get('fos_elastica.index_template.index_template_example_1');
         $this->assertInstanceOf(IndexTemplate::class, $instance);
         $this->assertInstanceOf(OriginalIndexTemplate::class, $instance);
 
-        $instance = self::$container->get('fos_elastica.config_manager.index_templates');
+        $instance = $this->getContainerBC()->get('fos_elastica.config_manager.index_templates');
         $this->assertInstanceOf(ConfigManager::class, $instance);
 
-        $instance = self::$container->get('fos_elastica.index_template_manager');
+        $instance = $this->getContainerBC()->get('fos_elastica.index_template_manager');
         $this->assertInstanceOf(IndexTemplateManager::class, $instance);
 
-        $instance = self::$container->get('fos_elastica.template_resetter');
+        $instance = $this->getContainerBC()->get('fos_elastica.template_resetter');
         $this->assertInstanceOf(TemplateResetter::class, $instance);
     }
 }

--- a/tests/Functional/IndexableCallbackTest.php
+++ b/tests/Functional/IndexableCallbackTest.php
@@ -32,7 +32,7 @@ class IndexableCallbackTest extends WebTestCase
         self::bootKernel(['test_case' => 'ORM']);
 
         /** @var Indexable $in */
-        $in = $this->getContainerBC()->get('test_alias.fos_elastica.indexable');
+        $in = self::getContainer()->get('test_alias.fos_elastica.indexable');
 
         $this->assertTrue($in->isObjectIndexable('index', new TypeObj()));
         $this->assertTrue($in->isObjectIndexable('third_index', new TypeObj()));

--- a/tests/Functional/IndexableCallbackTest.php
+++ b/tests/Functional/IndexableCallbackTest.php
@@ -32,7 +32,7 @@ class IndexableCallbackTest extends WebTestCase
         self::bootKernel(['test_case' => 'ORM']);
 
         /** @var Indexable $in */
-        $in = self::$container->get('test_alias.fos_elastica.indexable');
+        $in = $this->getContainerBC()->get('test_alias.fos_elastica.indexable');
 
         $this->assertTrue($in->isObjectIndexable('index', new TypeObj()));
         $this->assertTrue($in->isObjectIndexable('third_index', new TypeObj()));

--- a/tests/Functional/MappingToElasticaTest.php
+++ b/tests/Functional/MappingToElasticaTest.php
@@ -60,7 +60,7 @@ class MappingToElasticaTest extends WebTestCase
     {
         self::bootKernel(['test_case' => 'ORM']);
         /** @var ObjectPersisterInterface $persister */
-        $persister = $this->getContainerBC()->get('fos_elastica.object_persister.index');
+        $persister = self::getContainer()->get('fos_elastica.object_persister.index');
 
         $object = new TypeObj();
         $object->id = 1;
@@ -75,11 +75,11 @@ class MappingToElasticaTest extends WebTestCase
 
     private function getResetter(): ResetterInterface
     {
-        return $this->getContainerBC()->get('fos_elastica.resetter');
+        return self::getContainer()->get('fos_elastica.resetter');
     }
 
     private function getIndex(string $name = 'index'): Index
     {
-        return $this->getContainerBC()->get('fos_elastica.index.'.$name);
+        return self::getContainer()->get('fos_elastica.index.'.$name);
     }
 }

--- a/tests/Functional/MappingToElasticaTest.php
+++ b/tests/Functional/MappingToElasticaTest.php
@@ -60,7 +60,7 @@ class MappingToElasticaTest extends WebTestCase
     {
         self::bootKernel(['test_case' => 'ORM']);
         /** @var ObjectPersisterInterface $persister */
-        $persister = self::$container->get('fos_elastica.object_persister.index');
+        $persister = $this->getContainerBC()->get('fos_elastica.object_persister.index');
 
         $object = new TypeObj();
         $object->id = 1;
@@ -75,11 +75,11 @@ class MappingToElasticaTest extends WebTestCase
 
     private function getResetter(): ResetterInterface
     {
-        return self::$container->get('fos_elastica.resetter');
+        return $this->getContainerBC()->get('fos_elastica.resetter');
     }
 
     private function getIndex(string $name = 'index'): Index
     {
-        return self::$container->get('fos_elastica.index.'.$name);
+        return $this->getContainerBC()->get('fos_elastica.index.'.$name);
     }
 }

--- a/tests/Functional/PersistenceRepositoryTest.php
+++ b/tests/Functional/PersistenceRepositoryTest.php
@@ -20,7 +20,7 @@ class PersistenceRepositoryTest extends WebTestCase
     {
         self::bootKernel(['test_case' => 'ORM']);
 
-        $repository = $this->getContainerBC()->get('test_alias.fos_elastica.manager.orm')
+        $repository = self::getContainer()->get('test_alias.fos_elastica.manager.orm')
             ->getRepository(TypeObject::class)
         ;
 

--- a/tests/Functional/PersistenceRepositoryTest.php
+++ b/tests/Functional/PersistenceRepositoryTest.php
@@ -20,7 +20,7 @@ class PersistenceRepositoryTest extends WebTestCase
     {
         self::bootKernel(['test_case' => 'ORM']);
 
-        $repository = self::$container->get('test_alias.fos_elastica.manager.orm')
+        $repository = $this->getContainerBC()->get('test_alias.fos_elastica.manager.orm')
             ->getRepository(TypeObject::class)
         ;
 

--- a/tests/Functional/PropertyPathTest.php
+++ b/tests/Functional/PropertyPathTest.php
@@ -26,13 +26,13 @@ class PropertyPathTest extends WebTestCase
     {
         self::bootKernel(['test_case' => 'ORM']);
         /** @var ObjectPersisterInterface $persister */
-        $persister = $this->getContainerBC()->get('fos_elastica.object_persister.property_paths_index');
+        $persister = self::getContainer()->get('fos_elastica.object_persister.property_paths_index');
         $obj = new TypeObj();
         $obj->coll = 'Hello';
         $persister->insertOne($obj);
 
         /** @var Index $index */
-        $index = $this->getContainerBC()->get('fos_elastica.index.index');
+        $index = self::getContainer()->get('fos_elastica.index.index');
         $index->refresh();
 
         $query = new MatchQuery();

--- a/tests/Functional/PropertyPathTest.php
+++ b/tests/Functional/PropertyPathTest.php
@@ -26,13 +26,13 @@ class PropertyPathTest extends WebTestCase
     {
         self::bootKernel(['test_case' => 'ORM']);
         /** @var ObjectPersisterInterface $persister */
-        $persister = self::$container->get('fos_elastica.object_persister.property_paths_index');
+        $persister = $this->getContainerBC()->get('fos_elastica.object_persister.property_paths_index');
         $obj = new TypeObj();
         $obj->coll = 'Hello';
         $persister->insertOne($obj);
 
         /** @var Index $index */
-        $index = self::$container->get('fos_elastica.index.index');
+        $index = $this->getContainerBC()->get('fos_elastica.index.index');
         $index->refresh();
 
         $query = new MatchQuery();

--- a/tests/Functional/ResetTemplatesCommandTest.php
+++ b/tests/Functional/ResetTemplatesCommandTest.php
@@ -44,7 +44,7 @@ class ResetTemplatesCommandTest extends WebTestCase
         // required for old supported Symfony
         $application->all();
 
-        $this->client = self::$container->get('fos_elastica.client');
+        $this->client = $this->getContainerBC()->get('fos_elastica.client');
     }
 
     public function testResetAllTemplates()

--- a/tests/Functional/ResetTemplatesCommandTest.php
+++ b/tests/Functional/ResetTemplatesCommandTest.php
@@ -44,7 +44,7 @@ class ResetTemplatesCommandTest extends WebTestCase
         // required for old supported Symfony
         $application->all();
 
-        $this->client = $this->getContainerBC()->get('fos_elastica.client');
+        $this->client = self::getContainer()->get('fos_elastica.client');
     }
 
     public function testResetAllTemplates()

--- a/tests/Functional/SerializerTest.php
+++ b/tests/Functional/SerializerTest.php
@@ -21,7 +21,7 @@ class SerializerTest extends WebTestCase
     public function testMappingIteratorToArrayField()
     {
         static::bootKernel(['test_case' => 'Serializer']);
-        $persister = static::$container->get('fos_elastica.object_persister.index');
+        $persister = $this->getContainerBC()->get('fos_elastica.object_persister.index');
 
         $object = new TypeObj();
         $object->id = 1;
@@ -41,8 +41,8 @@ class SerializerTest extends WebTestCase
     {
         static::bootKernel(['test_case' => 'Serializer']);
 
-        $disabledNullPersister = static::$container->get('fos_elastica.object_persister.index_serialize_null_disabled');
-        $enabledNullPersister = static::$container->get('fos_elastica.object_persister.index_serialize_null_enabled');
+        $disabledNullPersister = $this->getContainerBC()->get('fos_elastica.object_persister.index_serialize_null_disabled');
+        $enabledNullPersister = $this->getContainerBC()->get('fos_elastica.object_persister.index_serialize_null_enabled');
 
         $object = new TypeObj();
         $object->id = 1;
@@ -51,12 +51,12 @@ class SerializerTest extends WebTestCase
         $enabledNullPersister->insertOne($object);
 
         // Tests that attributes with null values are not persisted into an Elasticsearch type without the serialize_null option
-        $disabledNullType = static::$container->get('fos_elastica.index.index_serialize_null_disabled');
+        $disabledNullType = $this->getContainerBC()->get('fos_elastica.index.index_serialize_null_disabled');
         $documentData = $disabledNullType->getDocument(1)->getData();
         $this->assertArrayNotHasKey('field1', $documentData);
 
         // Tests that attributes with null values are persisted into an Elasticsearch type with the serialize_null option
-        $enabledNullType = static::$container->get('fos_elastica.index.index_serialize_null_enabled');
+        $enabledNullType = $this->getContainerBC()->get('fos_elastica.index.index_serialize_null_enabled');
         $documentData = $enabledNullType->getDocument(1)->getData();
         $this->assertArrayHasKey('field1', $documentData);
         $this->assertNull($documentData['field1']);
@@ -65,7 +65,7 @@ class SerializerTest extends WebTestCase
     public function testUnmappedType()
     {
         static::bootKernel(['test_case' => 'Serializer']);
-        $resetter = static::$container->get('fos_elastica.resetter');
+        $resetter = $this->getContainerBC()->get('fos_elastica.resetter');
         $resetter->resetIndex('index');
     }
 }

--- a/tests/Functional/SerializerTest.php
+++ b/tests/Functional/SerializerTest.php
@@ -21,7 +21,7 @@ class SerializerTest extends WebTestCase
     public function testMappingIteratorToArrayField()
     {
         static::bootKernel(['test_case' => 'Serializer']);
-        $persister = $this->getContainerBC()->get('fos_elastica.object_persister.index');
+        $persister = self::getContainer()->get('fos_elastica.object_persister.index');
 
         $object = new TypeObj();
         $object->id = 1;
@@ -41,8 +41,8 @@ class SerializerTest extends WebTestCase
     {
         static::bootKernel(['test_case' => 'Serializer']);
 
-        $disabledNullPersister = $this->getContainerBC()->get('fos_elastica.object_persister.index_serialize_null_disabled');
-        $enabledNullPersister = $this->getContainerBC()->get('fos_elastica.object_persister.index_serialize_null_enabled');
+        $disabledNullPersister = self::getContainer()->get('fos_elastica.object_persister.index_serialize_null_disabled');
+        $enabledNullPersister = self::getContainer()->get('fos_elastica.object_persister.index_serialize_null_enabled');
 
         $object = new TypeObj();
         $object->id = 1;
@@ -51,12 +51,12 @@ class SerializerTest extends WebTestCase
         $enabledNullPersister->insertOne($object);
 
         // Tests that attributes with null values are not persisted into an Elasticsearch type without the serialize_null option
-        $disabledNullType = $this->getContainerBC()->get('fos_elastica.index.index_serialize_null_disabled');
+        $disabledNullType = self::getContainer()->get('fos_elastica.index.index_serialize_null_disabled');
         $documentData = $disabledNullType->getDocument(1)->getData();
         $this->assertArrayNotHasKey('field1', $documentData);
 
         // Tests that attributes with null values are persisted into an Elasticsearch type with the serialize_null option
-        $enabledNullType = $this->getContainerBC()->get('fos_elastica.index.index_serialize_null_enabled');
+        $enabledNullType = self::getContainer()->get('fos_elastica.index.index_serialize_null_enabled');
         $documentData = $enabledNullType->getDocument(1)->getData();
         $this->assertArrayHasKey('field1', $documentData);
         $this->assertNull($documentData['field1']);
@@ -65,7 +65,7 @@ class SerializerTest extends WebTestCase
     public function testUnmappedType()
     {
         static::bootKernel(['test_case' => 'Serializer']);
-        $resetter = $this->getContainerBC()->get('fos_elastica.resetter');
+        $resetter = self::getContainer()->get('fos_elastica.resetter');
         $resetter->resetIndex('index');
     }
 }

--- a/tests/Functional/WebTestCase.php
+++ b/tests/Functional/WebTestCase.php
@@ -13,7 +13,9 @@ namespace FOS\ElasticaBundle\Tests\Functional;
 
 use FOS\ElasticaBundle\Tests\Functional\app\AppKernel;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase as BaseKernelTestCase;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\HttpKernel\KernelInterface;
 
 /*
  * Based on https://github.com/symfony/symfony/blob/2.7/src/Symfony/Bundle/FrameworkBundle/Tests/Functional/WebTestCase.php
@@ -33,7 +35,7 @@ class WebTestCase extends BaseKernelTestCase
         static::deleteTmpDir();
     }
 
-    protected static function getKernelClass()
+    protected static function getKernelClass(): string
     {
         require_once __DIR__.'/app/AppKernel.php';
 
@@ -49,7 +51,7 @@ class WebTestCase extends BaseKernelTestCase
         $fs->remove($dir);
     }
 
-    protected static function createKernel(array $options = [])
+    protected static function createKernel(array $options = []): KernelInterface
     {
         $class = self::getKernelClass();
 
@@ -69,5 +71,15 @@ class WebTestCase extends BaseKernelTestCase
     protected static function getVarDir()
     {
         return \substr(\strrchr(static::class, '\\'), 1);
+    }
+
+    // To be removed when dropping support of Symfony < 5.3 and use "self::getContainer()" instead.
+    protected function getContainerBC(): ContainerInterface
+    {
+        if (\method_exists($this, 'getContainer')) {
+            return self::getContainer();
+        }
+
+        return self::$container;
     }
 }

--- a/tests/Functional/WebTestCase.php
+++ b/tests/Functional/WebTestCase.php
@@ -13,7 +13,6 @@ namespace FOS\ElasticaBundle\Tests\Functional;
 
 use FOS\ElasticaBundle\Tests\Functional\app\AppKernel;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase as BaseKernelTestCase;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpKernel\KernelInterface;
 
@@ -73,13 +72,21 @@ class WebTestCase extends BaseKernelTestCase
         return \substr(\strrchr(static::class, '\\'), 1);
     }
 
-    // To be removed when dropping support of Symfony < 5.3 and use "self::getContainer()" instead.
-    protected function getContainerBC(): ContainerInterface
+    /**
+     * To be removed when dropping support of Symfony < 5.3.
+     *
+     * @param mixed $arguments
+     */
+    public static function __callStatic(string $name, $arguments)
     {
-        if (\method_exists($this, 'getContainer')) {
-            return self::getContainer();
+        if ('getContainer' === $name) {
+            if (\method_exists(BaseKernelTestCase::class, $name)) {
+                return self::getContainer();
+            }
+
+            return self::$container;
         }
 
-        return self::$container;
+        throw new \BadMethodCallException("Method {$name} is not supported.");
     }
 }

--- a/tests/Functional/app/AppKernel.php
+++ b/tests/Functional/app/AppKernel.php
@@ -44,7 +44,7 @@ class AppKernel extends Kernel
         parent::__construct($environment, $debug);
     }
 
-    public function registerBundles()
+    public function registerBundles(): iterable
     {
         if (!\file_exists($filename = $this->getProjectDir().'/'.$this->testCase.'/bundles.php')) {
             throw new \RuntimeException(\sprintf('The bundles file "%s" does not exist.', $filename));
@@ -53,22 +53,22 @@ class AppKernel extends Kernel
         return include $filename;
     }
 
-    public function getProjectDir()
+    public function getProjectDir(): string
     {
         return __DIR__;
     }
 
-    public function getCacheDir()
+    public function getCacheDir(): string
     {
         return \sys_get_temp_dir().'/'.$this->varDir.'/'.$this->testCase.'/cache/'.$this->environment;
     }
 
-    public function getLogDir()
+    public function getLogDir(): string
     {
         return \sys_get_temp_dir().'/'.$this->varDir.'/'.$this->testCase.'/logs';
     }
 
-    public function registerContainerConfiguration(LoaderInterface $loader)
+    public function registerContainerConfiguration(LoaderInterface $loader): void
     {
         $loader->load(function (ContainerBuilder $container) {
             $container->setParameter('fos_elastica.host', $_SERVER['FOS_ELASTICA_HOST']);
@@ -77,7 +77,7 @@ class AppKernel extends Kernel
         $loader->load($this->rootConfig);
     }
 
-    protected function getKernelParameters()
+    protected function getKernelParameters(): array
     {
         $parameters = parent::getKernelParameters();
         $parameters['kernel.test_case'] = $this->testCase;

--- a/tests/Unit/Doctrine/AbstractListenerTest.php
+++ b/tests/Unit/Doctrine/AbstractListenerTest.php
@@ -40,7 +40,7 @@ class Entity
  *
  * @author Richard Miller <info@limethinking.co.uk>
  */
-abstract class ListenerTest extends TestCase
+abstract class AbstractListenerTest extends TestCase
 {
     public function testObjectInsertedOnPersist()
     {

--- a/tests/Unit/Doctrine/MongoDB/ListenerTest.php
+++ b/tests/Unit/Doctrine/MongoDB/ListenerTest.php
@@ -11,12 +11,12 @@
 
 namespace FOS\ElasticaBundle\Tests\Unit\Doctrine\MongoDB;
 
-use FOS\ElasticaBundle\Tests\Unit\Doctrine\ListenerTest as BaseListenerTest;
+use FOS\ElasticaBundle\Tests\Unit\Doctrine\AbstractListenerTest;
 
 /**
  * @internal
  */
-class ListenerTest extends BaseListenerTest
+class ListenerTest extends AbstractListenerTest
 {
     protected function setUp(): void
     {

--- a/tests/Unit/Doctrine/ORM/ListenerTest.php
+++ b/tests/Unit/Doctrine/ORM/ListenerTest.php
@@ -11,12 +11,12 @@
 
 namespace FOS\ElasticaBundle\Tests\Unit\Doctrine\ORM;
 
-use FOS\ElasticaBundle\Tests\Unit\Doctrine\ListenerTest as BaseListenerTest;
+use FOS\ElasticaBundle\Tests\Unit\Doctrine\AbstractListenerTest;
 
 /**
  * @internal
  */
-class ListenerTest extends BaseListenerTest
+class ListenerTest extends AbstractListenerTest
 {
     protected function getClassMetadataClass()
     {

--- a/tests/Unit/Doctrine/PHPCR/ListenerTest.php
+++ b/tests/Unit/Doctrine/PHPCR/ListenerTest.php
@@ -11,12 +11,12 @@
 
 namespace FOS\ElasticaBundle\Tests\Unit\Doctrine\PHPCR;
 
-use FOS\ElasticaBundle\Tests\Unit\Doctrine\ListenerTest as BaseListenerTest;
+use FOS\ElasticaBundle\Tests\Unit\Doctrine\AbstractListenerTest;
 
 /**
  * @internal
  */
-class ListenerTest extends BaseListenerTest
+class ListenerTest extends AbstractListenerTest
 {
     protected function setUp(): void
     {


### PR DESCRIPTION
supersedes https://github.com/FriendsOfSymfony/FOSElasticaBundle/pull/1840

This PR adds a CI job to test with Symfony 6, ~the `ConfigSourcePassTest` has been changed because there was a problem with `replaceArgument` not returning anything and I decided to change it to use an actual `ContainerBuilder`.~ (solved in https://github.com/FriendsOfSymfony/FOSElasticaBundle/pull/1845)