### PR TITLE
Use DI service locator for custom repository instantiation

### DIFF
--- a/doc/cookbook/custom-repositories.md
+++ b/doc/cookbook/custom-repositories.md
@@ -52,3 +52,42 @@ $repository = $repositoryManager->getRepository('UserBundle:User');
 /** var array of Acme\UserBundle\Entity\User */
 $users = $repository->findWithCustomQuery('bob');
 ```
+
+##### Injecting dependencies into custom repositories
+
+Custom repositories are registered as autowired services in the dependency injection
+container. This means you can inject any service into your repository constructor,
+alongside the finder:
+
+```php
+<?php
+
+namespace Acme\ElasticaBundle\SearchRepository;
+
+use FOS\ElasticaBundle\Finder\PaginatedFinderInterface;
+use FOS\ElasticaBundle\Repository;
+use Psr\Log\LoggerInterface;
+
+class UserRepository extends Repository
+{
+    private LoggerInterface $logger;
+
+    public function __construct(PaginatedFinderInterface $finder, LoggerInterface $logger)
+    {
+        parent::__construct($finder);
+
+        $this->logger = $logger;
+    }
+
+    public function findWithCustomQuery($searchText)
+    {
+        $this->logger->info('Searching for users with query: {query}', ['query' => $searchText]);
+
+        // build $query with Elastica objects
+        return $this->find($query);
+    }
+}
+```
+
+The `$finder` argument is automatically provided by the bundle. Any additional
+constructor arguments will be resolved by the container's autowiring.

--- a/src/DependencyInjection/FOSElasticaExtension.php
+++ b/src/DependencyInjection/FOSElasticaExtension.php
@@ -19,13 +19,16 @@ use FOS\ElasticaBundle\Elastica\NodePool\RoundRobinResurrect;
 use FOS\ElasticaBundle\Finder\TransformedFinder;
 use FOS\ElasticaBundle\Manager\RepositoryManagerInterface;
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Exception\LogicException;
 use Symfony\Component\DependencyInjection\Extension\Extension;
 use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\ServiceLocator;
 use Symfony\Component\Messenger\MessageBusInterface;
 
 /**
@@ -66,6 +69,13 @@ class FOSElasticaExtension extends Extension
      * @var list<string>
      */
     private $loadedDrivers = [];
+
+    /**
+     * Custom repository service references keyed by index name.
+     *
+     * @var array<string, ServiceClosureArgument>
+     */
+    private $customRepositories = [];
 
     public function load(array $configs, ContainerBuilder $container): void
     {
@@ -133,6 +143,10 @@ class FOSElasticaExtension extends Extension
 
         $this->loadIndexManager($container);
         $this->loadIndexTemplateManager($container);
+
+        $container->getDefinition('fos_elastica.repository_manager')
+            ->replaceArgument(0, new Definition(ServiceLocator::class, [$this->customRepositories]))
+        ;
 
         $this->createDefaultManagerAlias($config['default_manager'], $container);
     }
@@ -708,6 +722,14 @@ class FOSElasticaExtension extends Extension
         $arguments = [$indexName, new Reference($finderId)];
         if (isset($typeConfig['repository'])) {
             $arguments[] = $typeConfig['repository'];
+
+            $repositoryId = \sprintf('fos_elastica.repository.%s', $indexName);
+            $repositoryDef = new Definition($typeConfig['repository']);
+            $repositoryDef->setArgument('$finder', new Reference($finderId));
+            $repositoryDef->setAutowired(true);
+            $container->setDefinition($repositoryId, $repositoryDef);
+
+            $this->customRepositories[$indexName] = new ServiceClosureArgument(new Reference($repositoryId));
         }
 
         $container->getDefinition('fos_elastica.repository_manager')

--- a/src/Manager/RepositoryManager.php
+++ b/src/Manager/RepositoryManager.php
@@ -12,7 +12,9 @@
 namespace FOS\ElasticaBundle\Manager;
 
 use FOS\ElasticaBundle\Finder\FinderInterface;
+use FOS\ElasticaBundle\Finder\PaginatedFinderInterface;
 use FOS\ElasticaBundle\Repository;
+use Psr\Container\ContainerInterface;
 
 /**
  * @author Richard Miller <info@limethinking.co.uk>
@@ -31,6 +33,13 @@ class RepositoryManager implements RepositoryManagerInterface
      * @var array<string, Repository>
      */
     private $repositories = [];
+
+    private ContainerInterface $repositoryLocator;
+
+    public function __construct(ContainerInterface $repositoryLocator)
+    {
+        $this->repositoryLocator = $repositoryLocator;
+    }
 
     public function addIndex(string $indexName, FinderInterface $finder, ?string $repositoryName = null): void
     {
@@ -80,10 +89,16 @@ class RepositoryManager implements RepositoryManagerInterface
      */
     private function createRepository(string $indexName)
     {
-        if (!\class_exists($repositoryName = $this->getRepositoryName($indexName))) {
-            throw new \RuntimeException(\sprintf('%s repository for index "%s" does not exist', $repositoryName, $indexName));
+        if ($this->repositoryLocator->has($indexName)) {
+            return $this->repositoryLocator->get($indexName);
         }
 
-        return new $repositoryName($this->indexes[$indexName]['finder']);
+        $finder = $this->indexes[$indexName]['finder'];
+
+        if (!$finder instanceof PaginatedFinderInterface) {
+            throw new \RuntimeException(\sprintf('Finder for index "%s" must implement PaginatedFinderInterface', $indexName));
+        }
+
+        return new Repository($finder);
     }
 }

--- a/src/Resources/config/index.php
+++ b/src/Resources/config/index.php
@@ -25,7 +25,9 @@ use FOS\ElasticaBundle\Provider\Indexable;
 return static function (ContainerConfigurator $container): void {
     $services = $container->services();
 
-    $services->set('fos_elastica.repository_manager', RepositoryManager::class);
+    $services->set('fos_elastica.repository_manager', RepositoryManager::class)
+        ->args([abstract_arg('repository service locator')])
+    ;
 
     $services->set('fos_elastica.alias_processor', AliasProcessor::class);
 

--- a/tests/Unit/DependencyInjection/FOSElasticaExtensionTest.php
+++ b/tests/Unit/DependencyInjection/FOSElasticaExtensionTest.php
@@ -22,10 +22,13 @@ use FOS\ElasticaBundle\Persister\Listener\FilterObjectsListener;
 use FOS\ElasticaBundle\Persister\PagerPersisterRegistry;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\Argument\ServiceClosureArgument;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Loader\YamlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\DependencyInjection\ServiceLocator;
 use Symfony\Component\Yaml\Yaml;
 
 /**
@@ -536,5 +539,99 @@ class FOSElasticaExtensionTest extends TestCase
             $tag
         );
         $this->assertTrue($container->hasDefinition('fos_elastica.index_template.some_index_template'));
+    }
+
+    public function testShouldRegisterCustomRepositoryAsService()
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('kernel.debug', true);
+
+        $extension = new FOSElasticaExtension();
+        $extension->load(
+            [
+                'fos_elastica' => [
+                    'clients' => [
+                        'default' => ['hosts' => ['a_host:a_port']],
+                    ],
+                    'indexes' => [
+                        'acme_index' => [
+                            'persistence' => [
+                                'driver' => 'orm',
+                                'model' => 'theModelClass',
+                                'provider' => null,
+                                'listener' => null,
+                                'finder' => null,
+                                'repository' => 'App\Repository\CustomElasticaRepository',
+                            ],
+                            'properties' => ['text' => null],
+                        ],
+                    ],
+                ],
+            ],
+            $container
+        );
+
+        // Custom repository is registered as a DI service
+        $this->assertTrue($container->hasDefinition('fos_elastica.repository.acme_index'));
+
+        $repositoryDefinition = $container->getDefinition('fos_elastica.repository.acme_index');
+        $this->assertSame('App\Repository\CustomElasticaRepository', $repositoryDefinition->getClass());
+        $this->assertTrue($repositoryDefinition->isAutowired());
+
+        // Finder is injected into the custom repository
+        $finderArgument = $repositoryDefinition->getArgument('$finder');
+        $this->assertInstanceOf(Reference::class, $finderArgument);
+        $this->assertSame('fos_elastica.finder.acme_index', (string) $finderArgument);
+
+        // Repository manager receives a ServiceLocator with the custom repository
+        $repositoryManagerDef = $container->getDefinition('fos_elastica.repository_manager');
+        $locatorDefinition = $repositoryManagerDef->getArgument(0);
+        $this->assertInstanceOf(Definition::class, $locatorDefinition);
+        $this->assertSame(ServiceLocator::class, $locatorDefinition->getClass());
+
+        $locatorArguments = $locatorDefinition->getArguments();
+        $this->assertArrayHasKey(0, $locatorArguments);
+        $this->assertArrayHasKey('acme_index', $locatorArguments[0]);
+        $this->assertInstanceOf(ServiceClosureArgument::class, $locatorArguments[0]['acme_index']);
+    }
+
+    public function testShouldNotRegisterRepositoryServiceWhenNoCustomRepository()
+    {
+        $container = new ContainerBuilder();
+        $container->setParameter('kernel.debug', true);
+
+        $extension = new FOSElasticaExtension();
+        $extension->load(
+            [
+                'fos_elastica' => [
+                    'clients' => [
+                        'default' => ['hosts' => ['a_host:a_port']],
+                    ],
+                    'indexes' => [
+                        'acme_index' => [
+                            'persistence' => [
+                                'driver' => 'orm',
+                                'model' => 'theModelClass',
+                                'provider' => null,
+                                'listener' => null,
+                                'finder' => null,
+                            ],
+                            'properties' => ['text' => null],
+                        ],
+                    ],
+                ],
+            ],
+            $container
+        );
+
+        // No custom repository service should be registered
+        $this->assertFalse($container->hasDefinition('fos_elastica.repository.acme_index'));
+
+        // ServiceLocator should be empty
+        $repositoryManagerDef = $container->getDefinition('fos_elastica.repository_manager');
+        $locatorDefinition = $repositoryManagerDef->getArgument(0);
+        $this->assertInstanceOf(Definition::class, $locatorDefinition);
+        $locatorArguments = $locatorDefinition->getArguments();
+        $this->assertEmpty($locatorArguments[0]);
     }
 }

--- a/tests/Unit/Manager/RepositoryManagerTest.php
+++ b/tests/Unit/Manager/RepositoryManagerTest.php
@@ -15,6 +15,7 @@ use FOS\ElasticaBundle\Finder\TransformedFinder;
 use FOS\ElasticaBundle\Manager\RepositoryManager;
 use FOS\ElasticaBundle\Repository;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\DependencyInjection\ServiceLocator;
 
 class CustomRepository extends Repository
 {
@@ -37,22 +38,47 @@ class RepositoryManagerTest extends TestCase
 
         $indexName = 'index';
 
-        $manager = new RepositoryManager();
+        $manager = new RepositoryManager(new ServiceLocator([]));
         $manager->addIndex($indexName, $finderMock);
         $repository = $manager->getRepository($indexName);
         $this->assertInstanceOf(Repository::class, $repository);
     }
 
-    public function testThatGetRepositoryReturnsCustomRepository()
+    public function testThatGetRepositoryReturnsCustomRepositoryFromLocator()
     {
         $finderMock = $this->createMock(TransformedFinder::class);
+        $customRepository = new CustomRepository($finderMock);
 
         $indexName = 'index';
 
-        $manager = new RepositoryManager();
+        $locator = new ServiceLocator([
+            $indexName => static fn () => $customRepository,
+        ]);
+
+        $manager = new RepositoryManager($locator);
         $manager->addIndex($indexName, $finderMock, CustomRepository::class);
         $repository = $manager->getRepository($indexName);
         $this->assertInstanceOf(CustomRepository::class, $repository);
+        $this->assertSame($customRepository, $repository);
+    }
+
+    public function testThatGetRepositoryReturnsCachedRepository()
+    {
+        $finderMock = $this->createMock(TransformedFinder::class);
+        $customRepository = new CustomRepository($finderMock);
+
+        $indexName = 'index';
+
+        $locator = new ServiceLocator([
+            $indexName => static fn () => $customRepository,
+        ]);
+
+        $manager = new RepositoryManager($locator);
+        $manager->addIndex($indexName, $finderMock, CustomRepository::class);
+
+        $first = $manager->getRepository($indexName);
+        $second = $manager->getRepository($indexName);
+        $this->assertSame($first, $second);
     }
 
     public function testThatGetRepositoryThrowsExceptionIfEntityNotConfigured()
@@ -61,23 +87,43 @@ class RepositoryManagerTest extends TestCase
 
         $indexName = 'index';
 
-        $manager = new RepositoryManager();
+        $manager = new RepositoryManager(new ServiceLocator([]));
         $manager->addIndex($indexName, $finderMock);
 
         $this->expectException(\RuntimeException::class);
         $manager->getRepository('Missing type');
     }
 
-    public function testThatGetRepositoryThrowsExceptionIfCustomRepositoryNotFound()
+    public function testThatLocatorIsPreferredOverDefaultRepository()
     {
         $finderMock = $this->createMock(TransformedFinder::class);
+        $customRepository = new CustomRepository($finderMock);
 
         $indexName = 'index';
 
-        $manager = new RepositoryManager();
-        $manager->addIndex($indexName, $finderMock, 'FOS\ElasticaBundle\Tests\MissingRepository');
+        $locator = new ServiceLocator([
+            $indexName => static fn () => $customRepository,
+        ]);
 
-        $this->expectException(\RuntimeException::class);
-        $manager->getRepository($indexName);
+        $manager = new RepositoryManager($locator);
+        // Even without specifying a custom repository name, locator takes precedence
+        $manager->addIndex($indexName, $finderMock);
+        $repository = $manager->getRepository($indexName);
+        $this->assertSame($customRepository, $repository);
+    }
+
+    public function testThatDefaultRepositoryIsReturnedWhenNotInLocator()
+    {
+        $finderMock = $this->createMock(TransformedFinder::class);
+
+        $locator = new ServiceLocator([
+            'other_index' => static fn () => new CustomRepository($finderMock),
+        ]);
+
+        $manager = new RepositoryManager($locator);
+        $manager->addIndex('my_index', $finderMock);
+        $repository = $manager->getRepository('my_index');
+        $this->assertInstanceOf(Repository::class, $repository);
+        $this->assertNotInstanceOf(CustomRepository::class, $repository);
     }
 }


### PR DESCRIPTION
Instead of constructing custom repositories with `new` in RepositoryManager, register them as autowired DI services and resolve them through a ServiceLocator. This allows custom repositories to have additional dependencies injected by the container.