### PR TITLE
[docs]Update Dynamic Templates documentation based on issue

### DIFF
--- a/doc/indexes.md
+++ b/doc/indexes.md
@@ -66,11 +66,11 @@ fos_elastica:
     indexes:
         user:
             dynamic_templates:
-                my_template_1:
+                - my_template_1:
                     match: apples_*
                     mapping:
                         type: float
-                my_template_2:
+                - my_template_2:
                     match: *
                     match_mapping_type: text
                     mapping:


### PR DESCRIPTION
The dynamic_templates expects an array. That's nice, we the example states differently. I was only able to came up to the solution because of the issue below, but no action was done because of that 😢 

https://github.com/FriendsOfSymfony/FOSElasticaBundle/issues/1849