### PR TITLE
Client: log query on exception then rethrow it

### DIFF
--- a/src/Elastica/Client.php
+++ b/src/Elastica/Client.php
@@ -13,6 +13,7 @@ namespace FOS\ElasticaBundle\Elastica;
 
 use Elastica\Client as BaseClient;
 use Elastica\Exception\ClientException;
+use Elastica\Exception\ExceptionInterface;
 use Elastica\Index as BaseIndex;
 use Elastica\Request;
 use Elastica\Response;
@@ -58,7 +59,13 @@ class Client extends BaseClient
             $this->stopwatch->start('es_request', 'fos_elastica');
         }
 
-        $response = parent::request($path, $method, $data, $query, $contentType);
+        try {
+            $response = parent::request($path, $method, $data, $query, $contentType);
+        } catch (ExceptionInterface $e) {
+            $this->logQuery($path, $method, $data, $query, 0, 0, 0);
+            throw $e;
+        }
+
         $responseData = $response->getData();
 
         $transportInfo = $response->getTransferInfo();


### PR DESCRIPTION
If an Elastica exception was thrown upon request, then make the request visible that caused it (on verbose console or in your logs), then rethrow the exception.

Example with corrupted request data on the console (calling `php bin/console --env=dev -vvv fos:elastica:populate` very verbose)

### Before:
![Screenshot from 2023-08-04 14-02-06](https://github.com/FriendsOfSymfony/FOSElasticaBundle/assets/2794908/bedc5a3d-9dd6-4cc3-a52d-618eaf9c7a9d)
❓ 🤷🏻‍♂️ 

### After:
![Screenshot from 2023-08-04 14-04-31](https://github.com/FriendsOfSymfony/FOSElasticaBundle/assets/2794908/68fdc24c-35c6-45f5-bd45-c80d11f447f7)
❗ 🕵🏻‍♂️ 