### PR TITLE
[bug] The batch_size parameter should be max_per_page

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -209,7 +209,7 @@ class Configuration implements ConfigurationInterface
                 ->arrayNode('provider')
                     ->addDefaultsIfNotSet()
                     ->children()
-                        ->scalarNode('batch_size')->defaultValue(100)->end()
+                        ->scalarNode('max_per_page')->defaultValue(100)->end()
                         ->scalarNode('clear_object_manager')->defaultTrue()->end()
                         ->booleanNode('debug_logging')
                             ->defaultValue($this->debug)


### PR DESCRIPTION
I can see in the bundle that `batch_size` parameters is never used and the actual parameter that is provided to the `provider` is max_per_page.

https://github.com/FriendsOfSymfony/FOSElasticaBundle/blob/master/src/Persister/InPlacePagerPersister.php#L44