### PR TITLE
Describe $query param type with types accepted by Query::create()

### DIFF
--- a/src/Finder/FinderInterface.php
+++ b/src/Finder/FinderInterface.php
@@ -11,12 +11,25 @@
 
 namespace FOS\ElasticaBundle\Finder;
 
+use Elastica\Collapse;
+use Elastica\Query;
+use Elastica\Query\AbstractQuery;
+use Elastica\Suggest;
+use Elastica\Suggest\AbstractSuggest;
+
+/**
+ * @phpstan-type TQuery = Query|AbstractSuggest|AbstractQuery|Suggest|Collapse|array<string, mixed>|string
+ *
+ * @see \Elastica\Query::create()
+ */
 interface FinderInterface
 {
     /**
      * Searches for query results within a given limit.
      *
-     * @param mixed    $query Can be a string, an array or an \Elastica\Query object
+     * @param mixed $query Can be a string, an array or an \Elastica\Query object
+     * @phpstan-param TQuery $query
+     *
      * @param int|null $limit How many results to get
      *
      * @return array results

--- a/src/Finder/PaginatedFinderInterface.php
+++ b/src/Finder/PaginatedFinderInterface.php
@@ -15,7 +15,9 @@ use FOS\ElasticaBundle\Paginator\PaginatorAdapterInterface;
 use Pagerfanta\Pagerfanta;
 
 /**
- * @method Pagerfanta findHybridPaginated($query) Searches for query hybrid results.
+ * @method Pagerfanta findHybridPaginated(mixed $query) Searches for query hybrid results.
+ * @phpstan-method Pagerfanta findHybridPaginated(TQuery $query)
+ * @phpstan-import-type TQuery from FinderInterface
  */
 interface PaginatedFinderInterface extends FinderInterface
 {
@@ -23,6 +25,7 @@ interface PaginatedFinderInterface extends FinderInterface
      * Searches for query results and returns them wrapped in a paginator.
      *
      * @param mixed $query Can be a string, an array or an \Elastica\Query object
+     * @phpstan-param TQuery $query
      *
      * @return Pagerfanta paginated results
      */
@@ -32,6 +35,7 @@ interface PaginatedFinderInterface extends FinderInterface
      * Creates a paginator adapter for this query.
      *
      * @param mixed $query
+     * @phpstan-param TQuery $query
      *
      * @return PaginatorAdapterInterface
      */
@@ -41,6 +45,7 @@ interface PaginatedFinderInterface extends FinderInterface
      * Creates a hybrid paginator adapter for this query.
      *
      * @param mixed $query
+     * @phpstan-param TQuery $query
      *
      * @return PaginatorAdapterInterface
      */
@@ -50,6 +55,7 @@ interface PaginatedFinderInterface extends FinderInterface
      * Creates a raw paginator adapter for this query.
      *
      * @param mixed $query
+     * @phpstan-param TQuery $query
      *
      * @return PaginatorAdapterInterface
      */

--- a/src/Finder/TransformedFinder.php
+++ b/src/Finder/TransformedFinder.php
@@ -22,6 +22,8 @@ use Pagerfanta\Pagerfanta;
 
 /**
  * Finds elastica documents and map them to persisted objects.
+ *
+ * @phpstan-import-type TQuery from FinderInterface
  */
 class TransformedFinder implements PaginatedFinderInterface
 {
@@ -52,7 +54,8 @@ class TransformedFinder implements PaginatedFinderInterface
     }
 
     /**
-     * @param $query
+     * @param mixed $query
+     * @phpstan-param TQuery $query
      *
      * @return array
      */
@@ -64,7 +67,8 @@ class TransformedFinder implements PaginatedFinderInterface
     }
 
     /**
-     * @param $query
+     * @param mixed $query
+     * @phpstan-param TQuery $query
      */
     public function findRaw($query, ?int $limit = null, array $options = []): array
     {
@@ -85,6 +89,7 @@ class TransformedFinder implements PaginatedFinderInterface
      * Searches for query hybrid results and returns them wrapped in a paginator.
      *
      * @param mixed $query Can be a string, an array or an \Elastica\Query object
+     * @phpstan-param TQuery $query
      *
      * @return Pagerfanta paginated hybrid results
      */
@@ -126,7 +131,8 @@ class TransformedFinder implements PaginatedFinderInterface
     }
 
     /**
-     * @param $query
+     * @param mixed $query
+     * @phpstan-param TQuery $query
      *
      * @return array
      */

--- a/src/Repository.php
+++ b/src/Repository.php
@@ -11,6 +11,7 @@
 
 namespace FOS\ElasticaBundle;
 
+use FOS\ElasticaBundle\Finder\FinderInterface;
 use FOS\ElasticaBundle\Finder\PaginatedFinderInterface;
 
 /**
@@ -18,6 +19,7 @@ use FOS\ElasticaBundle\Finder\PaginatedFinderInterface;
  *
  * Basic repository to be extended to hold custom queries to be run
  * in the finder
+ * @phpstan-import-type TQuery from FinderInterface
  */
 class Repository
 {
@@ -31,6 +33,7 @@ class Repository
 
     /**
      * @param mixed $query
+     * @phpstan-param TQuery $query
      *
      * @return array
      */
@@ -41,6 +44,7 @@ class Repository
 
     /**
      * @param mixed $query
+     * @phpstan-param TQuery $query
      *
      * @return mixed
      */
@@ -51,6 +55,7 @@ class Repository
 
     /**
      * @param mixed $query
+     * @phpstan-param TQuery $query
      *
      * @return \Pagerfanta\Pagerfanta
      */
@@ -61,6 +66,7 @@ class Repository
 
     /**
      * @param mixed $query
+     * @phpstan-param TQuery $query
      *
      * @return Paginator\PaginatorAdapterInterface
      */
@@ -71,6 +77,7 @@ class Repository
 
     /**
      * @param mixed $query
+     * @phpstan-param TQuery $query
      *
      * @return Paginator\HybridPaginatorAdapter
      */


### PR DESCRIPTION
This should help users to build statically analyzed apps code.

`phpstan-type`/`phpstan-import-type` is supported by PHPStan and Psalm. PHPStorm will support them in the next release (available in EAP already).