### PR TITLE
Add support for 'aws_credential_provider'

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -383,6 +383,7 @@ class Configuration implements ConfigurationInterface
                                         ->scalarNode('aws_secret_access_key')->end()
                                         ->scalarNode('aws_region')->end()
                                         ->scalarNode('aws_session_token')->end()
+                                        ->scalarNode('aws_credential_provider')->end()
                                         ->booleanNode('ssl')->defaultValue(false)->end()
                                         ->scalarNode('logger')
                                             ->defaultValue($this->debug ? 'fos_elastica.logger' : false)

--- a/src/DependencyInjection/FOSElasticaExtension.php
+++ b/src/DependencyInjection/FOSElasticaExtension.php
@@ -144,6 +144,10 @@ class FOSElasticaExtension extends Extension
         foreach ($clients as $name => $clientConfig) {
             $clientId = \sprintf('fos_elastica.client.%s', $name);
 
+            if (isset($clientConfig['aws_credential_provider'])) {
+                $clientConfig['aws_credential_provider'] = new Reference($clientConfig['aws_credential_provider']);
+            }
+
             $clientDef = new ChildDefinition('fos_elastica.client_prototype');
             $clientDef->replaceArgument(0, $clientConfig);
             $clientDef->replaceArgument(1, null);

--- a/src/DependencyInjection/FOSElasticaExtension.php
+++ b/src/DependencyInjection/FOSElasticaExtension.php
@@ -144,8 +144,12 @@ class FOSElasticaExtension extends Extension
         foreach ($clients as $name => $clientConfig) {
             $clientId = \sprintf('fos_elastica.client.%s', $name);
 
-            if (isset($clientConfig['aws_credential_provider'])) {
-                $clientConfig['aws_credential_provider'] = new Reference($clientConfig['aws_credential_provider']);
+            if (isset($clientConfig['connections'])) {
+                foreach ($clientConfig['connections'] as $connectionIndex => $connectionConfig) {
+                    if (isset($connectionConfig['aws_credential_provider'])) {
+                        $clientConfig[$connectionIndex]['aws_credential_provider'] = new Reference($connectionConfig['aws_credential_provider']);
+                    }
+                }
             }
 
             $clientDef = new ChildDefinition('fos_elastica.client_prototype');

--- a/src/DependencyInjection/FOSElasticaExtension.php
+++ b/src/DependencyInjection/FOSElasticaExtension.php
@@ -147,7 +147,7 @@ class FOSElasticaExtension extends Extension
             if (isset($clientConfig['connections'])) {
                 foreach ($clientConfig['connections'] as $connectionIndex => $connectionConfig) {
                     if (isset($connectionConfig['aws_credential_provider'])) {
-                        $clientConfig[$connectionIndex]['aws_credential_provider'] = new Reference($connectionConfig['aws_credential_provider']);
+                        $clientConfig['connections'][$connectionIndex]['aws_credential_provider'] = new Reference($connectionConfig['aws_credential_provider']);
                     }
                 }
             }


### PR DESCRIPTION
Fixes #1596 

This adds support for the `aws_credential_provider` setting in Elastica, which was added in https://github.com/ruflin/Elastica/pull/1667

Example usage:
```yaml
// config/packages/fos_elastica.yaml
fos_elastica:
    clients:
        default:
            host: '%env(ELASTICSEARCH_HOST)%'
            port: '%env(ELASTICSEARCH_PORT)%'
            transport: "AwsAuthV4"
            aws_region: "eu-central-1"
            aws_credential_provider: 'aws.credentials_provider'

services:

    Aws\Credentials\CredentialProvider:
    aws.credentials_provider:
        class: 'Aws\Credentials\CredentialProvider'
        factory: [ '@Aws\Credentials\CredentialProvider', 'defaultProvider' ]
```