### PR TITLE
Fix empty dynamic date formats list

### DIFF
--- a/src/Index/MappingBuilder.php
+++ b/src/Index/MappingBuilder.php
@@ -76,7 +76,7 @@ class MappingBuilder
     {
         $mapping = $indexConfig->getMapping();
 
-        if (null !== $indexConfig->getDynamicDateFormats()) {
+        if (null !== $indexConfig->getDynamicDateFormats() && !empty($indexConfig->getDynamicDateFormats())) {
             $mapping['dynamic_date_formats'] = $indexConfig->getDynamicDateFormats();
         }
 


### PR DESCRIPTION
If the `dynamic_date_formats` is an empty list
this will produce a `Elastica\Exception\ResponseException` saying:

> class java.util.ArrayList cannot be cast to class java.util.Map (java.util.ArrayList and java.util.Map are in module java.base of loader 'bootstrap')

![Screenshot-from-2023-08-04-13-35-54](https://github.com/FriendsOfSymfony/FOSElasticaBundle/assets/2794908/efad44c1-c72f-4a3d-9da0-12506f82007d)

- friendsofsymfony/elastica-bundle v6.3.1
- ruflin/elastica 7.3.1
- Elasticsearch 6.8.22
- symfony/console v4.4.49