### PR TITLE
Add missing interfaces to TransformedFinder

### DIFF
--- a/src/Finder/HybridFinderInterface.php
+++ b/src/Finder/HybridFinderInterface.php
@@ -1,0 +1,34 @@
+<?php
+
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the FOSElasticaBundle package.
+ *
+ * (c) FriendsOfSymfony <https://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\ElasticaBundle\Finder;
+
+use FOS\ElasticaBundle\HybridResult;
+
+/**
+ * @phpstan-import-type TQuery from FinderInterface
+ * @phpstan-import-type TOptions from FinderInterface
+ */
+interface HybridFinderInterface
+{
+    /**
+     * Searches for query hybrid results within a given limit.
+     *
+     * @param TQuery   $query
+     * @param TOptions $options
+     *
+     * @return HybridResult[]
+     */
+    public function findHybrid($query, ?int $limit = null, array $options = []);
+}

--- a/src/Finder/PaginatedHybridFinderInterface.php
+++ b/src/Finder/PaginatedHybridFinderInterface.php
@@ -1,0 +1,45 @@
+<?php
+
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the FOSElasticaBundle package.
+ *
+ * (c) FriendsOfSymfony <https://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\ElasticaBundle\Finder;
+
+use FOS\ElasticaBundle\HybridResult;
+use FOS\ElasticaBundle\Paginator\PaginatorAdapterInterface;
+use Pagerfanta\PagerfantaInterface;
+
+/**
+ * @phpstan-import-type TQuery from FinderInterface
+ * @phpstan-import-type TOptions from FinderInterface
+ */
+interface PaginatedHybridFinderInterface extends HybridFinderInterface
+{
+    /**
+     * Searches for query hybrid results and returns them wrapped in a paginator.
+     *
+     * @param TQuery $query
+     *
+     * @return PagerfantaInterface<HybridResult>
+     */
+    public function findHybridPaginated($query);
+
+    /**
+     * Creates a hybrid paginator adapter for this query.
+     *
+     * @param TQuery   $query
+     * @param TOptions $options
+     *
+     * @return PaginatorAdapterInterface
+     */
+    public function createHybridPaginatorAdapter($query, array $options = []);
+}

--- a/src/Finder/PaginatedRawFinderInterface.php
+++ b/src/Finder/PaginatedRawFinderInterface.php
@@ -1,0 +1,46 @@
+<?php
+
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the FOSElasticaBundle package.
+ *
+ * (c) FriendsOfSymfony <https://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\ElasticaBundle\Finder;
+
+use Elastica\Result;
+use FOS\ElasticaBundle\Paginator\PaginatorAdapterInterface;
+use Pagerfanta\PagerfantaInterface;
+
+/**
+ * @phpstan-import-type TQuery from FinderInterface
+ * @phpstan-import-type TOptions from FinderInterface
+ */
+interface PaginatedRawFinderInterface extends RawFinderInterface
+{
+    /**
+     * Searches for query raw results and returns them wrapped in a paginator.
+     *
+     * @param TQuery   $query
+     * @param TOptions $options
+     *
+     * @return PagerfantaInterface<Result>
+     */
+    public function findRawPaginated($query, array $options = []);
+
+    /**
+     * Creates a raw paginator adapter for this query.
+     *
+     * @param TQuery   $query
+     * @param TOptions $options
+     *
+     * @return PaginatorAdapterInterface
+     */
+    public function createRawPaginatorAdapter($query, array $options = []);
+}

--- a/src/Finder/RawFinderInterface.php
+++ b/src/Finder/RawFinderInterface.php
@@ -1,0 +1,34 @@
+<?php
+
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the FOSElasticaBundle package.
+ *
+ * (c) FriendsOfSymfony <https://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\ElasticaBundle\Finder;
+
+use Elastica\Result;
+
+/**
+ * @phpstan-import-type TQuery from FinderInterface
+ * @phpstan-import-type TOptions from FinderInterface
+ */
+interface RawFinderInterface
+{
+    /**
+     * Searches for query raw results within a given limit.
+     *
+     * @param TQuery   $query
+     * @param TOptions $options
+     *
+     * @return Result[]
+     */
+    public function findRaw($query, ?int $limit = null, array $options = []);
+}

