### PR TITLE
Remove prophecy

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,6 @@
         "pagerfanta/doctrine-mongodb-odm-adapter": "^2.4 || ^3.0",
         "pagerfanta/doctrine-orm-adapter": "^2.4 || ^3.0",
         "pagerfanta/doctrine-phpcr-odm-adapter": "^2.4 || ^3.0",
-        "phpspec/prophecy-phpunit": "^1.1 || ^2.0",
         "phpunit/phpunit": "^8.5 || ^9.3",
         "symfony/expression-language": "^4.4 || ^5.3",
         "symfony/messenger": "^4.4 || ^5.3",

--- a/composer.json
+++ b/composer.json
@@ -53,7 +53,7 @@
         "pagerfanta/doctrine-mongodb-odm-adapter": "^2.4 || ^3.0",
         "pagerfanta/doctrine-orm-adapter": "^2.4 || ^3.0",
         "pagerfanta/doctrine-phpcr-odm-adapter": "^2.4 || ^3.0",
-        "phpunit/phpunit": "^8.5 || ^9.3",
+        "phpunit/phpunit": "^9.5",
         "symfony/expression-language": "^4.4 || ^5.3",
         "symfony/messenger": "^4.4 || ^5.3",
         "symfony/serializer": "^4.4 || ^5.3",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,7 +2,7 @@
 
 <phpunit
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/6.5/phpunit.xsd"
+        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.5/phpunit.xsd"
         colors                                     = "true"
         beStrictAboutOutputDuringTests             = "true"
         beStrictAboutTestsThatDoNotTestAnything    = "false"
@@ -21,12 +21,12 @@
         </testsuite>
     </testsuites>
 
-    <filter>
-        <whitelist>
+    <coverage>
+        <include>
             <directory>./src</directory>
-            <exclude>
-                <directory>./src/Resources</directory>
-            </exclude>
-        </whitelist>
-    </filter>
+        </include>
+        <exclude>
+            <directory>./src/Resources</directory>
+        </exclude>
+    </coverage>
 </phpunit>

--- a/src/Persister/AsyncPagerPersister.php
+++ b/src/Persister/AsyncPagerPersister.php
@@ -88,7 +88,7 @@ final class AsyncPagerPersister implements PagerPersisterInterface
         $pager->setCurrentPage($options['first_page']);
 
         $results = $pager->getCurrentPageResults();
-        $objectCount = $results instanceof \Traversable ? \iterator_count($results): \count($results);
+        $objectCount = $results instanceof \Traversable ? \iterator_count($results) : \count($results);
 
         $pagerPersister = $this->pagerPersisterRegistry->getPagerPersister(InPlacePagerPersister::NAME);
         $pagerPersister->insert($pager, $options);

--- a/tests/Unit/DependencyInjection/ConfigSourcePassTest.php
+++ b/tests/Unit/DependencyInjection/ConfigSourcePassTest.php
@@ -11,100 +11,74 @@
 
 namespace FOS\ElasticaBundle\Tests\Unit\DependencyInjection;
 
+use FOS\ElasticaBundle\Configuration\ConfigManager;
+use FOS\ElasticaBundle\Configuration\Source\ContainerSource;
 use FOS\ElasticaBundle\DependencyInjection\Compiler\ConfigSourcePass;
