### PR TITLE
Enable max depth for Symfony serializer too

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -78,8 +78,8 @@
     },
     "config": {
         "allow-plugins": {
-            "phpstan/extension-installer": true,
-            "ergebnis/composer-normalize": true
+            "ergebnis/composer-normalize": true,
+            "phpstan/extension-installer": true
         }
     },
     "extra": {

--- a/src/Serializer/Callback.php
+++ b/src/Serializer/Callback.php
@@ -13,6 +13,7 @@ namespace FOS\ElasticaBundle\Serializer;
 
 use JMS\Serializer\SerializationContext;
 use JMS\Serializer\SerializerInterface as JMSSerializer;
+use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer;
 use Symfony\Component\Serializer\SerializerInterface;
 
 class Callback
@@ -86,7 +87,7 @@ class Callback
      */
     public function serialize($object): string
     {
-        $context = $this->serializer instanceof JMSSerializer ? SerializationContext::create()->enableMaxDepthChecks() : [];
+        $context = $this->serializer instanceof JMSSerializer ? SerializationContext::create()->enableMaxDepthChecks() : [AbstractObjectNormalizer::ENABLE_MAX_DEPTH => true];
 
         if (!empty($this->groups)) {
             if ($context instanceof SerializationContext) {


### PR DESCRIPTION
To be consistent with the JMS Serializer configuration 