### PR TITLE
Add PHPStan template to HybridResult

### DIFF
--- a/src/HybridResult.php
+++ b/src/HybridResult.php
@@ -13,6 +13,9 @@ namespace FOS\ElasticaBundle;
 
 use Elastica\Result;
 
+/**
+ * @template T of object
+ */
 class HybridResult
 {
     /**
@@ -20,12 +23,12 @@ class HybridResult
      */
     protected $result;
     /**
-     * @var ?object
+     * @var T|null
      */
     protected $transformed;
 
     /**
-     * @param ?object $transformed
+     * @param T|null $transformed
      */
     public function __construct(Result $result, $transformed = null)
     {
@@ -34,7 +37,7 @@ class HybridResult
     }
 
     /**
-     * @return ?object
+     * @return T|null
      */
     public function getTransformed()
     {


### PR DESCRIPTION
This allows users to annotate what transformed object is contained in their HybridResults by annotating their search repositories.

See https://phpstan.org/blog/generics-in-php-using-phpdocs for more information about generics.