-use FOS\ElasticaBundle\Tests\Unit\ProphecyTrait;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
 
 /**
  * @internal
  */
 class ConfigSourcePassTest extends TestCase
 {
-    use ProphecyTrait;
-
     /** @var ContainerBuilder */
     private $container;
 
     protected function setUp(): void
     {
-        $this->container = $this->prophesize(ContainerBuilder::class);
+        $this->container = new ContainerBuilder();
     }
 
     public function testProcessWithoutConfigManager()
     {
-        $this->container
-            ->hasDefinition('fos_elastica.config_manager')
-            ->shouldBeCalled()
-            ->willReturn(false)
-        ;
+        $configManagerDefinition = new Definition(ConfigManager::class);
+        $configManagerDefinition->addArgument([]);
+        $this->container->setDefinition('fos_elastica.config_manager', $configManagerDefinition);
+
+        $configManagerIndexTemplatesDefinition = new Definition(ConfigManager::class);
+        $configManagerIndexTemplatesDefinition->addArgument([]);
+        $this->container->setDefinition('fos_elastica.config_manager.index_templates', $configManagerIndexTemplatesDefinition);
 
         $pass = new ConfigSourcePass();
-        $pass->process($this->container->reveal());
+        $pass->process($this->container);
 
-        $this->container->getDefinition('fos_elastica.config_manager')->shouldNotBeCalled();
-        $this->container->getDefinition('fos_elastica.config_manager.index_templates')->shouldNotBeCalled();
+        $this->assertSame([], $this->container->getDefinition('fos_elastica.config_manager')->getArgument(0));
+        $this->assertSame([], $this->container->getDefinition('fos_elastica.config_manager.index_templates')->getArgument(0));
     }
 
     public function testProcessWithConfigManager()
     {
-        $this->container
-            ->hasDefinition('fos_elastica.config_manager')
-            ->shouldBeCalled()
-            ->willReturn(true)
-        ;
+        $configManagerDefinition = new Definition(ConfigManager::class);
+        $configManagerDefinition->addArgument([]);
+        $this->container->setDefinition('fos_elastica.config_manager', $configManagerDefinition);
 
-        $this->container
-            ->findTaggedServiceIds('fos_elastica.config_source')
-            ->shouldBeCalled()
-            ->willReturn(
-                [
-                    'index_definition_id' => null,
-                    'index_template_definition_id' => null,
-                ]
-            )
-        ;
+        $configManagerIndexTemplatesDefinition = new Definition(ConfigManager::class);
+        $configManagerIndexTemplatesDefinition->addArgument([]);
+        $this->container->setDefinition('fos_elastica.config_manager.index_templates', $configManagerIndexTemplatesDefinition);
 
-        $indexDefinition = $this->prophesize(Definition::class);
-        $indexDefinition->getTag('fos_elastica.config_source')
-            ->shouldBeCalled()
-            ->willReturn([])
-        ;
-        $this->container
-            ->findDefinition('index_definition_id')
-            ->shouldBeCalled()
-            ->willReturn($indexDefinition->reveal())
-        ;
+        $indexDefinition = new Definition(ContainerSource::class);
+        $indexDefinition->addTag('fos_elastica.config_source');
 
-        $indexTemplateDefinition = $this->prophesize(Definition::class);
-        $indexTemplateDefinition->getTag('fos_elastica.config_source')
-            ->shouldBeCalled()
-            ->willReturn([])
-        ;
-        $this->container
-            ->findDefinition('index_template_definition_id')
-            ->shouldBeCalled()
-            ->willReturn($indexTemplateDefinition->reveal())
-        ;
+        $this->container->setDefinition('index_definition_id', $indexDefinition);
 
-        $configManagerDefinition = $this->prophesize(Definition::class);
-        $configManagerDefinition->replaceArgument(0, ['index_definition_id']);
-        $this->container
-            ->getDefinition('fos_elastica.config_manager')
-            ->shouldBeCalled()
-            ->willReturn($configManagerDefinition)
-        ;
+        $indexTemplateDefinition = new Definition(ContainerSource::class);
+        $indexTemplateDefinition->addTag('fos_elastica.config_source');
 
-        $templateConfigManagerDefinition = $this->prophesize(Definition::class);
-        $templateConfigManagerDefinition->replaceArgument(0, ['index_template_definition_id']);
-        $this->container
-            ->getDefinition('fos_elastica.config_manager.index_templates')
-            ->shouldBeCalled()
-            ->willReturn($templateConfigManagerDefinition)
-        ;
+        $this->container->setDefinition('index_template_definition_id', $indexTemplateDefinition);
 
         $pass = new ConfigSourcePass();
-        $pass->process($this->container->reveal());
+        $pass->process($this->container);
+
+        $argument = $configManagerDefinition->getArgument(0);
+
+        $this->assertIsArray($argument);
+        $this->assertCount(2, $argument);
+        $this->assertInstanceOf(Reference::class, $argument[0]);
+        $this->assertSame('index_definition_id', $argument[0]->__toString());
+        $this->assertInstanceOf(Reference::class, $argument[1]);
+        $this->assertSame('index_template_definition_id', $argument[1]->__toString());
     }
 }

--- a/tests/Unit/Elastica/IndexTemplateTest.php
+++ b/tests/Unit/Elastica/IndexTemplateTest.php
@@ -14,7 +14,6 @@ namespace FOS\ElasticaBundle\Tests\Unit\Elastica;
 use Elastica\Client;
 use Elastica\IndexTemplate as BaseIndexTemplate;
 use FOS\ElasticaBundle\Elastica\IndexTemplate;
