### PR TITLE
Use correct Extension class per Symfony deprecation

### DIFF
--- a/src/DependencyInjection/FOSElasticaExtension.php
+++ b/src/DependencyInjection/FOSElasticaExtension.php
@@ -21,9 +21,9 @@ use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Exception\LogicException;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\Messenger\MessageBusInterface;
 
 /**


### PR DESCRIPTION
As per #1950 the `Symfony\Component\HttpKernel\DependencyInjection\Extension` is deprecated and `Symfony\Component\DependencyInjection\Extension\Extension` should be used.

This class is available in all Symfony versions supported by this bundle.