--- a/src/Finder/TransformedFinder.php
+++ b/src/Finder/TransformedFinder.php
@@ -14,7 +14,6 @@ namespace FOS\ElasticaBundle\Finder;
 use Elastica\Query;
 use Elastica\Result;
 use Elastica\SearchableInterface;
-use FOS\ElasticaBundle\HybridResult;
 use FOS\ElasticaBundle\Paginator\FantaPaginatorAdapter;
 use FOS\ElasticaBundle\Paginator\HybridPaginatorAdapter;
 use FOS\ElasticaBundle\Paginator\RawPaginatorAdapter;
@@ -28,7 +27,7 @@ use Pagerfanta\Pagerfanta;
  * @phpstan-import-type TQuery from FinderInterface
  * @phpstan-import-type TOptions from FinderInterface
  */
-class TransformedFinder implements PaginatedFinderInterface
+class TransformedFinder implements PaginatedFinderInterface, PaginatedRawFinderInterface, PaginatedHybridFinderInterface
 {
     protected SearchableInterface $searchable;
     protected ElasticaToModelTransformerInterface $transformer;
@@ -50,11 +49,7 @@ class TransformedFinder implements PaginatedFinderInterface
     }
 
     /**
-     * @param mixed $query
-     * @phpstan-param TQuery $query
-     * @phpstan-param TOptions $options
-     *
-     * @return list<HybridResult>
+     * {@inheritdoc}
      */
     public function findHybrid($query, ?int $limit = null, array $options = [])
     {
@@ -64,11 +59,7 @@ class TransformedFinder implements PaginatedFinderInterface
     }
 
     /**
-     * @param mixed $query
-     * @phpstan-param TQuery $query
-     * @phpstan-param TOptions $options
-     *
-     * @return Result[]
+     * {@inheritdoc}
      */
     public function findRaw($query, ?int $limit = null, array $options = []): array
     {
@@ -86,17 +77,21 @@ class TransformedFinder implements PaginatedFinderInterface
     }
 
     /**
-     * Searches for query hybrid results and returns them wrapped in a paginator.
-     *
-     * @param mixed $query Can be a string, an array or an \Elastica\Query object
-     * @phpstan-param TQuery $query
-     * @phpstan-param TOptions $options
-     *
-     * @return Pagerfanta<HybridResult> paginated hybrid results
+     * {@inheritdoc}
      */
     public function findHybridPaginated($query, array $options = [])
     {
         $paginatorAdapter = $this->createHybridPaginatorAdapter($query, $options);
+
+        return new Pagerfanta(new FantaPaginatorAdapter($paginatorAdapter));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function findRawPaginated($query, array $options = [])
+    {
+        $paginatorAdapter = $this->createRawPaginatorAdapter($query, $options);
 
         return new Pagerfanta(new FantaPaginatorAdapter($paginatorAdapter));
     }
@@ -133,6 +128,7 @@ class TransformedFinder implements PaginatedFinderInterface
 
     /**
      * @param mixed $query
+     *
      * @phpstan-param TQuery $query
      * @phpstan-param TOptions $options
      *


### PR DESCRIPTION
Previously, `TransformedFinder`'s public methods were poorly covered with interfaces. This PR adds missing, granular contracts for each public method.

✅ Each public method of `TransformedFinder` is covered by interface
✅ Each interface is granular
✅ Backward-compatible

I wanted to clean up the `PaginatedFinderInterface`, but due to BC reasons I decided to left it as is. Current state doesn't block making this PR working, and we can refactor it later, when new major would be on the horizon.