### PR TITLE
Return null instead of [] for a null object in Elastica Document

### DIFF
--- a/src/Transformer/ModelToElasticaAutoTransformer.php
+++ b/src/Transformer/ModelToElasticaAutoTransformer.php
@@ -78,10 +78,8 @@ class ModelToElasticaAutoTransformer implements ModelToElasticaTransformerInterf
      *
      * @param array|\Traversable|\ArrayAccess $objects the object to convert
      * @param array                           $fields  the keys we want to have in the returned array
-     *
-     * @return array
      */
-    protected function transformNested($objects, array $fields)
+    protected function transformNested($objects, array $fields): ?array
     {
         if (\is_iterable($objects)) {
             $documents = [];
@@ -99,7 +97,7 @@ class ModelToElasticaAutoTransformer implements ModelToElasticaTransformerInterf
             return $document->getData();
         }
 
-        return [];
+        return null;
     }
 
     /**

--- a/tests/Unit/Transformer/ModelToElasticaAutoTransformerTest.php
+++ b/tests/Unit/Transformer/ModelToElasticaAutoTransformerTest.php
@@ -492,7 +492,7 @@ class ModelToElasticaAutoTransformerTest extends TestCase
         ]);
 
         $data = $document->getData();
-        $this->assertIsArray($data['nullValue']);
+        $this->assertNull($data['nullValue']);
         $this->assertEmpty($data['nullValue']);
     }
 


### PR DESCRIPTION
Hello, I don't know if this is a real problem or only my problem.
In fact, looking at the pieces of code below, the first is the current result and the second is the expected result and that I would rather have.
```php
{
  "childOf": [],
  "section": {
    "label": "section"
  },
  "nature": {
    "label": "nature"
  }
}
```
```php
{
  "childOf": null,
  "section": {
    "label": "section"
  },
  "nature": {
    "label": "nature"
  }
}
```
In my fos_elastica.yaml, my "childOf" property is declared as an object.
```yml
app_company:
    properties:
        childOf:
            type: object
            properties:
                id: ~
```

Except that I find that it is not very logical to recover an empty array instead of null for an object whose value is null in database.
What do you think of my proposition ?
Thanks