### PR TITLE
optimize() deprecated and replaced with forcemerge()

### DIFF
--- a/doc/cookbook/populate-events.md
+++ b/doc/cookbook/populate-events.md
@@ -70,7 +70,7 @@ class PopulateListener
     {
         $index = $this->indexManager->getIndex($event->getIndex());
         $settings = $index->getSettings();
-        $index->optimize(['max_num_segments' => 5]);
+        $index->forcemerge(['max_num_segments' => 5]);
         $settings->setRefreshInterval('1s');
     }
 }


### PR DESCRIPTION
`optimize()` deprecated in favor of `forcemerge()` in Elastica v5.x and removed in v6.x.