### PR TITLE
Remove count from async persister

### DIFF
--- a/src/Persister/AsyncPagerPersister.php
+++ b/src/Persister/AsyncPagerPersister.php
@@ -76,7 +76,7 @@ final class AsyncPagerPersister implements PagerPersisterInterface
     /**
      * @phpstan-param TPagerPersisterOptions $options
      */
-    public function insertPage(int $page, array $options = []): int
+    public function insertPage(int $page, array $options = []): void
     {
         if (!isset($options['indexName'])) {
             throw new \RuntimeException('Invalid call. $options is missing the indexName key.');
@@ -93,12 +93,7 @@ final class AsyncPagerPersister implements PagerPersisterInterface
         $pager->setMaxPerPage($options['max_per_page']);
         $pager->setCurrentPage($options['first_page']);
 
-        $results = $pager->getCurrentPageResults();
-        $objectCount = $results instanceof \Traversable ? \iterator_count($results) : \count($results);
-
         $pagerPersister = $this->pagerPersisterRegistry->getPagerPersister(InPlacePagerPersister::NAME);
         $pagerPersister->insert($pager, $options);
-
-        return $objectCount;
     }
 }

--- a/src/Persister/AsyncPagerPersister.php
+++ b/src/Persister/AsyncPagerPersister.php
@@ -93,6 +93,7 @@ final class AsyncPagerPersister implements PagerPersisterInterface
         $pager->setMaxPerPage($options['max_per_page']);
         $pager->setCurrentPage($options['first_page']);
 
+        /** @var InPlacePagerPersister $pagerPersister */
         $pagerPersister = $this->pagerPersisterRegistry->getPagerPersister(InPlacePagerPersister::NAME);
         $pagerPersister->insert($pager, $options);
     }

--- a/tests/Unit/Persister/AsyncPagerPersisterTest.php
+++ b/tests/Unit/Persister/AsyncPagerPersisterTest.php
@@ -13,17 +13,12 @@ namespace FOS\ElasticaBundle\Tests\Unit\Persister;
 
 use FOS\ElasticaBundle\Message\AsyncPersistPage;
 use FOS\ElasticaBundle\Persister\AsyncPagerPersister;
-use FOS\ElasticaBundle\Persister\InPlacePagerPersister;
-use FOS\ElasticaBundle\Persister\ObjectPersisterInterface;
 use FOS\ElasticaBundle\Persister\PagerPersisterInterface;
 use FOS\ElasticaBundle\Persister\PagerPersisterRegistry;
-use FOS\ElasticaBundle\Persister\PersisterRegistry;
 use FOS\ElasticaBundle\Provider\PagerInterface;
-use FOS\ElasticaBundle\Provider\PagerProviderInterface;
 use FOS\ElasticaBundle\Provider\PagerProviderRegistry;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ServiceLocator;
-use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBusInterface;
 

--- a/tests/Unit/Persister/AsyncPagerPersisterTest.php
+++ b/tests/Unit/Persister/AsyncPagerPersisterTest.php
@@ -56,46 +56,4 @@ class AsyncPagerPersisterTest extends TestCase
         $pager = $this->createMock(PagerInterface::class);
         $sut->insert($pager);
     }
-
-    public function testInsertPageReturnObjectCount()
-    {
-        $persistersLocator = $this->createMock(ServiceLocator::class);
-        $persistersLocator->expects($this->once())->method('has')->with('foo')->willReturn(true);
-        $persistersLocator->expects($this->once())->method('get')->with('foo')->willReturn($this->createMock(ObjectPersisterInterface::class));
-
-        $pagerPersistersLocator = $this->createMock(ServiceLocator::class);
-        $pagerPersistersLocator->expects($this->once())->method('has')->with('in_place')->willReturn(true);
-        $pagerPersistersLocator->expects($this->once())->method('get')->with('in_place')->willReturn(
-            new InPlacePagerPersister(
-                new PersisterRegistry($persistersLocator),
-                $this->createMock(EventDispatcherInterface::class)
-            )
-        );
-
-        $pagerPersisterRegistry = new PagerPersisterRegistry($pagerPersistersLocator);
-
-        $pagerMock = $this->createMock(PagerInterface::class);
-        $pagerMock->expects($this->exactly(2))->method('setMaxPerPage')->with(10);
-        $pagerMock->method('setCurrentPage')->withConsecutive([1], [1], [0]);
-        $pagerMock->expects($this->exactly(2))->method('getCurrentPageResults')->willReturn([]);
-
-        $provider = $this->createMock(PagerProviderInterface::class);
-        $provider->expects($this->once())->method('provide')->with([
-            'first_page' => 1,
-            'last_page' => 1,
-            'indexName' => 'foo',
-            'max_per_page' => 10,
-        ])->willReturn($pagerMock);
-
-        $pagerProviderRegistry = $this->createMock(PagerProviderRegistry::class);
-        $pagerProviderRegistry->expects($this->once())->method('getProvider')->with('foo')->willReturn($provider);
-
-        $messageBus = $this->createMock(MessageBusInterface::class);
-        $sut = new AsyncPagerPersister($pagerPersisterRegistry, $pagerProviderRegistry, $messageBus);
-
-        $sut->insertPage(1, [
-            'indexName' => 'foo',
-            'max_per_page' => 10,
-        ]);
-    }
 }


### PR DESCRIPTION
Async Persister is returning useless count that is not used anywhere but to calculate it, we are making an expensive COUNT() query.