### PR TITLE
Show filtered object count during populate

### DIFF
--- a/src/Command/ConsoleProgressLogger.php
+++ b/src/Command/ConsoleProgressLogger.php
@@ -26,6 +26,7 @@ final class ConsoleProgressLogger
     private string $action;
     private string $index;
     private int $offset;
+    private int $filteredCount = 0;
     private bool $finished = false;
 
     public function __construct(OutputInterface $output, string $action, string $index, int $offset)
@@ -36,7 +37,7 @@ final class ConsoleProgressLogger
         $this->offset = $offset;
     }
 
-    public function call(int $increment, int $totalObjects, ?string $message = null): void
+    public function call(int $increment, int $filteredIncrement, int $totalObjects, ?string $message = null): void
     {
         if ($this->finished) {
             return;
@@ -47,6 +48,12 @@ final class ConsoleProgressLogger
             $this->progress->setMessage(\sprintf('<info>%s</info> <comment>%s</comment>', $this->action, $this->index));
             $this->progress->start();
             $this->progress->setProgress($this->offset);
+        }
+
+        if (0 !== $filteredIncrement) {
+            $this->filteredCount += $filteredIncrement;
+            $this->progress->setMaxSteps($totalObjects - $this->filteredCount);
+            $this->progress->setMessage(\sprintf('<info>%s</info> <comment>%s</comment> (%d/%d filtered)', $this->action, $this->index, $this->filteredCount, $totalObjects));
         }
 
         if (null !== $message) {

--- a/src/Command/PopulateCommand.php
+++ b/src/Command/PopulateCommand.php
@@ -158,6 +158,7 @@ class PopulateCommand extends Command
             $exceptionListener = function (OnExceptionEvent $event) use ($consoleLogger) {
                 $consoleLogger->call(
                     \count($event->getObjects()),
+                    0,
                     $event->getPager()->getNbResults(),
                     \sprintf('<error>%s</error>', $event->getException()->getMessage())
                 );
@@ -167,14 +168,14 @@ class PopulateCommand extends Command
         $this->dispatcher->addListener(
             PostInsertObjectsEvent::class,
             $postInsertListener = function (PostInsertObjectsEvent $event) use ($consoleLogger) {
-                $consoleLogger->call(\count($event->getObjects()), $event->getPager()->getNbResults());
+                $consoleLogger->call(\count($event->getObjects()), $event->getFilteredObjectCount(), $event->getPager()->getNbResults());
             }
         );
 
         $this->dispatcher->addListener(
             PostAsyncInsertObjectsEvent::class,
             $postAsyncInsertListener = function (PostAsyncInsertObjectsEvent $event) use ($consoleLogger) {
-                $consoleLogger->call($event->getObjectsCount(), $event->getPager()->getNbResults(), $event->getErrorMessage());
+                $consoleLogger->call($event->getObjectsCount(), 0, $event->getPager()->getNbResults(), $event->getErrorMessage());
             }
         );
 

--- a/src/Persister/Event/PostInsertObjectsEvent.php
+++ b/src/Persister/Event/PostInsertObjectsEvent.php
@@ -38,15 +38,21 @@ final class PostInsertObjectsEvent extends Event implements PersistEvent
     private $options;
 
     /**
+     * @var int
+     */
+    private $filteredObjectCount;
+
+    /**
      * @param list<object>         $objects
      * @param array<string, mixed> $options
      */
-    public function __construct(PagerInterface $pager, ObjectPersisterInterface $objectPersister, array $objects, array $options)
+    public function __construct(PagerInterface $pager, ObjectPersisterInterface $objectPersister, array $objects, array $options, int $filteredObjectCount = 0)
     {
         $this->pager = $pager;
         $this->objectPersister = $objectPersister;
         $this->objects = $objects;
         $this->options = $options;
+        $this->filteredObjectCount = $filteredObjectCount;
     }
 
     public function getPager(): PagerInterface
@@ -70,5 +76,10 @@ final class PostInsertObjectsEvent extends Event implements PersistEvent
     public function getObjects(): array
     {
         return $this->objects;
+    }
+
+    public function getFilteredObjectCount(): int
+    {
+        return $this->filteredObjectCount;
     }
 }

--- a/src/Persister/Event/PostInsertObjectsEvent.php
+++ b/src/Persister/Event/PostInsertObjectsEvent.php
@@ -37,10 +37,7 @@ final class PostInsertObjectsEvent extends Event implements PersistEvent
      */
     private $options;
 
-    /**
-     * @var int
-     */
-    private $filteredObjectCount;
+    private int $filteredObjectCount;
 
     /**
      * @param list<object>         $objects

--- a/src/Persister/Event/PreInsertObjectsEvent.php
+++ b/src/Persister/Event/PreInsertObjectsEvent.php
@@ -37,10 +37,7 @@ final class PreInsertObjectsEvent extends Event implements PersistEvent
      */
     private $options;
 
-    /**
-     * @var int
-     */
-    private $filteredObjectCount = 0;
+    private int $filteredObjectCount = 0;
 
     /**
      * @param list<object>         $objects
@@ -114,21 +111,14 @@ final class PreInsertObjectsEvent extends Event implements PersistEvent
     }
 
     /**
-     * @param int $count
-     *
-     * @return void
-     *
      * @internal
      */
-    public function setFilteredObjectCount($count)
+    public function setFilteredObjectCount(int $count): void
     {
         $this->filteredObjectCount = $count;
     }
 
-    /**
-     * @return int
-     */
-    public function getFilteredObjectCount()
+    public function getFilteredObjectCount(): int
     {
         return $this->filteredObjectCount;
     }

--- a/src/Persister/Event/PreInsertObjectsEvent.php
+++ b/src/Persister/Event/PreInsertObjectsEvent.php
@@ -38,6 +38,11 @@ final class PreInsertObjectsEvent extends Event implements PersistEvent
     private $options;
 
     /**
+     * @var int
+     */
+    private $filteredObjectCount = 0;
+
+    /**
      * @param list<object>         $objects
      * @param array<string, mixed> $options
      */
@@ -106,5 +111,25 @@ final class PreInsertObjectsEvent extends Event implements PersistEvent
     public function setObjects($objects)
     {
         $this->objects = $objects;
+    }
+
+    /**
+     * @param int $count
+     *
+     * @return void
+     *
+     * @internal
+     */
+    public function setFilteredObjectCount($count)
+    {
+        $this->filteredObjectCount = $count;
+    }
+
+    /**
+     * @return int
+     */
+    public function getFilteredObjectCount()
+    {
+        return $this->filteredObjectCount;
     }
 }

--- a/src/Persister/InPlacePagerPersister.php
+++ b/src/Persister/InPlacePagerPersister.php
@@ -95,18 +95,19 @@ final class InPlacePagerPersister implements PagerPersisterInterface
         $pager = $event->getPager();
         $options = $event->getOptions();
         $objects = $event->getObjects();
+        $filteredObjectCount = $event->getFilteredObjectCount();
 
         try {
             if (!empty($objects)) {
                 $objectPersister->insertMany($objects);
             }
 
-            $this->dispatcher->dispatch(new PostInsertObjectsEvent($pager, $objectPersister, $objects, $options));
+            $this->dispatcher->dispatch(new PostInsertObjectsEvent($pager, $objectPersister, $objects, $options, $filteredObjectCount));
         } catch (\Exception $e) {
             $this->dispatcher->dispatch($event = new OnExceptionEvent($pager, $objectPersister, $e, $objects, $options));
 
             if ($event->isIgnored()) {
-                $this->dispatcher->dispatch(new PostInsertObjectsEvent($pager, $objectPersister, $objects, $options));
+                $this->dispatcher->dispatch(new PostInsertObjectsEvent($pager, $objectPersister, $objects, $options, $filteredObjectCount));
             } else {
                 $e = $event->getException();
 

--- a/src/Persister/Listener/FilterObjectsListener.php
+++ b/src/Persister/Listener/FilterObjectsListener.php
@@ -43,6 +43,7 @@ class FilterObjectsListener implements EventSubscriberInterface
             $filtered[] = $object;
         }
 
+        $event->setFilteredObjectCount(\count($objects) - \count($filtered));
         $event->setObjects($filtered);
     }
 


### PR DESCRIPTION
With the current populate command output you are not given insight in the amount of filtered objects, and they are not used to advance the progress bar as well. Before #1891 this would result in the progress bar not being completed at all, but now it jumps to the end as it is being marked as completed.

I propose the following adjustment: register the amount of filtered objects into the `PreInserObjectsEvent` and forward to the `PostInsertObjectsEvent`. There is also a `PostAsyncInsertObjectsEvent`, but I believe that is not being used at (~~will open a dedicated MR for it~~ #1893). With the data now available to the console logger, we can print the skipped/total object after the populating message, and adjust the progress bar total to show the amount of objects to be really inserted.

I expect test will fail with this change, but before I update them I would love to hear if this is a reasonable change!

### Old output

https://user-images.githubusercontent.com/1835343/202022563-561b2bfe-749f-487a-8b33-cf9af9d5863e.mp4

### New output

https://user-images.githubusercontent.com/1835343/202179821-67ee1dd7-b5b0-4a37-9f28-9cf4cb164470.mp4



