### PR TITLE
Only require `pagerfanta/core`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "homepage": "https://github.com/FriendsOfSymfony/FOSElasticaBundle",
     "require": {
         "php": "^7.4 || ^8.0",
-        "pagerfanta/pagerfanta": "^2.4 || ^3.0",
+        "pagerfanta/core": "^2.4 || ^3.0",
         "psr/log": "^1.0 || ^2.0 || ^3.0",
         "ruflin/elastica": "^7.1",
         "symfony/console": "^4.4 || ^5.4 || ^6.0",


### PR DESCRIPTION
Instead of depending on the `pagerfanta/pagerfanta` monopackage (which installs everything), only the `pagerfanta/core` package needs to be a hard dependency.  The subsplit repos for the supported Doctrine integrations are already listed as dev requirements, so this mainly just lightens the production dependencies and allows Composer to work a bit more efficiently (the monorepo has a heavier list of conflicts to deal with because it's trying to set constraints for everything whereas the subsplit packages have rather small dependency lists).