### PR TITLE
Run code style checks on PHP 8.1

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -11,10 +11,10 @@ jobs:
       - name: 'Setup PHP'
         uses: 'shivammathur/setup-php@v2'
         with:
-          php-version: '7.4'
+          php-version: '8.1'
           coverage: 'none'
           extensions: 'json, mbstring, tokenizer'
-          tools: 'composer-normalize, php-cs-fixer:3.0.0'
+          tools: 'composer-normalize, php-cs-fixer:3.8.0'
 
       - name: 'Display tools versions'
         run: |


### PR DESCRIPTION
This will allow using modern PHP features, e.g. for Enums in https://github.com/FriendsOfSymfony/FOSElasticaBundle/pull/1866

PHP 8.1 support was introduced in php-cs-fixer v3.4.0, but I decided to update it to the latest version available.