### PR TITLE
Add events for requests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,8 @@
         "symfony/dependency-injection": "^5.4 || ^6.4 || ^7.1",
         "symfony/framework-bundle": "^5.4 || ^6.4 || ^7.1",
         "symfony/property-access": "^5.4 || ^6.4 || ^7.1",
-        "symfony/stopwatch": "^5.4 || ^6.4 || ^7.1"
+        "symfony/stopwatch": "^5.4 || ^6.4 || ^7.1",
+        "symfony/event-dispatcher": "^5.4 || ^6.4 || ^7.1"
     },
     "require-dev": {
         "doctrine/doctrine-bundle": "^2.1.1",

--- a/composer.json
+++ b/composer.json
@@ -36,10 +36,10 @@
         "ruflin/elastica": "^7.1",
         "symfony/console": "^5.4 || ^6.4 || ^7.1",
         "symfony/dependency-injection": "^5.4 || ^6.4 || ^7.1",
+        "symfony/event-dispatcher": "^5.4 || ^6.4 || ^7.1",
         "symfony/framework-bundle": "^5.4 || ^6.4 || ^7.1",
         "symfony/property-access": "^5.4 || ^6.4 || ^7.1",
-        "symfony/stopwatch": "^5.4 || ^6.4 || ^7.1",
-        "symfony/event-dispatcher": "^5.4 || ^6.4 || ^7.1"
+        "symfony/stopwatch": "^5.4 || ^6.4 || ^7.1"
     },
     "require-dev": {
         "doctrine/doctrine-bundle": "^2.1.1",

--- a/src/Event/ElasticaRequestExceptionEvent.php
+++ b/src/Event/ElasticaRequestExceptionEvent.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the FOSElasticaBundle package.
+ *
+ * (c) FriendsOfSymfony <https://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\ElasticaBundle\Event;
+
+use Elastica\Exception\ExceptionInterface;
+use Elastica\Request;
+
+class ElasticaRequestExceptionEvent
+{
+    private Request $request;
+    private ExceptionInterface $exception;
+
+    public function __construct(
+        Request $request,
+        ExceptionInterface $exception
+    ) {
+        $this->request = $request;
+        $this->exception = $exception;
+    }
+
+    public function getRequest(): Request
+    {
+        return $this->request;
+    }
+
+    public function getException(): ExceptionInterface
+    {
+        return $this->exception;
+    }
+}

--- a/src/Event/PostElasticaRequestEvent.php
+++ b/src/Event/PostElasticaRequestEvent.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the FOSElasticaBundle package.
+ *
+ * (c) FriendsOfSymfony <https://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\ElasticaBundle\Event;
+
+use Elastica\Request;
+use Elastica\Response;
+
+class PostElasticaRequestEvent
+{
+    private Request $request;
+    private Response $response;
+
+    public function __construct(
+        Request $request,
+        Response $response
+    ) {
+        $this->request = $request;
+        $this->response = $response;
+    }
+
+    public function getRequest(): Request
+    {
+        return $this->request;
+    }
+
+    public function getResponse(): Response
+    {
+        return $this->response;
+    }
+}

--- a/src/Event/PreElasticaRequestEvent.php
+++ b/src/Event/PreElasticaRequestEvent.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of the FOSElasticaBundle package.
+ *
+ * (c) FriendsOfSymfony <https://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\ElasticaBundle\Event;
+
+use Elastica\Request;
+use Symfony\Contracts\EventDispatcher\Event;
+
+class PreElasticaRequestEvent extends Event
+{
+
+    private string $path;
+    private string $method;
+
+    /**
+     * @var array<string, mixed>|string
+     */
+    private $data;
+
+    /**
+     * @var array<string, mixed>
+     */
+    private array $query;
+    private string $contentType;
+
+    public function __construct(
+        string $path,
+        string $method,
+        $data,
+        array $query,
+        string $contentType = Request::DEFAULT_CONTENT_TYPE
+    ) {
+        $this->path = $path;
+        $this->method = $method;
+        $this->data = $data;
+        $this->query = $query;
+        $this->contentType = $contentType;
+    }
+
+    public function getPath(): string
+    {
+        return $this->path;
+    }
+
+    public function getMethod(): string
+    {
+        return $this->method;
+    }
+
+    /**
+     * @return array<string, mixed>|string
+     */
+    public function getData()
+    {
+        return $this->data;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getQuery(): array
+    {
+        return $this->query;
+    }
+
+    public function getContentType(): string
+    {
+        return $this->contentType;
+    }
+}

--- a/src/Event/PreElasticaRequestEvent.php
+++ b/src/Event/PreElasticaRequestEvent.php
@@ -16,7 +16,6 @@ use Symfony\Contracts\EventDispatcher\Event;
 
 class PreElasticaRequestEvent extends Event
 {
-
     private string $path;
     private string $method;
 

--- a/src/Resources/config/config.xml
+++ b/src/Resources/config/config.xml
@@ -17,6 +17,9 @@
             <call method="setStopwatch">
                 <argument type="service" id="debug.stopwatch" on-invalid="null" />
             </call>
+            <call method="setEventDispatcher">
+                <argument type="service" id="event_dispatcher" on-invalid="null" />
+            </call>
         </service>
 
         <service id="fos_elastica.config_manager" class="FOS\ElasticaBundle\Configuration\ConfigManager">

--- a/tests/Unit/Elastica/ClientTest.php
+++ b/tests/Unit/Elastica/ClientTest.php
@@ -96,7 +96,8 @@ class ClientTest extends TestCase
                 }
 
                 return true;
-            }));
+            }))
+        ;
 
         $client->setEventDispatcher($dispatcher);
         $client->request('event', Request::GET, ['some' => 'data'], ['query' => 'data']);
@@ -157,7 +158,8 @@ class ClientTest extends TestCase
                 }
 
                 return true;
-            }));
+            }))
+        ;
 
         $client->setEventDispatcher($dispatcher);
         $this->expectException(ClientException::class);

--- a/tests/Unit/Elastica/ClientTest.php
+++ b/tests/Unit/Elastica/ClientTest.php
@@ -117,7 +117,8 @@ class ClientTest extends TestCase
 
         $connection = $this->getConnectionMock();
         $connection->method('getTransportObject')
-            ->willThrowException(new ClientException());
+            ->willThrowException(new ClientException())
+        ;
 
         $client = $this->getClientMock($response, $connection);
 


### PR DESCRIPTION
Fixes #1963 

Things to consider: at this time it's not possible to pass the full request object in the `PreRequest` event as that object is created and used by the client below. It could be done if the library would change it so that it's in a separate method so we could override it.

The settting of `EventDispatcher` could also just be done in the constructor at this point.