### PR TITLE
Allow install psr/log 2 and 3

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -30,29 +30,34 @@ jobs:
 
   phpunit:
     runs-on: 'ubuntu-20.04'
-    name: 'PHPUnit (PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony_require }}, ES ${{ matrix.elasticsearch }})'
+    name: 'PHPUnit (PHP ${{ matrix.php }}, Symfony ${{ matrix.symfony }} + ${{ matrix.dependencies }} deps, ES ${{ matrix.elasticsearch }})'
     timeout-minutes: 10
     env:
-      SYMFONY_REQUIRE: "${{ matrix.symfony_require }}"
+      SYMFONY_REQUIRE: "${{ matrix.symfony }}"
     strategy:
       matrix:
+        php:
+          - '7.4'
+          - '8.0'
+          - '8.1'
+        symfony:
+          - '4.4.*'
+          - '5.4.*'
+          - '6.0.*'
+        elasticsearch:
+          - '7.11.0'
+        dependencies:
+          - 'highest'
         include:
           - php: '7.4'
             elasticsearch: '7.0.0'
             dependencies: 'lowest'
-            symfony_require: '4.4.*'
+            symfony: '4.4.*'
+        exclude:
           - php: '7.4'
-            elasticsearch: '7.9.0'
+            symfony: '6.0.*'
             dependencies: 'highest'
-            symfony_require: '5.4.*'
-          - php: '8.0'
             elasticsearch: '7.11.0'
-            dependencies: 'highest'
-            symfony_require: '5.4.*'
-          - php: '8.1'
-            elasticsearch: '7.11.0'
-            dependencies: 'highest'
-            symfony_require: '6.0.*'
       fail-fast: false
     steps:
       - name: 'Checkout'

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     "require": {
         "php": "^7.4 || ^8.0",
         "pagerfanta/pagerfanta": "^2.4 || ^3.0",
-        "psr/log": "^1.0",
+        "psr/log": "^1.0 || ^2.0 || ^3.0",
         "ruflin/elastica": "^7.1",
         "symfony/console": "^4.4 || ^5.4 || ^6.0",
         "symfony/dependency-injection": "^4.4 || ^5.4 || ^6.0",


### PR DESCRIPTION
We implement it in https://github.com/FriendsOfSymfony/FOSElasticaBundle/blob/723c6649efadcbf3331daa91e4c5a6e89288d904/src/Logger/ElasticaLogger.php which [is already compatibly with version 2 and 3](https://github.com/php-fig/log/compare/2.0.0...3.0.0).

psr/log 3 cannot be installed because [`elasticsearch-php` doesn't support it yet](https://github.com/elastic/elasticsearch-php/blob/d7539aa7c414a92ee34ae95070da1bc5dd9d30c3/composer.json#L19).

I've also modified the job matrix to add more tests with different versions.