### PR TITLE
Update config.xml

### DIFF
--- a/src/Resources/config/config.xml
+++ b/src/Resources/config/config.xml
@@ -36,7 +36,7 @@
         </service>
 
         <service id="fos_elastica.paginator.subscriber" class="FOS\ElasticaBundle\Subscriber\PaginateElasticaQuerySubscriber" public="true">
-            <tag name="knp_paginator.subscriber" />
+            <tag name="kernel.event_subscriber" />
             <argument type="service" id="request_stack" />
         </service>
 


### PR DESCRIPTION
Fix to this deprecated message : 
Using "knp_paginator.subscriber" tag is deprecated, use "kernel.event_subscriber" instead

Please have a look at this : 
https://github.com/KnpLabs/KnpPaginatorBundle/issues/731