### PR TITLE
Move command name to tag attribute

### DIFF
--- a/src/Command/CreateCommand.php
+++ b/src/Command/CreateCommand.php
@@ -25,8 +25,6 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class CreateCommand extends Command
 {
-    protected static $defaultName = 'fos:elastica:create';
-
     private $indexManager;
     private $mappingBuilder;
     private $configManager;

--- a/src/Command/DeleteCommand.php
+++ b/src/Command/DeleteCommand.php
@@ -25,8 +25,6 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class DeleteCommand extends Command
 {
-    protected static $defaultName = 'fos:elastica:delete';
-
     private $client;
     private $indexManager;
 

--- a/src/Command/PopulateCommand.php
+++ b/src/Command/PopulateCommand.php
@@ -37,8 +37,6 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
  */
 class PopulateCommand extends Command
 {
-    protected static $defaultName = 'fos:elastica:populate';
-
     /**
      * @var EventDispatcherInterface
      */

--- a/src/Command/ResetCommand.php
+++ b/src/Command/ResetCommand.php
@@ -23,8 +23,6 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class ResetCommand extends Command
 {
-    protected static $defaultName = 'fos:elastica:reset';
-
     private $indexManager;
     private $resetter;
 

--- a/src/Command/ResetTemplatesCommand.php
+++ b/src/Command/ResetTemplatesCommand.php
@@ -23,8 +23,6 @@ use Symfony\Component\Console\Question\ConfirmationQuestion;
  */
 final class ResetTemplatesCommand extends Command
 {
-    protected static $defaultName = 'fos:elastica:reset-templates';
-
     /** @var TemplateResetter */
     private $resetter;
 

--- a/src/Command/SearchCommand.php
+++ b/src/Command/SearchCommand.php
@@ -25,8 +25,6 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class SearchCommand extends Command
 {
-    protected static $defaultName = 'fos:elastica:search';
-
     private $indexManager;
 
     public function __construct(IndexManager $indexManager)

--- a/src/Resources/config/commands.xml
+++ b/src/Resources/config/commands.xml
@@ -6,7 +6,7 @@
 
     <services>
         <service id="fos_elastica.command.create" class="FOS\ElasticaBundle\Command\CreateCommand">
-            <tag name="console.command" />
+            <tag name="console.command" command="fos:elastica:create" />
             <argument type="service" id="fos_elastica.index_manager" />
             <argument type="service" id="fos_elastica.mapping_builder" />
             <argument type="service" id="fos_elastica.config_manager" />
@@ -14,13 +14,13 @@
         </service>
 
         <service id="fos_elastica.command.delete" class="FOS\ElasticaBundle\Command\DeleteCommand">
-            <tag name="console.command" />
+            <tag name="console.command" command="fos:elastica:delete" />
             <argument type="service" id="fos_elastica.client.default" />
             <argument type="service" id="fos_elastica.index_manager" />
         </service>
 
         <service id="fos_elastica.command.populate" class="FOS\ElasticaBundle\Command\PopulateCommand">
-            <tag name="console.command" />
+            <tag name="console.command" command="fos:elastica:populate" />
             <argument type="service" id="event_dispatcher" />
             <argument type="service" id="fos_elastica.index_manager" />
             <argument type="service" id="fos_elastica.pager_provider_registry" />
@@ -29,18 +29,18 @@
         </service>
 
         <service id="fos_elastica.command.reset" class="FOS\ElasticaBundle\Command\ResetCommand">
-            <tag name="console.command" />
+            <tag name="console.command" command="fos:elastica:reset" />
             <argument type="service" id="fos_elastica.index_manager" />
             <argument type="service" id="fos_elastica.resetter" />
         </service>
 
         <service id="fos_elastica.command.templates_reset" class="FOS\ElasticaBundle\Command\ResetTemplatesCommand">
-            <tag name="console.command" />
+            <tag name="console.command" command="fos:elastica:reset-templates" />
             <argument type="service" id="fos_elastica.template_resetter" />
         </service>
 
         <service id="fos_elastica.command.search" class="FOS\ElasticaBundle\Command\SearchCommand">
-            <tag name="console.command" />
+            <tag name="console.command" command="fos:elastica:search" />
             <argument type="service" id="fos_elastica.index_manager" />
         </service>
     </services>


### PR DESCRIPTION
This will keep [the command lazy loaded](https://symfony.com/doc/4.4/console/commands_as_services.html#lazy-loading) and prevents triggering deprecations when using [Symfony 6.1](https://github.com/symfony/symfony/blob/6.1/UPGRADE-6.1.md#console)