-use FOS\ElasticaBundle\Tests\Unit\ProphecyTrait;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -24,11 +23,9 @@ use PHPUnit\Framework\TestCase;
  */
 class IndexTemplateTest extends TestCase
 {
-    use ProphecyTrait;
-
     public function testInstantiate()
     {
-        $template = new IndexTemplate($this->prophesize(Client::class)->reveal(), 'some_name');
+        $template = new IndexTemplate($this->createStub(Client::class), 'some_name');
         $this->assertInstanceOf(BaseIndexTemplate::class, $template);
     }
 }

--- a/tests/Unit/Index/IndexTemplateManagerTest.php
+++ b/tests/Unit/Index/IndexTemplateManagerTest.php
@@ -13,7 +13,6 @@ namespace FOS\ElasticaBundle\Tests\Unit\Index;
 
 use Elastica\IndexTemplate;
 use FOS\ElasticaBundle\Index\IndexTemplateManager;
-use FOS\ElasticaBundle\Tests\Unit\ProphecyTrait;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -23,8 +22,6 @@ use PHPUnit\Framework\TestCase;
  */
 class IndexTemplateManagerTest extends TestCase
 {
-    use ProphecyTrait;
-
     /**
      * Test get index template.
      *
@@ -56,16 +53,16 @@ class IndexTemplateManagerTest extends TestCase
             ],
             'expected template found' => [
                 'templates' => [
-                    'first template' => $firstTemplate = $this->prophesize(IndexTemplate::class)->reveal(),
-                    'second template' => $secondTemplate = $this->prophesize(IndexTemplate::class)->reveal(),
+                    'first template' => $firstTemplate = $this->createStub(IndexTemplate::class),
+                    'second template' => $secondTemplate = $this->createStub(IndexTemplate::class),
                 ],
                 'name' => 'second template',
                 'expectedTemplate' => $secondTemplate,
             ],
             'expected template not found' => [
                 'templates' => [
-                    'first template' => $firstTemplate = $this->prophesize(IndexTemplate::class)->reveal(),
-                    'second template' => $secondTemplate = $this->prophesize(IndexTemplate::class)->reveal(),
+                    'first template' => $firstTemplate = $this->createStub(IndexTemplate::class),
+                    'second template' => $secondTemplate = $this->createStub(IndexTemplate::class),
                 ],
                 'name' => 'some template',
                 'expectedTemplate' => null,

--- a/tests/Unit/Index/TemplateResetterTest.php
+++ b/tests/Unit/Index/TemplateResetterTest.php
@@ -20,9 +20,8 @@ use FOS\ElasticaBundle\Index\IndexTemplateManager;
 use FOS\ElasticaBundle\Index\MappingBuilder;
 use FOS\ElasticaBundle\Index\ResetterInterface;
 use FOS\ElasticaBundle\Index\TemplateResetter;
-use FOS\ElasticaBundle\Tests\Unit\ProphecyTrait;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Prophecy\Argument;
 
 /**
  * @author Dmitry Balabka <dmitry.balabka@intexsys.lv>
@@ -31,25 +30,23 @@ use Prophecy\Argument;
  */
 class TemplateResetterTest extends TestCase
 {
-    use ProphecyTrait;
-
     /**
-     * @var ManagerInterface
+     * @var ManagerInterface&MockObject
      */
     private $configManager;
 
     /**
-     * @var MappingBuilder
+     * @var MappingBuilder&MockObject
      */
     private $mappingBuilder;
 
     /**
-     * @var Client
+     * @var Client&MockObject
      */
     private $client;
 
     /**
-     * @var IndexTemplateManager
+     * @var IndexTemplateManager&MockObject
      */
     private $templateManager;
 
@@ -60,15 +57,15 @@ class TemplateResetterTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->configManager = $this->prophesize(ManagerInterface::class);
-        $this->mappingBuilder = $this->prophesize(MappingBuilder::class);
-        $this->client = $this->prophesize(Client::class);
-        $this->templateManager = $this->prophesize(IndexTemplateManager::class);
+        $this->configManager = $this->createMock(ManagerInterface::class);
+        $this->mappingBuilder = $this->createMock(MappingBuilder::class);
+        $this->client = $this->createMock(Client::class);
+        $this->templateManager = $this->createMock(IndexTemplateManager::class);
         $this->resetter = new TemplateResetter(
-            $this->configManager->reveal(),
-            $this->mappingBuilder->reveal(),
-            $this->client->reveal(),
-            $this->templateManager->reveal()
+            $this->configManager,
+            $this->mappingBuilder,
+            $this->client,
+            $this->templateManager
         );
     }
 
@@ -82,26 +79,37 @@ class TemplateResetterTest extends TestCase
         // assemble
         $names = ['first_template'];
         $mapping = ['properties' => []];
-        $this->configManager->getIndexNames()
+        $this->configManager
+            ->method('getIndexNames')
             ->willReturn($names)
         ;
-        $this->configManager->getIndexConfiguration('first_template')
-            ->willReturn($indexTemplateConfig = $this->prophesize(IndexTemplateConfig::class)->reveal())
+        $this->configManager
+            ->method('getIndexConfiguration')
+            ->with('first_template')
+            ->willReturn($indexTemplateConfig = $this->createStub(IndexTemplateConfig::class))
         ;
-        $indexTemplate = $this->prophesize(IndexTemplate::class);
-        $this->templateManager->getIndexTemplate('first_template')
-            ->willReturn($indexTemplate->reveal())
+        $indexTemplate = $this->createMock(IndexTemplate::class);
+        $this->templateManager
+            ->method('getIndexTemplate')
+            ->with('first_template')
+            ->willReturn($indexTemplate)
         ;
-        $this->mappingBuilder->buildIndexTemplateMapping($indexTemplateConfig)
+        $this->mappingBuilder
+            ->method('buildIndexTemplateMapping')
+            ->with($indexTemplateConfig)
             ->willReturn($mapping)
         ;
 
         // assert
-        $indexTemplate->create($mapping)
-            ->shouldBeCalled()
+        $indexTemplate
+            ->expects($this->once())
+            ->method('create')
+            ->with($mapping)
         ;
-        $this->client->request(Argument::any(), Request::DELETE)
-            ->shouldNotBeCalled()
+        $this->client
+            ->expects($this->never())
+            ->method('request')
+            ->with($this->any(), Request::DELETE)
         ;
 
         // act
@@ -113,30 +121,42 @@ class TemplateResetterTest extends TestCase
         // assemble
         $names = ['first_template'];
         $mapping = ['properties' => []];
-        $this->configManager->getIndexNames()
+        $this->configManager
+            ->method('getIndexNames')
             ->willReturn($names)
         ;
-        $indexTemplateConfig = $this->prophesize(IndexTemplateConfig::class);
-        $this->configManager->getIndexConfiguration('first_template')
-            ->willReturn($indexTemplateConfig->reveal())
+        $indexTemplateConfig = $this->createMock(IndexTemplateConfig::class);
+        $this->configManager
+            ->method('getIndexConfiguration')
+            ->with('first_template')
+            ->willReturn($indexTemplateConfig)
         ;
-        $indexTemplate = $this->prophesize(IndexTemplate::class);
-        $this->templateManager->getIndexTemplate('first_template')
-            ->willReturn($indexTemplate->reveal())
+        $indexTemplate = $this->createMock(IndexTemplate::class);
+        $this->templateManager
+            ->method('getIndexTemplate')
+            ->with('first_template')
+            ->willReturn($indexTemplate)
         ;
-        $this->mappingBuilder->buildIndexTemplateMapping($indexTemplateConfig)
+        $this->mappingBuilder
+            ->method('buildIndexTemplateMapping')
+            ->with($indexTemplateConfig)
             ->willReturn($mapping)
         ;
 
         // assert
-        $indexTemplate->create($mapping)
-            ->shouldBeCalled()
+        $indexTemplate
+            ->expects($this->once())
+            ->method('create')
+            ->with($mapping)
         ;
-        $this->client->request('first_template/', Request::DELETE)
-            ->shouldBeCalled()
+        $this->client
+            ->expects($this->once())
+            ->method('request')
+            ->with('first_template/', Request::DELETE)
         ;
-        $indexTemplateConfig->getTemplate()
-            ->shouldBeCalled()
+        $indexTemplateConfig
+            ->expects($this->once())
+            ->method('getTemplate')
             ->willReturn('first_template')
         ;
 
@@ -149,23 +169,33 @@ class TemplateResetterTest extends TestCase
         // assemble
         $name = 'first_template';
         $mapping = ['properties' => []];
-        $this->configManager->getIndexConfiguration('first_template')
-            ->willReturn($indexTemplateConfig = $this->prophesize(IndexTemplateConfig::class)->reveal())
+        $this->configManager
+            ->method('getIndexConfiguration')
+            ->with('first_template')
+            ->willReturn($indexTemplateConfig = $this->createStub(IndexTemplateConfig::class))
         ;
-        $indexTemplate = $this->prophesize(IndexTemplate::class);
-        $this->templateManager->getIndexTemplate('first_template')
-            ->willReturn($indexTemplate->reveal())
+        $indexTemplate = $this->createMock(IndexTemplate::class);
+        $this->templateManager
+            ->method('getIndexTemplate')
+            ->with('first_template')
+            ->willReturn($indexTemplate)
         ;
-        $this->mappingBuilder->buildIndexTemplateMapping($indexTemplateConfig)
+        $this->mappingBuilder
+            ->method('buildIndexTemplateMapping')
+            ->with($indexTemplateConfig)
             ->willReturn($mapping)
         ;
 
         // assert
-        $indexTemplate->create($mapping)
-            ->shouldBeCalled()
+        $indexTemplate
+            ->expects($this->once())
+            ->method('create')
+            ->with($mapping)
         ;
-        $this->client->request(Argument::any(), Request::DELETE)
-            ->shouldNotBeCalled()
+        $this->client
+            ->expects($this->never())
+            ->method('request')
+            ->with($this->any(), Request::DELETE)
         ;
 
         // act
@@ -177,27 +207,38 @@ class TemplateResetterTest extends TestCase
         // assemble
         $name = 'first_template';
         $mapping = ['properties' => []];
-        $indexTemplateConfig = $this->prophesize(IndexTemplateConfig::class);
-        $this->configManager->getIndexConfiguration('first_template')
-            ->willReturn($indexTemplateConfig->reveal())
+        $indexTemplateConfig = $this->createMock(IndexTemplateConfig::class);
+        $this->configManager
+            ->method('getIndexConfiguration')
+            ->with('first_template')
+            ->willReturn($indexTemplateConfig)
         ;
-        $indexTemplate = $this->prophesize(IndexTemplate::class);
-        $this->templateManager->getIndexTemplate('first_template')
-            ->willReturn($indexTemplate->reveal())
+        $indexTemplate = $this->createMock(IndexTemplate::class);
+        $this->templateManager
+            ->method('getIndexTemplate')
+            ->with('first_template')
+            ->willReturn($indexTemplate)
         ;
-        $this->mappingBuilder->buildIndexTemplateMapping($indexTemplateConfig)
+        $this->mappingBuilder
+            ->method('buildIndexTemplateMapping')
+            ->with($indexTemplateConfig)
             ->willReturn($mapping)
         ;
 
         // assert
-        $indexTemplate->create($mapping)
-            ->shouldBeCalled()
+        $indexTemplate
+            ->expects($this->once())
+            ->method('create')
+            ->with($mapping)
         ;
-        $this->client->request('first_template/', Request::DELETE)
-            ->shouldBeCalled()
+        $this->client
+            ->expects($this->once())
+            ->method('request')
+            ->with('first_template/', Request::DELETE)
         ;
-        $indexTemplateConfig->getTemplate()
-            ->shouldBeCalled()
+        $indexTemplateConfig
+            ->expects($this->once())
+            ->method('getTemplate')
             ->willReturn('first_template')
         ;
 
@@ -209,17 +250,21 @@ class TemplateResetterTest extends TestCase
     {
         // assemble
         $name = 'some_template';
-        $template = $this->prophesize(IndexTemplateConfig::class);
+        $template = $this->createMock(IndexTemplateConfig::class);
 
         // assert
-        $template->getTemplate()
-            ->shouldBeCalled()
+        $template
+            ->expects($this->once())
+            ->method('getTemplate')
             ->willReturn($name)
         ;
-        $this->client->request('some_template/', Request::DELETE)
-            ->shouldBeCalled()
+
+        $this->client
+            ->expects($this->once())
+            ->method('request')
+            ->with('some_template/', Request::DELETE)
         ;
 
-        $this->resetter->deleteTemplateIndexes($template->reveal());
+        $this->resetter->deleteTemplateIndexes($template);
     }
 }


### PR DESCRIPTION
While doing https://github.com/FriendsOfSymfony/FOSElasticaBundle/pull/1844 I've seen that it was only used in 3 files, so this PR replaces the use of prophecy and also bumps phpunit to 9.5 