### PR TITLE
Modernize codebase for PHP 8.1

### DIFF
--- a/src/Command/ConsoleProgressLogger.php
+++ b/src/Command/ConsoleProgressLogger.php
@@ -22,19 +22,13 @@ use Symfony\Component\Console\Output\OutputInterface;
 final class ConsoleProgressLogger
 {
     private ?ProgressBar $progress = null;
-    private OutputInterface $output;
-    private string $action;
-    private string $index;
-    private int $offset;
+    private readonly OutputInterface $output;
     private int $filteredCount = 0;
     private bool $finished = false;
 
-    public function __construct(OutputInterface $output, string $action, string $index, int $offset)
+    public function __construct(OutputInterface $output, private readonly string $action, private readonly string $index, private readonly int $offset)
     {
         $this->output = $output;
-        $this->action = $action;
-        $this->index = $index;
-        $this->offset = $offset;
     }
 
     public function call(int $increment, int $filteredIncrement, int $totalObjects, ?string $message = null): void
@@ -43,7 +37,7 @@ final class ConsoleProgressLogger
             return;
         }
 
-        if (null === $this->progress) {
+        if (!$this->progress instanceof ProgressBar) {
             $this->progress = new ProgressBar($this->output, $totalObjects);
             $this->progress->setMessage(\sprintf('<info>%s</info> <comment>%s</comment>', $this->action, $this->index));
             $this->progress->start();
@@ -68,7 +62,7 @@ final class ConsoleProgressLogger
     public function finish(): void
     {
         $this->finished = true;
-        if (!$this->progress) {
+        if (!$this->progress instanceof ProgressBar) {
             return;
         }
 

--- a/src/Command/ConsoleProgressLogger.php
+++ b/src/Command/ConsoleProgressLogger.php
@@ -22,13 +22,11 @@ use Symfony\Component\Console\Output\OutputInterface;
 final class ConsoleProgressLogger
 {
     private ?ProgressBar $progress = null;
-    private readonly OutputInterface $output;
     private int $filteredCount = 0;
     private bool $finished = false;
 
-    public function __construct(OutputInterface $output, private readonly string $action, private readonly string $index, private readonly int $offset)
+    public function __construct(private readonly OutputInterface $output, private readonly string $action, private readonly string $index, private readonly int $offset)
     {
-        $this->output = $output;
     }
 
     public function call(int $increment, int $filteredIncrement, int $totalObjects, ?string $message = null): void

--- a/src/Command/CreateCommand.php
+++ b/src/Command/CreateCommand.php
@@ -26,23 +26,13 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class CreateCommand extends Command
 {
-    private IndexManager $indexManager;
-    private MappingBuilder $mappingBuilder;
-    private ConfigManager $configManager;
-    private AliasProcessor $aliasProcessor;
-
     public function __construct(
-        IndexManager $indexManager,
-        MappingBuilder $mappingBuilder,
-        ConfigManager $configManager,
-        AliasProcessor $aliasProcessor,
+        private readonly IndexManager $indexManager,
+        private readonly MappingBuilder $mappingBuilder,
+        private readonly ConfigManager $configManager,
+        private readonly AliasProcessor $aliasProcessor,
     ) {
         parent::__construct();
-
-        $this->indexManager = $indexManager;
-        $this->mappingBuilder = $mappingBuilder;
-        $this->configManager = $configManager;
-        $this->aliasProcessor = $aliasProcessor;
     }
 
     protected function configure(): void
@@ -64,7 +54,7 @@ class CreateCommand extends Command
 
             $indexConfig = $this->configManager->getIndexConfiguration($indexName);
             if (!$indexConfig instanceof IndexConfig) {
-                throw new \RuntimeException(\sprintf('Incorrect index configuration object. Expecting IndexConfig, but got: %s ', \get_class($indexConfig)));
+                throw new \RuntimeException(\sprintf('Incorrect index configuration object. Expecting IndexConfig, but got: %s ', $indexConfig::class));
             }
             $index = $this->indexManager->getIndex($indexName);
             if ($indexConfig->isUseAlias()) {

--- a/src/Command/DeleteCommand.php
+++ b/src/Command/DeleteCommand.php
@@ -23,14 +23,10 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class DeleteCommand extends Command
 {
-    private IndexManager $indexManager;
-
     public function __construct(
-        IndexManager $indexManager,
+        private readonly IndexManager $indexManager,
     ) {
         parent::__construct();
-
-        $this->indexManager = $indexManager;
     }
 
     protected function configure(): void

--- a/src/Command/PopulateCommand.php
+++ b/src/Command/PopulateCommand.php
@@ -39,19 +39,16 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
  */
 class PopulateCommand extends Command
 {
-    private readonly EventDispatcherInterface $dispatcher;
     private PagerPersisterInterface $pagerPersister;
 
     public function __construct(
-        EventDispatcherInterface $dispatcher,
+        private readonly EventDispatcherInterface $dispatcher,
         private readonly IndexManager $indexManager,
         private readonly PagerProviderRegistry $pagerProviderRegistry,
         private readonly PagerPersisterRegistry $pagerPersisterRegistry,
         private readonly Resetter $resetter,
     ) {
         parent::__construct();
-
-        $this->dispatcher = $dispatcher;
     }
 
     protected function configure(): void

--- a/src/Command/PopulateCommand.php
+++ b/src/Command/PopulateCommand.php
@@ -39,27 +39,19 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
  */
 class PopulateCommand extends Command
 {
-    private EventDispatcherInterface $dispatcher;
-    private IndexManager $indexManager;
-    private PagerProviderRegistry $pagerProviderRegistry;
-    private PagerPersisterRegistry $pagerPersisterRegistry;
+    private readonly EventDispatcherInterface $dispatcher;
     private PagerPersisterInterface $pagerPersister;
-    private Resetter $resetter;
 
     public function __construct(
         EventDispatcherInterface $dispatcher,
-        IndexManager $indexManager,
-        PagerProviderRegistry $pagerProviderRegistry,
-        PagerPersisterRegistry $pagerPersisterRegistry,
-        Resetter $resetter,
+        private readonly IndexManager $indexManager,
+        private readonly PagerProviderRegistry $pagerProviderRegistry,
+        private readonly PagerPersisterRegistry $pagerPersisterRegistry,
+        private readonly Resetter $resetter,
     ) {
         parent::__construct();
 
         $this->dispatcher = $dispatcher;
-        $this->indexManager = $indexManager;
-        $this->pagerProviderRegistry = $pagerProviderRegistry;
-        $this->pagerPersisterRegistry = $pagerPersisterRegistry;
-        $this->resetter = $resetter;
     }
 
     protected function configure(): void
@@ -149,7 +141,7 @@ class PopulateCommand extends Command
 
         $this->dispatcher->addListener(
             OnExceptionEvent::class,
-            $exceptionListener = function (OnExceptionEvent $event) use ($consoleLogger) {
+            $exceptionListener = function (OnExceptionEvent $event) use ($consoleLogger): void {
                 $consoleLogger->call(
                     \count($event->getObjects()),
                     0,
@@ -161,7 +153,7 @@ class PopulateCommand extends Command
 
         $this->dispatcher->addListener(
             PostInsertObjectsEvent::class,
-            $postInsertListener = function (PostInsertObjectsEvent $event) use ($consoleLogger) {
+            $postInsertListener = function (PostInsertObjectsEvent $event) use ($consoleLogger): void {
                 $consoleLogger->call(\count($event->getObjects()), $event->getFilteredObjectCount(), $event->getPager()->getNbResults());
             }
         );
@@ -169,7 +161,7 @@ class PopulateCommand extends Command
         if ($options['ignore_errors']) {
             $this->dispatcher->addListener(
                 OnExceptionEvent::class,
-                $ignoreExceptionsListener = function (OnExceptionEvent $event) {
+                $ignoreExceptionsListener = function (OnExceptionEvent $event): void {
                     if ($event->getException() instanceof BulkResponseException) {
                         $event->setIgnored(true);
                     }

--- a/src/Command/ResetCommand.php
+++ b/src/Command/ResetCommand.php
@@ -23,17 +23,11 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class ResetCommand extends Command
 {
-    private IndexManager $indexManager;
-    private Resetter $resetter;
-
     public function __construct(
-        IndexManager $indexManager,
-        Resetter $resetter,
+        private readonly IndexManager $indexManager,
+        private readonly Resetter $resetter,
     ) {
         parent::__construct();
-
-        $this->indexManager = $indexManager;
-        $this->resetter = $resetter;
     }
 
     protected function configure(): void

--- a/src/Command/ResetTemplatesCommand.php
+++ b/src/Command/ResetTemplatesCommand.php
@@ -24,14 +24,10 @@ use Symfony\Component\Console\Question\ConfirmationQuestion;
  */
 final class ResetTemplatesCommand extends Command
 {
-    private TemplateResetter $resetter;
-
     public function __construct(
-        TemplateResetter $resetter,
+        private readonly TemplateResetter $resetter,
     ) {
         parent::__construct();
-
-        $this->resetter = $resetter;
     }
 
     protected function configure(): void

--- a/src/Command/SearchCommand.php
+++ b/src/Command/SearchCommand.php
@@ -25,13 +25,9 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class SearchCommand extends Command
 {
-    private IndexManager $indexManager;
-
-    public function __construct(IndexManager $indexManager)
+    public function __construct(private readonly IndexManager $indexManager)
     {
         parent::__construct();
-
-        $this->indexManager = $indexManager;
     }
 
     protected function configure(): void
@@ -80,11 +76,7 @@ class SearchCommand extends Command
     protected function formatResult(Result $result, $showField, $showSource, $showId, $explain)
     {
         $source = $result->getSource();
-        if ($showField) {
-            $toString = $source[$showField] ?? '-';
-        } else {
-            $toString = \reset($source);
-        }
+        $toString = $showField ? $source[$showField] ?? '-' : \reset($source);
         $string = \sprintf('[%0.2f] %s', $result->getScore(), \var_export($toString, true));
         if ($showSource) {
             $string = \sprintf('%s %s', $string, \json_encode($source));
@@ -93,7 +85,7 @@ class SearchCommand extends Command
             $string = \sprintf('{%s} %s', $result->getId(), $string);
         }
         if ($explain) {
-            $string = \sprintf('%s %s', $string, \json_encode($result->getExplanation()));
+            return \sprintf('%s %s', $string, \json_encode($result->getExplanation()));
         }
 
         return $string;

--- a/src/Command/SearchCommand.php
+++ b/src/Command/SearchCommand.php
@@ -70,10 +70,8 @@ class SearchCommand extends Command
      * @param string $showSource
      * @param string $showId
      * @param string $explain
-     *
-     * @return string
      */
-    protected function formatResult(Result $result, $showField, $showSource, $showId, $explain)
+    protected function formatResult(Result $result, $showField, $showSource, $showId, $explain): string
     {
         $source = $result->getSource();
         $toString = $showField ? $source[$showField] ?? '-' : \reset($source);

--- a/src/Configuration/ConfigManager.php
+++ b/src/Configuration/ConfigManager.php
@@ -21,7 +21,7 @@ class ConfigManager implements ManagerInterface
      *
      * @phpstan-var array<string, IndexConfigInterface>
      */
-    private $indexes = [];
+    private array $indexes = [];
 
     /**
      * @param Source\SourceInterface[] $sources

--- a/src/Configuration/IndexConfigInterface.php
+++ b/src/Configuration/IndexConfigInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the FOSElasticaBundle package.
  *

--- a/src/Configuration/IndexConfigInterface.php
+++ b/src/Configuration/IndexConfigInterface.php
@@ -70,9 +70,7 @@ interface IndexConfigInterface
     public function getNumericDetection(): ?bool;
 
     /**
-     * @return string|bool|null
-     *
      * @phpstan-return ?TDynamic
      */
-    public function getDynamic();
+    public function getDynamic(): string|bool|null;
 }

--- a/src/Configuration/IndexConfigTrait.php
+++ b/src/Configuration/IndexConfigTrait.php
@@ -113,7 +113,7 @@ trait IndexConfigTrait
         return $this->config['numeric_detection'] ?? null;
     }
 
-    public function getDynamic()
+    public function getDynamic(): string|bool|null
     {
         return $this->config['dynamic'] ?? null;
     }

--- a/src/Configuration/IndexTemplateConfig.php
+++ b/src/Configuration/IndexTemplateConfig.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the FOSElasticaBundle package.
  *

--- a/src/Configuration/ManagerInterface.php
+++ b/src/Configuration/ManagerInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the FOSElasticaBundle package.
  *

--- a/src/Configuration/Source/ContainerSource.php
+++ b/src/Configuration/Source/ContainerSource.php
@@ -22,20 +22,16 @@ use FOS\ElasticaBundle\Configuration\IndexConfigInterface;
 class ContainerSource implements SourceInterface
 {
     /**
-     * The internal container representation of information.
-     *
-     * @var array
-     *
-     * @phpstan-var list<TConfig>
-     */
-    private $configArray;
-
-    /**
      * @param list<TConfig> $configArray
      */
-    public function __construct(array $configArray)
-    {
-        $this->configArray = $configArray;
+    public function __construct(
+        /**
+         * The internal container representation of information.
+         *
+         * @phpstan-var list<TConfig>
+         */
+        private readonly array $configArray
+    ) {
     }
 
     /**

--- a/src/Configuration/Source/SourceInterface.php
+++ b/src/Configuration/Source/SourceInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the FOSElasticaBundle package.
  *

--- a/src/Configuration/Source/TemplateContainerSource.php
+++ b/src/Configuration/Source/TemplateContainerSource.php
@@ -22,20 +22,16 @@ use FOS\ElasticaBundle\Configuration\IndexTemplateConfig;
 class TemplateContainerSource implements SourceInterface
 {
     /**
-     * The internal container representation of information.
-     *
-     * @var array
-     *
-     * @phpstan-var list<TConfig>
-     */
-    private $configArray;
-
-    /**
      * @param list<TConfig> $configArray
      */
-    public function __construct(array $configArray)
-    {
-        $this->configArray = $configArray;
+    public function __construct(
+        /**
+         * The internal container representation of information.
+         *
+         * @phpstan-var list<TConfig>
+         */
+        private readonly array $configArray
+    ) {
     }
 
     /**

--- a/src/Configuration/TypeConfig.php
+++ b/src/Configuration/TypeConfig.php
@@ -20,34 +20,21 @@ namespace FOS\ElasticaBundle\Configuration;
 class TypeConfig
 {
     /**
-     * @var array
-     *
-     * @phpstan-var TElasticConfig
-     */
-    private $config;
-
-    /**
-     * @var array
-     *
-     * @phpstan-var TMapping
-     */
-    private $mapping;
-
-    /**
-     * @var string
-     */
-    private $name;
-
-    /**
      * @param TMapping $mapping
      *
      * @phpstan-param TElasticConfig $config
      */
-    public function __construct(string $name, array $mapping, array $config = [])
-    {
-        $this->config = $config;
-        $this->mapping = $mapping;
-        $this->name = $name;
+    public function __construct(
+        private readonly string $name,
+        /**
+         * @phpstan-var TMapping
+         */
+        private readonly array $mapping,
+        /**
+         * @phpstan-var TElasticConfig
+         */
+        private array $config = []
+    ) {
     }
 
     public function getDateDetection(): ?bool

--- a/src/Configuration/TypeConfig.php
+++ b/src/Configuration/TypeConfig.php
@@ -76,7 +76,7 @@ class TypeConfig
     /**
      * @phpstan-return ?TDynamic
      */
-    public function getDynamic()
+    public function getDynamic(): string|bool|null
     {
         return $this->config['dynamic'] ?? null;
     }

--- a/src/DataCollector/ElasticaDataCollector.php
+++ b/src/DataCollector/ElasticaDataCollector.php
@@ -33,12 +33,12 @@ class ElasticaDataCollector extends DataCollector
         $this->data['queries'] = $this->logger->getQueries();
     }
 
-    public function getQueryCount()
+    public function getQueryCount(): int
     {
         return $this->data['nb_queries'];
     }
 
-    public function getQueries()
+    public function getQueries(): array
     {
         return $this->data['queries'];
     }
@@ -46,7 +46,7 @@ class ElasticaDataCollector extends DataCollector
     /**
      * @return int
      */
-    public function getTime()
+    public function getTime(): int|float
     {
         $time = 0;
         foreach ($this->data['queries'] as $query) {
@@ -59,7 +59,7 @@ class ElasticaDataCollector extends DataCollector
     /**
      * @return int
      */
-    public function getExecutionTime()
+    public function getExecutionTime(): int|float
     {
         $time = 0;
         foreach ($this->data['queries'] as $query) {

--- a/src/DataCollector/ElasticaDataCollector.php
+++ b/src/DataCollector/ElasticaDataCollector.php
@@ -23,11 +23,8 @@ use Symfony\Component\HttpKernel\DataCollector\DataCollector;
  */
 class ElasticaDataCollector extends DataCollector
 {
-    protected ElasticaLogger $logger;
-
-    public function __construct(ElasticaLogger $logger)
+    public function __construct(protected ElasticaLogger $logger)
     {
-        $this->logger = $logger;
     }
 
     public function collect(Request $request, Response $response, ?\Throwable $exception = null): void

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -94,7 +94,7 @@ class Configuration implements ConfigurationInterface
                     ->end()
                 ->end()
                 ->validate()
-                    ->ifTrue(static fn (array $v) => 1 !== \count($v))
+                    ->ifTrue(static fn (array $v): bool => 1 !== \count($v))
                     ->thenInvalid('Dynamic template should consist of a single named object: %s.')
                 ->end()
             ->end()
@@ -178,16 +178,13 @@ class Configuration implements ConfigurationInterface
         return $node;
     }
 
-    /**
-     * @return ArrayNodeDefinition
-     */
-    private function getPersistenceNode()
+    private function getPersistenceNode(): ArrayNodeDefinition
     {
         $node = $this->createTreeBuilderNode('persistence');
 
         $node
             ->validate()
-                ->ifTrue(fn (array $v) => isset($v['driver']) && 'orm' !== $v['driver'] && !empty($v['elastica_to_model_transformer']['hints']))
+                ->ifTrue(fn (array $v): bool => isset($v['driver']) && 'orm' !== $v['driver'] && !empty($v['elastica_to_model_transformer']['hints']))
                     ->thenInvalid('Hints are only supported by the "orm" driver')
             ->end()
             ->children()
@@ -280,10 +277,7 @@ class Configuration implements ConfigurationInterface
         return $node;
     }
 
-    /**
-     * @return ArrayNodeDefinition
-     */
-    private function getSerializerNode()
+    private function getSerializerNode(): ArrayNodeDefinition
     {
         $node = $this->createTreeBuilderNode('serializer');
 
@@ -323,8 +317,8 @@ class Configuration implements ConfigurationInterface
                                 ->requiresAtLeastOneElement()
                                 ->prototype('scalar')
                                     ->validate()
-                                    ->ifTrue(fn (mixed $url) => $url && !\str_ends_with((string) $url, '/'))
-                                    ->then(fn (mixed $url) => $url.'/')
+                                    ->ifTrue(fn (mixed $url): bool => $url && !\str_ends_with((string) $url, '/'))
+                                    ->then(fn (mixed $url): string => $url.'/')
                                     ->end()
                                 ->end()
                             ->end()
@@ -336,8 +330,8 @@ class Configuration implements ConfigurationInterface
                             ->scalarNode('api_key')->end()
                             ->arrayNode('http_error_codes')
                                 ->beforeNormalization()
-                                    ->ifTrue(fn (mixed $v) => !\is_array($v))
-                                    ->then(fn (mixed $v) => [$v])
+                                    ->ifTrue(fn (mixed $v): bool => !\is_array($v))
+                                    ->then(fn (mixed $v): array => [$v])
                                 ->end()
                                 ->requiresAtLeastOneElement()
                                 ->defaultValue([400, 403])
@@ -433,7 +427,7 @@ class Configuration implements ConfigurationInterface
     /**
      * @return ArrayNodeDefinition
      */
-    private function createTreeBuilderNode(string $name)
+    private function createTreeBuilderNode(string $name): \Symfony\Component\Config\Definition\Builder\NodeDefinition
     {
         return (new TreeBuilder($name))->getRootNode();
     }
@@ -457,8 +451,8 @@ class Configuration implements ConfigurationInterface
                         // Support multiple dynamic_template formats to match the old bundle style
                         // and the way ElasticSearch expects them
                         ->beforeNormalization()
-                        ->ifTrue(fn (array $v) => isset($v['dynamic_templates']))
-                        ->then(function (array $v) {
+                        ->ifTrue(fn (array $v): bool => isset($v['dynamic_templates']))
+                        ->then(function (array $v): array {
                             $dt = [];
                             foreach ($v['dynamic_templates'] as $key => $type) {
                                 if (\is_int($key)) {

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -94,7 +94,7 @@ class Configuration implements ConfigurationInterface
                     ->end()
                 ->end()
                 ->validate()
-                    ->ifTrue(static fn ($v) => 1 !== \count($v))
+                    ->ifTrue(static fn (array $v) => 1 !== \count($v))
                     ->thenInvalid('Dynamic template should consist of a single named object: %s.')
                 ->end()
             ->end()
@@ -187,7 +187,7 @@ class Configuration implements ConfigurationInterface
 
         $node
             ->validate()
-                ->ifTrue(fn ($v) => isset($v['driver']) && 'orm' !== $v['driver'] && !empty($v['elastica_to_model_transformer']['hints']))
+                ->ifTrue(fn (array $v) => isset($v['driver']) && 'orm' !== $v['driver'] && !empty($v['elastica_to_model_transformer']['hints']))
                     ->thenInvalid('Hints are only supported by the "orm" driver')
             ->end()
             ->children()
@@ -323,8 +323,8 @@ class Configuration implements ConfigurationInterface
                                 ->requiresAtLeastOneElement()
                                 ->prototype('scalar')
                                     ->validate()
-                                    ->ifTrue(fn ($url) => $url && !\str_ends_with((string) $url, '/'))
-                                    ->then(fn ($url) => $url.'/')
+                                    ->ifTrue(fn (mixed $url) => $url && !\str_ends_with((string) $url, '/'))
+                                    ->then(fn (mixed $url) => $url.'/')
                                     ->end()
                                 ->end()
                             ->end()
@@ -336,8 +336,8 @@ class Configuration implements ConfigurationInterface
                             ->scalarNode('api_key')->end()
                             ->arrayNode('http_error_codes')
                                 ->beforeNormalization()
-                                    ->ifTrue(fn ($v) => !\is_array($v))
-                                    ->then(fn ($v) => [$v])
+                                    ->ifTrue(fn (mixed $v) => !\is_array($v))
+                                    ->then(fn (mixed $v) => [$v])
                                 ->end()
                                 ->requiresAtLeastOneElement()
                                 ->defaultValue([400, 403])
@@ -457,7 +457,7 @@ class Configuration implements ConfigurationInterface
                         // Support multiple dynamic_template formats to match the old bundle style
                         // and the way ElasticSearch expects them
                         ->beforeNormalization()
-                        ->ifTrue(fn ($v) => isset($v['dynamic_templates']))
+                        ->ifTrue(fn (array $v) => isset($v['dynamic_templates']))
                         ->then(function (array $v) {
                             $dt = [];
                             foreach ($v['dynamic_templates'] as $key => $type) {

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -21,14 +21,12 @@ class Configuration implements ConfigurationInterface
 {
     private const SUPPORTED_DRIVERS = ['orm', 'mongodb', 'phpcr'];
 
-    /**
-     * If the kernel is running in debug mode.
-     */
-    private bool $debug;
-
-    public function __construct(bool $debug)
-    {
-        $this->debug = $debug;
+    public function __construct(
+        /**
+         * If the kernel is running in debug mode.
+         */
+        private readonly bool $debug
+    ) {
     }
 
     /**
@@ -96,9 +94,7 @@ class Configuration implements ConfigurationInterface
                     ->end()
                 ->end()
                 ->validate()
-                    ->ifTrue(static function ($v) {
-                        return 1 !== \count($v);
-                    })
+                    ->ifTrue(static fn ($v) => 1 !== \count($v))
                     ->thenInvalid('Dynamic template should consist of a single named object: %s.')
                 ->end()
             ->end()
@@ -191,9 +187,7 @@ class Configuration implements ConfigurationInterface
 
         $node
             ->validate()
-                ->ifTrue(function ($v) {
-                    return isset($v['driver']) && 'orm' !== $v['driver'] && !empty($v['elastica_to_model_transformer']['hints']);
-                })
+                ->ifTrue(fn ($v) => isset($v['driver']) && 'orm' !== $v['driver'] && !empty($v['elastica_to_model_transformer']['hints']))
                     ->thenInvalid('Hints are only supported by the "orm" driver')
             ->end()
             ->children()
@@ -329,12 +323,8 @@ class Configuration implements ConfigurationInterface
                                 ->requiresAtLeastOneElement()
                                 ->prototype('scalar')
                                     ->validate()
-                                    ->ifTrue(function ($url) {
-                                        return $url && !\str_ends_with($url, '/');
-                                    })
-                                    ->then(function ($url) {
-                                        return $url.'/';
-                                    })
+                                    ->ifTrue(fn ($url) => $url && !\str_ends_with((string) $url, '/'))
+                                    ->then(fn ($url) => $url.'/')
                                     ->end()
                                 ->end()
                             ->end()
@@ -346,8 +336,8 @@ class Configuration implements ConfigurationInterface
                             ->scalarNode('api_key')->end()
                             ->arrayNode('http_error_codes')
                                 ->beforeNormalization()
-                                    ->ifTrue(function ($v) { return !\is_array($v); })
-                                    ->then(function ($v) { return [$v]; })
+                                    ->ifTrue(fn ($v) => !\is_array($v))
+                                    ->then(fn ($v) => [$v])
                                 ->end()
                                 ->requiresAtLeastOneElement()
                                 ->defaultValue([400, 403])
@@ -450,10 +440,8 @@ class Configuration implements ConfigurationInterface
 
     /**
      * Adds the configuration for the "index_templates" key.
-     *
-     * @return void
      */
-    private function addIndexTemplatesSection(ArrayNodeDefinition $rootNode)
+    private function addIndexTemplatesSection(ArrayNodeDefinition $rootNode): void
     {
         $rootNode
             ->fixXmlConfig('index_template')
@@ -469,10 +457,8 @@ class Configuration implements ConfigurationInterface
                         // Support multiple dynamic_template formats to match the old bundle style
                         // and the way ElasticSearch expects them
                         ->beforeNormalization()
-                        ->ifTrue(function ($v) {
-                            return isset($v['dynamic_templates']);
-                        })
-                        ->then(function ($v) {
+                        ->ifTrue(fn ($v) => isset($v['dynamic_templates']))
+                        ->then(function (array $v) {
                             $dt = [];
                             foreach ($v['dynamic_templates'] as $key => $type) {
                                 if (\is_int($key)) {

--- a/src/DependencyInjection/FOSElasticaExtension.php
+++ b/src/DependencyInjection/FOSElasticaExtension.php
@@ -42,25 +42,21 @@ class FOSElasticaExtension extends Extension
      *
      * @var array<string, array{id: string, reference: Reference}>
      */
-    private $clients = [];
+    private array $clients = [];
 
     /**
      * An array of indexes as configured by the extension.
      *
-     * @var array
-     *
      * @phpstan-var array<string, TIndexConfig>
      */
-    private $indexConfigs = [];
+    private array $indexConfigs = [];
 
     /**
      * An array of index templates as configured by the extension.
      *
-     * @var array
-     *
      * @phpstan-var array<string, TIndexTemplateConfig>
      */
-    private $indexTemplateConfigs = [];
+    private array $indexTemplateConfigs = [];
 
     /**
      * If we've encountered a type mapped to a specific persistence driver, it will be loaded
@@ -68,7 +64,7 @@ class FOSElasticaExtension extends Extension
      *
      * @var list<string>
      */
-    private $loadedDrivers = [];
+    private array $loadedDrivers = [];
 
     /**
      * Custom repository service references keyed by index name.
@@ -397,7 +393,7 @@ class FOSElasticaExtension extends Extension
         }
     }
 
-    private function buildCallback($indexCallback, $indexName)
+    private function buildCallback($indexCallback, int|string $indexName)
     {
         if (\is_array($indexCallback)) {
             if (!isset($indexCallback[0])) {
@@ -425,7 +421,7 @@ class FOSElasticaExtension extends Extension
 
     private function transformServiceReference($classOrService)
     {
-        return 0 === \strpos($classOrService, '@') ? new Reference(\substr($classOrService, 1)) : $classOrService;
+        return \str_starts_with((string) $classOrService, '@') ? new Reference(\substr((string) $classOrService, 1)) : $classOrService;
     }
 
     private function loadIndexSerializerIntegration(array $config, ContainerBuilder $container, Reference $indexRef): void
@@ -664,22 +660,17 @@ class FOSElasticaExtension extends Extension
 
     /**
      * Map Elastica to Doctrine events for the current driver.
+     *
+     * @return mixed[]
      */
-    private function getDoctrineEvents(array $indexConfig)
+    private function getDoctrineEvents(array $indexConfig): array
     {
-        switch ($indexConfig['driver']) {
-            case 'orm':
-                $eventsClass = '\Doctrine\ORM\Events';
-                break;
-            case 'phpcr':
-                $eventsClass = '\Doctrine\ODM\PHPCR\Event';
-                break;
-            case 'mongodb':
-                $eventsClass = '\Doctrine\ODM\MongoDB\Events';
-                break;
-            default:
-                throw new \InvalidArgumentException(\sprintf('Cannot determine events for driver "%s"', $indexConfig['driver']));
-        }
+        $eventsClass = match ($indexConfig['driver']) {
+            'orm' => '\Doctrine\ORM\Events',
+            'phpcr' => '\Doctrine\ODM\PHPCR\Event',
+            'mongodb' => '\Doctrine\ODM\MongoDB\Events',
+            default => throw new \InvalidArgumentException(\sprintf('Cannot determine events for driver "%s"', $indexConfig['driver'])),
+        };
 
         $events = [];
         $eventMapping = [
@@ -749,9 +740,7 @@ class FOSElasticaExtension extends Extension
      */
     private function loadIndexManager(ContainerBuilder $container): void
     {
-        $indexRefs = \array_map(static function ($index) {
-            return $index['reference'];
-        }, $this->indexConfigs);
+        $indexRefs = \array_map(static fn (array $index) => $index['reference'], $this->indexConfigs);
 
         $managerDef = $container->getDefinition('fos_elastica.index_manager');
         $managerDef->replaceArgument(0, $indexRefs);
@@ -762,9 +751,7 @@ class FOSElasticaExtension extends Extension
      */
     private function loadIndexTemplateManager(ContainerBuilder $container): void
     {
-        $indexTemplateRefs = \array_map(static function ($index) {
-            return $index['reference'];
-        }, $this->indexTemplateConfigs);
+        $indexTemplateRefs = \array_map(static fn (array $index) => $index['reference'], $this->indexTemplateConfigs);
 
         $managerDef = $container->getDefinition('fos_elastica.index_template_manager');
         $managerDef->replaceArgument(0, $indexTemplateRefs);
@@ -806,7 +793,7 @@ class FOSElasticaExtension extends Extension
      */
     private function createDefaultManagerAlias(string $defaultManager, ContainerBuilder $container): void
     {
-        if (0 == \count($this->loadedDrivers)) {
+        if (0 === \count($this->loadedDrivers)) {
             return;
         }
 

--- a/src/DependencyInjection/FOSElasticaExtension.php
+++ b/src/DependencyInjection/FOSElasticaExtension.php
@@ -393,7 +393,7 @@ class FOSElasticaExtension extends Extension
         }
     }
 
-    private function buildCallback($indexCallback, int|string $indexName)
+    private function buildCallback(mixed $indexCallback, int|string $indexName): Reference|array|string
     {
         if (\is_array($indexCallback)) {
             if (!isset($indexCallback[0])) {
@@ -419,7 +419,7 @@ class FOSElasticaExtension extends Extension
         throw new \InvalidArgumentException(\sprintf('Invalid indexable_callback for index "%s"', $indexName));
     }
 
-    private function transformServiceReference($classOrService)
+    private function transformServiceReference(mixed $classOrService): mixed
     {
         return \str_starts_with((string) $classOrService, '@') ? new Reference(\substr((string) $classOrService, 1)) : $classOrService;
     }
@@ -666,9 +666,9 @@ class FOSElasticaExtension extends Extension
     private function getDoctrineEvents(array $indexConfig): array
     {
         $eventsClass = match ($indexConfig['driver']) {
-            'orm' => '\Doctrine\ORM\Events',
-            'phpcr' => '\Doctrine\ODM\PHPCR\Event',
-            'mongodb' => '\Doctrine\ODM\MongoDB\Events',
+            'orm' => \Doctrine\ORM\Events::class,
+            'phpcr' => \Doctrine\ODM\PHPCR\Event::class,
+            'mongodb' => \Doctrine\ODM\MongoDB\Events::class,
             default => throw new \InvalidArgumentException(\sprintf('Cannot determine events for driver "%s"', $indexConfig['driver'])),
         };
 
@@ -740,7 +740,7 @@ class FOSElasticaExtension extends Extension
      */
     private function loadIndexManager(ContainerBuilder $container): void
     {
-        $indexRefs = \array_map(static fn (array $index) => $index['reference'], $this->indexConfigs);
+        $indexRefs = \array_map(static fn (array $index): mixed => $index['reference'], $this->indexConfigs);
 
         $managerDef = $container->getDefinition('fos_elastica.index_manager');
         $managerDef->replaceArgument(0, $indexRefs);
@@ -751,7 +751,7 @@ class FOSElasticaExtension extends Extension
      */
     private function loadIndexTemplateManager(ContainerBuilder $container): void
     {
-        $indexTemplateRefs = \array_map(static fn (array $index) => $index['reference'], $this->indexTemplateConfigs);
+        $indexTemplateRefs = \array_map(static fn (array $index): mixed => $index['reference'], $this->indexTemplateConfigs);
 
         $managerDef = $container->getDefinition('fos_elastica.index_template_manager');
         $managerDef->replaceArgument(0, $indexTemplateRefs);

--- a/src/Doctrine/AbstractElasticaToModelTransformer.php
+++ b/src/Doctrine/AbstractElasticaToModelTransformer.php
@@ -30,13 +30,6 @@ abstract class AbstractElasticaToModelTransformer extends BaseTransformer
     protected ManagerRegistry $registry;
 
     /**
-     * Class of the model to map to the elastica documents.
-     *
-     * @phpstan-var class-string
-     */
-    protected string $objectClass;
-
-    /**
      * Optional parameters.
      */
     protected array $options = [
@@ -50,10 +43,14 @@ abstract class AbstractElasticaToModelTransformer extends BaseTransformer
     /**
      * Instantiates a new Mapper.
      */
-    public function __construct(ManagerRegistry $registry, string $objectClass, array $options = [])
+    public function __construct(ManagerRegistry $registry, /**
+     * Class of the model to map to the elastica documents.
+     *
+     * @phpstan-var class-string
+     */
+        protected string $objectClass, array $options = [])
     {
         $this->registry = $registry;
-        $this->objectClass = $objectClass;
         $this->options = \array_merge($this->options, $options);
     }
 
@@ -89,9 +86,7 @@ abstract class AbstractElasticaToModelTransformer extends BaseTransformer
         $propertyAccessor = $this->propertyAccessor;
         $identifier = $this->options['identifier'];
         if (!$this->options['ignore_missing'] && $objectsCnt < $elasticaObjectsCnt) {
-            $missingIds = \array_diff($ids, \array_map(static function ($object) use ($propertyAccessor, $identifier) {
-                return $propertyAccessor->getValue($object, $identifier);
-            }, $objects));
+            $missingIds = \array_diff($ids, \array_map(static fn ($object) => $propertyAccessor->getValue($object, $identifier), $objects));
 
             throw new \RuntimeException(\sprintf('Cannot find corresponding Doctrine objects (%d) for all Elastica results (%d). Missing IDs: %s. IDs: %s', $objectsCnt, $elasticaObjectsCnt, \implode(', ', $missingIds), \implode(', ', $ids)));
         }
@@ -107,7 +102,7 @@ abstract class AbstractElasticaToModelTransformer extends BaseTransformer
         $idPos = \array_flip($ids);
         \usort(
             $objects,
-            function ($a, $b) use ($idPos, $identifier, $propertyAccessor) {
+            function ($a, $b) use ($idPos, $identifier, $propertyAccessor): int {
                 if ($this->options['hydrate']) {
                     return $idPos[(string) $propertyAccessor->getValue(
                         $a,

--- a/src/Doctrine/AbstractElasticaToModelTransformer.php
+++ b/src/Doctrine/AbstractElasticaToModelTransformer.php
@@ -25,11 +25,6 @@ use FOS\ElasticaBundle\Transformer\HighlightableModelInterface;
 abstract class AbstractElasticaToModelTransformer extends BaseTransformer
 {
     /**
-     * Manager registry.
-     */
-    protected ManagerRegistry $registry;
-
-    /**
      * Optional parameters.
      */
     protected array $options = [
@@ -43,14 +38,17 @@ abstract class AbstractElasticaToModelTransformer extends BaseTransformer
     /**
      * Instantiates a new Mapper.
      */
-    public function __construct(ManagerRegistry $registry, /**
+    public function __construct(/**
+     * Manager registry.
+     */
+        protected ManagerRegistry $registry, /**
      * Class of the model to map to the elastica documents.
      *
      * @phpstan-var class-string
      */
-        protected string $objectClass, array $options = [])
-    {
-        $this->registry = $registry;
+        protected string $objectClass,
+        array $options = []
+    ) {
         $this->options = \array_merge($this->options, $options);
     }
 
@@ -68,11 +66,9 @@ abstract class AbstractElasticaToModelTransformer extends BaseTransformer
      *
      * @param Result[] $elasticaObjects of elastica objects
      *
-     * @return array
-     *
      * @throws \RuntimeException
      */
-    public function transform(array $elasticaObjects)
+    public function transform(array $elasticaObjects): array
     {
         $ids = $highlights = [];
         foreach ($elasticaObjects as $elasticaObject) {
@@ -86,7 +82,7 @@ abstract class AbstractElasticaToModelTransformer extends BaseTransformer
         $propertyAccessor = $this->propertyAccessor;
         $identifier = $this->options['identifier'];
         if (!$this->options['ignore_missing'] && $objectsCnt < $elasticaObjectsCnt) {
-            $missingIds = \array_diff($ids, \array_map(static fn (array|object $object) => $propertyAccessor->getValue($object, $identifier), $objects));
+            $missingIds = \array_diff($ids, \array_map(static fn (array|object $object): mixed => $propertyAccessor->getValue($object, $identifier), $objects));
 
             throw new \RuntimeException(\sprintf('Cannot find corresponding Doctrine objects (%d) for all Elastica results (%d). Missing IDs: %s. IDs: %s', $objectsCnt, $elasticaObjectsCnt, \implode(', ', $missingIds), \implode(', ', $ids)));
         }
@@ -117,7 +113,7 @@ abstract class AbstractElasticaToModelTransformer extends BaseTransformer
         return $objects;
     }
 
-    public function hybridTransform(array $elasticaObjects)
+    public function hybridTransform(array $elasticaObjects): array
     {
         $indexedElasticaResults = [];
         foreach ($elasticaObjects as $elasticaObject) {
@@ -152,5 +148,5 @@ abstract class AbstractElasticaToModelTransformer extends BaseTransformer
      *
      * @return array of objects or arrays
      */
-    abstract protected function findByIdentifiers(array $identifierValues, bool $hydrate);
+    abstract protected function findByIdentifiers(array $identifierValues, bool $hydrate): array;
 }

--- a/src/Doctrine/AbstractElasticaToModelTransformer.php
+++ b/src/Doctrine/AbstractElasticaToModelTransformer.php
@@ -86,7 +86,7 @@ abstract class AbstractElasticaToModelTransformer extends BaseTransformer
         $propertyAccessor = $this->propertyAccessor;
         $identifier = $this->options['identifier'];
         if (!$this->options['ignore_missing'] && $objectsCnt < $elasticaObjectsCnt) {
-            $missingIds = \array_diff($ids, \array_map(static fn ($object) => $propertyAccessor->getValue($object, $identifier), $objects));
+            $missingIds = \array_diff($ids, \array_map(static fn (array|object $object) => $propertyAccessor->getValue($object, $identifier), $objects));
 
             throw new \RuntimeException(\sprintf('Cannot find corresponding Doctrine objects (%d) for all Elastica results (%d). Missing IDs: %s. IDs: %s', $objectsCnt, $elasticaObjectsCnt, \implode(', ', $missingIds), \implode(', ', $ids)));
         }
@@ -102,7 +102,7 @@ abstract class AbstractElasticaToModelTransformer extends BaseTransformer
         $idPos = \array_flip($ids);
         \usort(
             $objects,
-            function ($a, $b) use ($idPos, $identifier, $propertyAccessor): int {
+            function (array|object $a, array|object $b) use ($idPos, $identifier, $propertyAccessor): int {
                 if ($this->options['hydrate']) {
                     return $idPos[(string) $propertyAccessor->getValue(
                         $a,

--- a/src/Doctrine/ConditionalUpdate.php
+++ b/src/Doctrine/ConditionalUpdate.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the FOSElasticaBundle package.
  *

--- a/src/Doctrine/Listener.php
+++ b/src/Doctrine/Listener.php
@@ -39,10 +39,6 @@ class Listener
      * IDs of objects scheduled for removal.
      */
     public array $scheduledForDeletion = [];
-    /**
-     * Object persister.
-     */
-    protected ObjectPersisterInterface $objectPersister;
 
     /**
      * PropertyAccessor instance.
@@ -54,11 +50,12 @@ class Listener
      */
     private array $config;
 
-    private IndexableInterface $indexable;
-
     public function __construct(
-        ObjectPersisterInterface $objectPersister,
-        IndexableInterface $indexable,
+        /**
+         * Object persister.
+         */
+        protected ObjectPersisterInterface $objectPersister,
+        private readonly IndexableInterface $indexable,
         array $config = [],
         ?LoggerInterface $logger = null,
     ) {
@@ -66,8 +63,6 @@ class Listener
             'identifier' => 'id',
             'defer' => false,
         ], $config);
-        $this->indexable = $indexable;
-        $this->objectPersister = $objectPersister;
         $this->propertyAccessor = PropertyAccess::createPropertyAccessor();
 
         if ($logger && $this->objectPersister instanceof ObjectPersister) {
@@ -79,7 +74,7 @@ class Listener
      * Handler for the "kernel.terminate" and "console.terminate" Symfony events.
      * These event are subscribed to if the listener is configured to persist asynchronously.
      */
-    public function onTerminate()
+    public function onTerminate(): void
     {
         if ($this->config['defer']) {
             $this->config['defer'] = false;
@@ -91,21 +86,19 @@ class Listener
     /**
      * Looks for new objects that should be indexed.
      */
-    public function postPersist(LifecycleEventArgs $eventArgs)
+    public function postPersist(LifecycleEventArgs $eventArgs): void
     {
         $entity = $eventArgs->getObject();
 
-        if ($this->objectPersister->handlesObject($entity) && $this->isObjectIndexable($entity)) {
-            if (!$entity instanceof ConditionalUpdate || $entity->shouldBeUpdated()) {
-                $this->scheduledForInsertion[] = $entity;
-            }
+        if ($this->objectPersister->handlesObject($entity) && $this->isObjectIndexable($entity) && (!$entity instanceof ConditionalUpdate || $entity->shouldBeUpdated())) {
+            $this->scheduledForInsertion[] = $entity;
         }
     }
 
     /**
      * Looks for objects being updated that should be indexed or removed from the index.
      */
-    public function postUpdate(LifecycleEventArgs $eventArgs)
+    public function postUpdate(LifecycleEventArgs $eventArgs): void
     {
         $entity = $eventArgs->getObject();
 
@@ -125,7 +118,7 @@ class Listener
      * Delete objects preRemove instead of postRemove so that we have access to the id.  Because this is called
      * preRemove, first check that the entity is managed by Doctrine.
      */
-    public function preRemove(LifecycleEventArgs $eventArgs)
+    public function preRemove(LifecycleEventArgs $eventArgs): void
     {
         $entity = $eventArgs->getObject();
 
@@ -145,7 +138,7 @@ class Listener
      *             on the behaviour that entities are indexed regardless of if a
      *             flush is successful
      */
-    public function preFlush()
+    public function preFlush(): void
     {
         $this->persistScheduled();
     }
@@ -154,17 +147,15 @@ class Listener
      * Iterating through scheduled actions *after* flushing ensures that the
      * ElasticSearch index will be affected only if the query is successful.
      */
-    public function postFlush()
+    public function postFlush(): void
     {
         $this->persistScheduled();
     }
 
     /**
      * Determines whether or not it is okay to persist now.
-     *
-     * @return bool
      */
-    private function shouldPersist()
+    private function shouldPersist(): bool
     {
         return !$this->config['defer'];
     }
@@ -173,7 +164,7 @@ class Listener
      * Persist scheduled objects to ElasticSearch
      * After persisting, clear the scheduled queue to prevent multiple data updates when using multiple flush calls.
      */
-    private function persistScheduled()
+    private function persistScheduled(): void
     {
         if ($this->shouldPersist()) {
             if (\count($this->scheduledForInsertion)) {
@@ -196,7 +187,7 @@ class Listener
      *
      * @param object $object
      */
-    private function scheduleForDeletion($object)
+    private function scheduleForDeletion($object): void
     {
         if ($identifierValue = $this->propertyAccessor->getValue($object, $this->config['identifier'])) {
             $this->scheduledForDeletion[] = (string) $identifierValue;
@@ -205,12 +196,8 @@ class Listener
 
     /**
      * Checks if the object is indexable or not.
-     *
-     * @param object $object
-     *
-     * @return bool
      */
-    private function isObjectIndexable($object)
+    private function isObjectIndexable(object $object): bool
     {
         return $this->indexable->isObjectIndexable(
             $this->config['indexName'],

--- a/src/Doctrine/MongoDB/ElasticaToModelTransformer.php
+++ b/src/Doctrine/MongoDB/ElasticaToModelTransformer.php
@@ -28,7 +28,7 @@ class ElasticaToModelTransformer extends AbstractElasticaToModelTransformer
      *
      * @return array of objects or arrays
      */
-    protected function findByIdentifiers(array $identifierValues, $hydrate)
+    protected function findByIdentifiers(array $identifierValues, bool $hydrate): array
     {
         return $this->registry
             ->getManagerForClass($this->objectClass)

--- a/src/Doctrine/MongoDBPagerProvider.php
+++ b/src/Doctrine/MongoDBPagerProvider.php
@@ -20,21 +20,15 @@ use Pagerfanta\Pagerfanta;
 
 final class MongoDBPagerProvider implements PagerProviderInterface
 {
-    private string $objectClass;
-    private ManagerRegistry $doctrine;
-    private array $baseOptions;
-    private RegisterListenersService $registerListenersService;
+    private readonly ManagerRegistry $doctrine;
 
     public function __construct(
         ManagerRegistry $doctrine,
-        RegisterListenersService $registerListenersService,
-        string $objectClass,
-        array $baseOptions,
+        private readonly RegisterListenersService $registerListenersService,
+        private readonly string $objectClass,
+        private readonly array $baseOptions,
     ) {
         $this->doctrine = $doctrine;
-        $this->objectClass = $objectClass;
-        $this->baseOptions = $baseOptions;
-        $this->registerListenersService = $registerListenersService;
     }
 
     public function provide(array $options = []): PagerInterface

--- a/src/Doctrine/MongoDBPagerProvider.php
+++ b/src/Doctrine/MongoDBPagerProvider.php
@@ -20,15 +20,8 @@ use Pagerfanta\Pagerfanta;
 
 final class MongoDBPagerProvider implements PagerProviderInterface
 {
-    private readonly ManagerRegistry $doctrine;
-
-    public function __construct(
-        ManagerRegistry $doctrine,
-        private readonly RegisterListenersService $registerListenersService,
-        private readonly string $objectClass,
-        private readonly array $baseOptions,
-    ) {
-        $this->doctrine = $doctrine;
+    public function __construct(private readonly ManagerRegistry $doctrine, private readonly RegisterListenersService $registerListenersService, private readonly string $objectClass, private readonly array $baseOptions)
+    {
     }
 
     public function provide(array $options = []): PagerInterface

--- a/src/Doctrine/ORM/ElasticaToModelTransformer.php
+++ b/src/Doctrine/ORM/ElasticaToModelTransformer.php
@@ -31,7 +31,7 @@ class ElasticaToModelTransformer extends AbstractElasticaToModelTransformer
      *
      * @return array of objects or arrays
      */
-    protected function findByIdentifiers(array $identifierValues, $hydrate)
+    protected function findByIdentifiers(array $identifierValues, bool $hydrate): array
     {
         if ([] === $identifierValues) {
             return [];
@@ -54,10 +54,8 @@ class ElasticaToModelTransformer extends AbstractElasticaToModelTransformer
 
     /**
      * Retrieves a query builder to be used for querying by identifiers.
-     *
-     * @return \Doctrine\ORM\QueryBuilder
      */
-    protected function getEntityQueryBuilder()
+    protected function getEntityQueryBuilder(): \Doctrine\ORM\QueryBuilder
     {
         $repository = $this->registry
             ->getManagerForClass($this->objectClass)

--- a/src/Doctrine/ORM/ElasticaToModelTransformer.php
+++ b/src/Doctrine/ORM/ElasticaToModelTransformer.php
@@ -33,7 +33,7 @@ class ElasticaToModelTransformer extends AbstractElasticaToModelTransformer
      */
     protected function findByIdentifiers(array $identifierValues, $hydrate)
     {
-        if (empty($identifierValues)) {
+        if ([] === $identifierValues) {
             return [];
         }
         $hydrationMode = $hydrate ? Query::HYDRATE_OBJECT : Query::HYDRATE_ARRAY;

--- a/src/Doctrine/ORMPagerProvider.php
+++ b/src/Doctrine/ORMPagerProvider.php
@@ -23,22 +23,15 @@ use Pagerfanta\Pagerfanta;
 final class ORMPagerProvider implements PagerProviderInterface
 {
     public const ENTITY_ALIAS = 'a';
-
-    private string $objectClass;
-    private ManagerRegistry $doctrine;
-    private array $baseOptions;
-    private RegisterListenersService $registerListenersService;
+    private readonly ManagerRegistry $doctrine;
 
     public function __construct(
         ManagerRegistry $doctrine,
-        RegisterListenersService $registerListenersService,
-        string $objectClass,
-        array $baseOptions,
+        private readonly RegisterListenersService $registerListenersService,
+        private readonly string $objectClass,
+        private readonly array $baseOptions,
     ) {
         $this->doctrine = $doctrine;
-        $this->objectClass = $objectClass;
-        $this->baseOptions = $baseOptions;
-        $this->registerListenersService = $registerListenersService;
     }
 
     public function provide(array $options = []): PagerInterface

--- a/src/Doctrine/ORMPagerProvider.php
+++ b/src/Doctrine/ORMPagerProvider.php
@@ -23,15 +23,9 @@ use Pagerfanta\Pagerfanta;
 final class ORMPagerProvider implements PagerProviderInterface
 {
     public const ENTITY_ALIAS = 'a';
-    private readonly ManagerRegistry $doctrine;
 
-    public function __construct(
-        ManagerRegistry $doctrine,
-        private readonly RegisterListenersService $registerListenersService,
-        private readonly string $objectClass,
-        private readonly array $baseOptions,
-    ) {
-        $this->doctrine = $doctrine;
+    public function __construct(private readonly ManagerRegistry $doctrine, private readonly RegisterListenersService $registerListenersService, private readonly string $objectClass, private readonly array $baseOptions)
+    {
     }
 
     public function provide(array $options = []): PagerInterface

--- a/src/Doctrine/PHPCR/ElasticaToModelTransformer.php
+++ b/src/Doctrine/PHPCR/ElasticaToModelTransformer.php
@@ -28,7 +28,7 @@ class ElasticaToModelTransformer extends AbstractElasticaToModelTransformer
      *
      * @return array of objects or arrays
      */
-    protected function findByIdentifiers(array $identifierValues, $hydrate)
+    protected function findByIdentifiers(array $identifierValues, bool $hydrate): array
     {
         // @phpstan-ignore-next-line The call is \Doctrine\ODM\PHPCR\DocumentRepository::findMany()
         $documents = $this->registry

--- a/src/Doctrine/PHPCRPagerProvider.php
+++ b/src/Doctrine/PHPCRPagerProvider.php
@@ -25,16 +25,10 @@ final class PHPCRPagerProvider implements PagerProviderInterface
     public const ENTITY_ALIAS = 'a';
 
     /**
-     * @var ManagerRegistry
-     */
-    private $doctrine;
-
-    /**
      * @param string $objectClass
      */
-    public function __construct(ManagerRegistry $doctrine, private readonly RegisterListenersService $registerListenersService, private $objectClass, private readonly array $baseOptions)
+    public function __construct(private readonly ManagerRegistry $doctrine, private readonly RegisterListenersService $registerListenersService, private $objectClass, private readonly array $baseOptions)
     {
-        $this->doctrine = $doctrine;
     }
 
     public function provide(array $options = []): PagerInterface

--- a/src/Doctrine/PHPCRPagerProvider.php
+++ b/src/Doctrine/PHPCRPagerProvider.php
@@ -25,34 +25,16 @@ final class PHPCRPagerProvider implements PagerProviderInterface
     public const ENTITY_ALIAS = 'a';
 
     /**
-     * @var string
-     */
-    private $objectClass;
-
-    /**
      * @var ManagerRegistry
      */
     private $doctrine;
 
     /**
-     * @var array
-     */
-    private $baseOptions;
-
-    /**
-     * @var RegisterListenersService
-     */
-    private $registerListenersService;
-
-    /**
      * @param string $objectClass
      */
-    public function __construct(ManagerRegistry $doctrine, RegisterListenersService $registerListenersService, $objectClass, array $baseOptions)
+    public function __construct(ManagerRegistry $doctrine, private readonly RegisterListenersService $registerListenersService, private $objectClass, private readonly array $baseOptions)
     {
         $this->doctrine = $doctrine;
-        $this->objectClass = $objectClass;
-        $this->baseOptions = $baseOptions;
-        $this->registerListenersService = $registerListenersService;
     }
 
     public function provide(array $options = []): PagerInterface

--- a/src/Doctrine/RegisterListenersService.php
+++ b/src/Doctrine/RegisterListenersService.php
@@ -22,14 +22,14 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class RegisterListenersService
 {
-    private EventDispatcherInterface $dispatcher;
+    private readonly EventDispatcherInterface $dispatcher;
 
     public function __construct(EventDispatcherInterface $dispatcher)
     {
         $this->dispatcher = $dispatcher;
     }
 
-    public function register(ObjectManager $manager, PagerInterface $pager, array $options)
+    public function register(ObjectManager $manager, PagerInterface $pager, array $options): void
     {
         $options = \array_replace([
             'clear_object_manager' => true,
@@ -38,13 +38,13 @@ class RegisterListenersService
         ], $options);
 
         if ($options['clear_object_manager']) {
-            $this->addListener($pager, PostInsertObjectsEvent::class, function () use ($manager) {
+            $this->addListener($pager, PostInsertObjectsEvent::class, function () use ($manager): void {
                 $manager->clear();
             });
         }
 
         if ($options['sleep']) {
-            $this->addListener($pager, PostInsertObjectsEvent::class, function () use ($options) {
+            $this->addListener($pager, PostInsertObjectsEvent::class, function () use ($options): void {
                 \usleep($options['sleep']);
             });
         }
@@ -57,23 +57,20 @@ class RegisterListenersService
             if (\method_exists($configuration, 'getSQLLogger') && \method_exists($configuration, 'setSQLLogger')) {
                 $logger = $configuration->getSQLLogger();
 
-                $this->addListener($pager, PreFetchObjectsEvent::class, function () use ($configuration) {
+                $this->addListener($pager, PreFetchObjectsEvent::class, function () use ($configuration): void {
                     $configuration->setSQLLogger(null);
                 });
 
-                $this->addListener($pager, PreInsertObjectsEvent::class, function () use ($configuration, $logger) {
+                $this->addListener($pager, PreInsertObjectsEvent::class, function () use ($configuration, $logger): void {
                     $configuration->setSQLLogger($logger);
                 });
             }
         }
     }
 
-    /**
-     * @param string $eventName
-     */
-    private function addListener(PagerInterface $pager, $eventName, \Closure $callable)
+    private function addListener(PagerInterface $pager, string $eventName, \Closure $callable): void
     {
-        $this->dispatcher->addListener($eventName, function (PersistEvent $event) use ($pager, $callable) {
+        $this->dispatcher->addListener($eventName, function (PersistEvent $event) use ($pager, $callable): void {
             if ($event->getPager() !== $pager) {
                 return;
             }

--- a/src/Doctrine/RegisterListenersService.php
+++ b/src/Doctrine/RegisterListenersService.php
@@ -22,11 +22,8 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class RegisterListenersService
 {
-    private readonly EventDispatcherInterface $dispatcher;
-
-    public function __construct(EventDispatcherInterface $dispatcher)
+    public function __construct(private readonly EventDispatcherInterface $dispatcher)
     {
-        $this->dispatcher = $dispatcher;
     }
 
     public function register(ObjectManager $manager, PagerInterface $pager, array $options): void

--- a/src/Doctrine/RepositoryManager.php
+++ b/src/Doctrine/RepositoryManager.php
@@ -26,11 +26,9 @@ class RepositoryManager implements RepositoryManagerInterface
 {
     protected array $entities = [];
     protected array $repositories = [];
-    protected ManagerRegistry $managerRegistry;
 
-    public function __construct(ManagerRegistry $managerRegistry, private readonly RepositoryManagerInterface $repositoryManager)
+    public function __construct(protected ManagerRegistry $managerRegistry, private readonly RepositoryManagerInterface $repositoryManager)
     {
-        $this->managerRegistry = $managerRegistry;
     }
 
     public function addIndex(string $indexName, FinderInterface $finder, ?string $repositoryName = null): void

--- a/src/Doctrine/RepositoryManager.php
+++ b/src/Doctrine/RepositoryManager.php
@@ -27,12 +27,10 @@ class RepositoryManager implements RepositoryManagerInterface
     protected array $entities = [];
     protected array $repositories = [];
     protected ManagerRegistry $managerRegistry;
-    private RepositoryManagerInterface $repositoryManager;
 
-    public function __construct(ManagerRegistry $managerRegistry, RepositoryManagerInterface $repositoryManager)
+    public function __construct(ManagerRegistry $managerRegistry, private readonly RepositoryManagerInterface $repositoryManager)
     {
         $this->managerRegistry = $managerRegistry;
-        $this->repositoryManager = $repositoryManager;
     }
 
     public function addIndex(string $indexName, FinderInterface $finder, ?string $repositoryName = null): void
@@ -53,7 +51,7 @@ class RepositoryManager implements RepositoryManagerInterface
     public function getRepository(string $entityName): Repository
     {
         $realEntityName = $entityName;
-        if (false !== \strpos($entityName, ':')) {
+        if (\str_contains($entityName, ':')) {
             [$namespaceAlias, $simpleClassName] = \explode(':', $entityName);
             // @link https://github.com/doctrine/persistence/pull/204
             if (\method_exists($this->managerRegistry, 'getAliasNamespace')) {

--- a/src/Elastica/Client.php
+++ b/src/Elastica/Client.php
@@ -34,13 +34,9 @@ use Symfony\Contracts\Service\ResetInterface;
  */
 class Client extends BaseClient implements ResetInterface
 {
-    private array $forbiddenCodes;
-
-    public function __construct(array|string $config = [], array $forbiddenCodes = [400, 403, 404], ?LoggerInterface $logger = null)
+    public function __construct(array|string $config = [], private readonly array $forbiddenCodes = [400, 403, 404], ?LoggerInterface $logger = null)
     {
         parent::__construct($config, $logger);
-
-        $this->forbiddenCodes = $forbiddenCodes;
     }
 
     /**
@@ -68,7 +64,7 @@ class Client extends BaseClient implements ResetInterface
     {
         $this->stopwatch?->start('es_request', 'fos_elastica');
 
-        $path = \ltrim($request->getUri()->getPath(), '/'); // to have the same result as in the 6.0
+        $path = \ltrim((string) $request->getUri()->getPath(), '/'); // to have the same result as in the 6.0
         $method = $request->getMethod();
         try {
             $data = \json_decode((string) $request->getBody(), true, 512, \JSON_THROW_ON_ERROR);
@@ -76,7 +72,7 @@ class Client extends BaseClient implements ResetInterface
             $data = [];
         }
         $query = [];
-        \parse_str($request->getUri()->getQuery(), $query);
+        \parse_str((string) $request->getUri()->getQuery(), $query);
 
         $this->dispatcher?->dispatch(new PreElasticaRequestEvent($path, $method, $data, $query, $request->getHeaderLine('Content-Type')));
 

--- a/src/Elastica/Client.php
+++ b/src/Elastica/Client.php
@@ -64,7 +64,7 @@ class Client extends BaseClient implements ResetInterface
     {
         $this->stopwatch?->start('es_request', 'fos_elastica');
 
-        $path = \ltrim((string) $request->getUri()->getPath(), '/'); // to have the same result as in the 6.0
+        $path = \ltrim($request->getUri()->getPath(), '/'); // to have the same result as in the 6.0
         $method = $request->getMethod();
         try {
             $data = \json_decode((string) $request->getBody(), true, 512, \JSON_THROW_ON_ERROR);
@@ -72,7 +72,7 @@ class Client extends BaseClient implements ResetInterface
             $data = [];
         }
         $query = [];
-        \parse_str((string) $request->getUri()->getQuery(), $query);
+        \parse_str($request->getUri()->getQuery(), $query);
 
         $this->dispatcher?->dispatch(new PreElasticaRequestEvent($path, $method, $data, $query, $request->getHeaderLine('Content-Type')));
 

--- a/src/Elastica/IndexTemplate.php
+++ b/src/Elastica/IndexTemplate.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the FOSElasticaBundle package.
  *

--- a/src/Event/AbstractIndexEvent.php
+++ b/src/Event/AbstractIndexEvent.php
@@ -15,14 +15,8 @@ use Symfony\Contracts\EventDispatcher\Event;
 
 abstract class AbstractIndexEvent extends Event
 {
-    /**
-     * @var string
-     */
-    private $index;
-
-    public function __construct(string $index)
+    public function __construct(private readonly string $index)
     {
-        $this->index = $index;
     }
 
     public function getIndex(): string

--- a/src/Event/AbstractIndexPopulateEvent.php
+++ b/src/Event/AbstractIndexPopulateEvent.php
@@ -57,7 +57,7 @@ abstract class AbstractIndexPopulateEvent extends AbstractIndexEvent
     /**
      * @throws \InvalidArgumentException if option does not exist
      */
-    public function getOption(string $name)
+    public function getOption(string $name): mixed
     {
         if (!isset($this->options[$name])) {
             throw new \InvalidArgumentException(\sprintf('The "%s" option does not exist.', $name));

--- a/src/Event/AbstractIndexPopulateEvent.php
+++ b/src/Event/AbstractIndexPopulateEvent.php
@@ -31,26 +31,14 @@ namespace FOS\ElasticaBundle\Event;
 abstract class AbstractIndexPopulateEvent extends AbstractIndexEvent
 {
     /**
-     * @var bool
-     */
-    protected $reset;
-
-    /**
-     * @var array
-     *
-     * @phpstan-var TOptions
-     */
-    protected $options;
-
-    /**
      * @phpstan-param TOptions $options
      */
-    public function __construct(string $index, bool $reset, array $options)
+    public function __construct(string $index, protected bool $reset, /**
+     * @phpstan-var TOptions
+     */
+        protected array $options)
     {
         parent::__construct($index);
-
-        $this->reset = $reset;
-        $this->options = $options;
     }
 
     public function isReset(): bool

--- a/src/Event/AbstractIndexResetEvent.php
+++ b/src/Event/AbstractIndexResetEvent.php
@@ -18,22 +18,9 @@ namespace FOS\ElasticaBundle\Event;
  */
 abstract class AbstractIndexResetEvent extends AbstractIndexEvent
 {
-    /**
-     * @var bool
-     */
-    protected $force;
-
-    /**
-     * @var bool
-     */
-    private $populating;
-
-    public function __construct(string $index, bool $populating, bool $force)
+    public function __construct(string $index, private readonly bool $populating, protected bool $force)
     {
         parent::__construct($index);
-
-        $this->force = $force;
-        $this->populating = $populating;
     }
 
     public function isForce(): bool

--- a/src/Event/AbstractTransformEvent.php
+++ b/src/Event/AbstractTransformEvent.php
@@ -21,19 +21,16 @@ use Symfony\Contracts\EventDispatcher\Event;
 abstract class AbstractTransformEvent extends Event
 {
     /**
-     * @var Document
-     */
-    protected $document;
-
-    /**
      * @phpstan-param TFields $fields
      */
-    public function __construct(Document $document, /**
-     * @phpstan-var TFields
-     */
-        private readonly array $fields, private readonly object $object)
-    {
-        $this->document = $document;
+    public function __construct(
+        protected Document $document,
+        /**
+         * @phpstan-var TFields
+         */
+        private readonly array $fields,
+        private readonly object $object
+    ) {
     }
 
     public function getDocument(): Document

--- a/src/Event/AbstractTransformEvent.php
+++ b/src/Event/AbstractTransformEvent.php
@@ -26,25 +26,14 @@ abstract class AbstractTransformEvent extends Event
     protected $document;
 
     /**
-     * @var array
-     *
-     * @phpstan-var TFields
-     */
-    private $fields;
-
-    /**
-     * @var object
-     */
-    private $object;
-
-    /**
      * @phpstan-param TFields $fields
      */
-    public function __construct(Document $document, array $fields, object $object)
+    public function __construct(Document $document, /**
+     * @phpstan-var TFields
+     */
+        private readonly array $fields, private readonly object $object)
     {
         $this->document = $document;
-        $this->fields = $fields;
-        $this->object = $object;
     }
 
     public function getDocument(): Document

--- a/src/Event/ElasticaRequestExceptionEvent.php
+++ b/src/Event/ElasticaRequestExceptionEvent.php
@@ -18,15 +18,8 @@ use Psr\Http\Message\RequestInterface;
 
 class ElasticaRequestExceptionEvent
 {
-    private readonly RequestInterface $request;
-    private readonly ElasticsearchException $exception;
-
-    public function __construct(
-        RequestInterface $request,
-        ElasticsearchException $exception
-    ) {
-        $this->request = $request;
-        $this->exception = $exception;
+    public function __construct(private readonly RequestInterface $request, private readonly ElasticsearchException $exception)
+    {
     }
 
     public function getRequest(): RequestInterface

--- a/src/Event/ElasticaRequestExceptionEvent.php
+++ b/src/Event/ElasticaRequestExceptionEvent.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the FOSElasticaBundle package.
  *
@@ -16,8 +18,8 @@ use Psr\Http\Message\RequestInterface;
 
 class ElasticaRequestExceptionEvent
 {
-    private RequestInterface $request;
-    private ElasticsearchException $exception;
+    private readonly RequestInterface $request;
+    private readonly ElasticsearchException $exception;
 
     public function __construct(
         RequestInterface $request,

--- a/src/Event/PostElasticaRequestEvent.php
+++ b/src/Event/PostElasticaRequestEvent.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the FOSElasticaBundle package.
  *
@@ -16,8 +18,8 @@ use Psr\Http\Message\RequestInterface;
 
 class PostElasticaRequestEvent
 {
-    private RequestInterface $request;
-    private Response $response;
+    private readonly RequestInterface $request;
+    private readonly Response $response;
 
     public function __construct(
         RequestInterface $request,

--- a/src/Event/PostElasticaRequestEvent.php
+++ b/src/Event/PostElasticaRequestEvent.php
@@ -18,15 +18,8 @@ use Psr\Http\Message\RequestInterface;
 
 class PostElasticaRequestEvent
 {
-    private readonly RequestInterface $request;
-    private readonly Response $response;
-
-    public function __construct(
-        RequestInterface $request,
-        Response $response
-    ) {
-        $this->request = $request;
-        $this->response = $response;
+    public function __construct(private readonly RequestInterface $request, private readonly Response $response)
+    {
     }
 
     public function getRequest(): RequestInterface

--- a/src/Event/PostIndexMappingBuildEvent.php
+++ b/src/Event/PostIndexMappingBuildEvent.php
@@ -19,26 +19,14 @@ use FOS\ElasticaBundle\Configuration\IndexConfigInterface;
 final class PostIndexMappingBuildEvent extends AbstractIndexEvent
 {
     /**
-     * @var IndexConfigInterface
-     */
-    private $indexConfig;
-
-    /**
-     * @var array
-     *
-     * @phpstan-var TMapping
-     */
-    private $mapping;
-
-    /**
      * @phpstan-param TMapping $mapping
      */
-    public function __construct(IndexConfigInterface $indexConfig, array $mapping)
+    public function __construct(private readonly IndexConfigInterface $indexConfig, /**
+     * @phpstan-var TMapping
+     */
+        private array $mapping)
     {
-        $this->indexConfig = $indexConfig;
-        $this->mapping = $mapping;
-
-        parent::__construct($indexConfig->getName());
+        parent::__construct($this->indexConfig->getName());
     }
 
     public function getIndexConfig(): IndexConfigInterface

--- a/src/Event/PostIndexPopulateEvent.php
+++ b/src/Event/PostIndexPopulateEvent.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the FOSElasticaBundle package.
  *

--- a/src/Event/PostIndexResetEvent.php
+++ b/src/Event/PostIndexResetEvent.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the FOSElasticaBundle package.
  *

--- a/src/Event/PostTransformEvent.php
+++ b/src/Event/PostTransformEvent.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the FOSElasticaBundle package.
  *

--- a/src/Event/PreElasticaRequestEvent.php
+++ b/src/Event/PreElasticaRequestEvent.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the FOSElasticaBundle package.
  *
@@ -16,32 +18,22 @@ use Symfony\Contracts\EventDispatcher\Event;
 
 class PreElasticaRequestEvent extends Event
 {
-    private string $path;
-    private string $method;
-
     /**
-     * @var array<string, mixed>|string
+     * @param array<string, mixed>|string $data
      */
-    private $data;
-
-    /**
-     * @var array<string, mixed>
-     */
-    private array $query;
-    private string $contentType;
-
     public function __construct(
-        string $path,
-        string $method,
-        $data,
-        array $query,
-        string $contentType = Request::DEFAULT_CONTENT_TYPE
+        private readonly string $path,
+        private readonly string $method,
+        /**
+         * @var array<string, mixed>|string
+         */
+        private $data,
+        /**
+         * @var array<string, mixed>
+         */
+        private readonly array $query,
+        private readonly string $contentType = Request::DEFAULT_CONTENT_TYPE
     ) {
-        $this->path = $path;
-        $this->method = $method;
-        $this->data = $data;
-        $this->query = $query;
-        $this->contentType = $contentType;
     }
 
     public function getPath(): string

--- a/src/Event/PreElasticaRequestEvent.php
+++ b/src/Event/PreElasticaRequestEvent.php
@@ -27,7 +27,7 @@ class PreElasticaRequestEvent extends Event
         /**
          * @var array<string, mixed>|string
          */
-        private $data,
+        private array|string $data,
         /**
          * @var array<string, mixed>
          */
@@ -49,7 +49,7 @@ class PreElasticaRequestEvent extends Event
     /**
      * @return array<string, mixed>|string
      */
-    public function getData()
+    public function getData(): array|string
     {
         return $this->data;
     }

--- a/src/EventListener/PopulateListener.php
+++ b/src/EventListener/PopulateListener.php
@@ -22,16 +22,10 @@ use FOS\ElasticaBundle\Index\Resetter;
 class PopulateListener
 {
     /**
-     * @var Resetter
-     */
-    private $resetter;
-
-    /**
      * PopulateListener constructor.
      */
-    public function __construct(Resetter $resetter)
+    public function __construct(private readonly Resetter $resetter)
     {
-        $this->resetter = $resetter;
     }
 
     public function onPostIndexPopulate(PostIndexPopulateEvent $event): void

--- a/src/Exception/AliasIsIndexException.php
+++ b/src/Exception/AliasIsIndexException.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the FOSElasticaBundle package.
  *

--- a/src/Finder/FinderInterface.php
+++ b/src/Finder/FinderInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the FOSElasticaBundle package.
  *

--- a/src/Finder/FinderInterface.php
+++ b/src/Finder/FinderInterface.php
@@ -41,5 +41,5 @@ interface FinderInterface
      *
      * @return array<object> results
      */
-    public function find($query, ?int $limit = null, array $options = []);
+    public function find(mixed $query, ?int $limit = null, array $options = []): array;
 }

--- a/src/Finder/HybridFinderInterface.php
+++ b/src/Finder/HybridFinderInterface.php
@@ -29,5 +29,5 @@ interface HybridFinderInterface
      *
      * @return HybridResult[]
      */
-    public function findHybrid($query, ?int $limit = null, array $options = []);
+    public function findHybrid(mixed $query, ?int $limit = null, array $options = []): array;
 }

--- a/src/Finder/PaginatedFinderInterface.php
+++ b/src/Finder/PaginatedFinderInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the FOSElasticaBundle package.
  *

--- a/src/Finder/PaginatedFinderInterface.php
+++ b/src/Finder/PaginatedFinderInterface.php
@@ -39,35 +39,29 @@ interface PaginatedFinderInterface extends FinderInterface
      *
      * @return Pagerfanta<object> paginated results
      */
-    public function findPaginated($query, array $options = []);
+    public function findPaginated(mixed $query, array $options = []): Pagerfanta;
 
     /**
      * Creates a paginator adapter for this query.
      *
      * @phpstan-param TQuery $query
      * @phpstan-param TOptions $options
-     *
-     * @return PaginatorAdapterInterface
      */
-    public function createPaginatorAdapter($query, array $options = []);
+    public function createPaginatorAdapter(mixed $query, array $options = []): PaginatorAdapterInterface;
 
     /**
      * Creates a hybrid paginator adapter for this query.
      *
      * @phpstan-param TQuery $query
      * @phpstan-param TOptions $options
-     *
-     * @return PaginatorAdapterInterface
      */
-    public function createHybridPaginatorAdapter($query, array $options = []);
+    public function createHybridPaginatorAdapter(mixed $query, array $options = []): PaginatorAdapterInterface;
 
     /**
      * Creates a raw paginator adapter for this query.
      *
      * @phpstan-param TQuery $query
      * @phpstan-param TOptions $options
-     *
-     * @return PaginatorAdapterInterface
      */
-    public function createRawPaginatorAdapter($query, array $options = []);
+    public function createRawPaginatorAdapter(mixed $query, array $options = []): PaginatorAdapterInterface;
 }

--- a/src/Finder/PaginatedHybridFinderInterface.php
+++ b/src/Finder/PaginatedHybridFinderInterface.php
@@ -30,15 +30,13 @@ interface PaginatedHybridFinderInterface extends HybridFinderInterface
      *
      * @return PagerfantaInterface<HybridResult>
      */
-    public function findHybridPaginated($query);
+    public function findHybridPaginated(mixed $query): PagerfantaInterface;
 
     /**
      * Creates a hybrid paginator adapter for this query.
      *
      * @param TQuery   $query
      * @param TOptions $options
-     *
-     * @return PaginatorAdapterInterface
      */
-    public function createHybridPaginatorAdapter($query, array $options = []);
+    public function createHybridPaginatorAdapter(mixed $query, array $options = []): PaginatorAdapterInterface;
 }

--- a/src/Finder/PaginatedRawFinderInterface.php
+++ b/src/Finder/PaginatedRawFinderInterface.php
@@ -31,15 +31,13 @@ interface PaginatedRawFinderInterface extends RawFinderInterface
      *
      * @return PagerfantaInterface<Result>
      */
-    public function findRawPaginated($query, array $options = []);
+    public function findRawPaginated(mixed $query, array $options = []): PagerfantaInterface;
 
     /**
      * Creates a raw paginator adapter for this query.
      *
      * @param TQuery   $query
      * @param TOptions $options
-     *
-     * @return PaginatorAdapterInterface
      */
-    public function createRawPaginatorAdapter($query, array $options = []);
+    public function createRawPaginatorAdapter(mixed $query, array $options = []): PaginatorAdapterInterface;
 }

--- a/src/Finder/RawFinderInterface.php
+++ b/src/Finder/RawFinderInterface.php
@@ -29,5 +29,5 @@ interface RawFinderInterface
      *
      * @return Result[]
      */
-    public function findRaw($query, ?int $limit = null, array $options = []);
+    public function findRaw(mixed $query, ?int $limit = null, array $options = []): array;
 }

--- a/src/Finder/TransformedFinder.php
+++ b/src/Finder/TransformedFinder.php
@@ -29,68 +29,65 @@ use Pagerfanta\Pagerfanta;
  */
 class TransformedFinder implements PaginatedFinderInterface, PaginatedRawFinderInterface, PaginatedHybridFinderInterface
 {
-    protected SearchableInterface $searchable;
-
-    public function __construct(SearchableInterface $searchable, protected ElasticaToModelTransformerInterface $transformer)
+    public function __construct(protected SearchableInterface $searchable, protected ElasticaToModelTransformerInterface $transformer)
     {
-        $this->searchable = $searchable;
     }
 
-    public function find($query, ?int $limit = null, array $options = [])
+    public function find(mixed $query, ?int $limit = null, array $options = []): array
     {
         $results = $this->search($query, $limit, $options);
 
         return $this->transformer->transform($results);
     }
 
-    public function findHybrid($query, ?int $limit = null, array $options = [])
+    public function findHybrid(mixed $query, ?int $limit = null, array $options = []): array
     {
         $results = $this->search($query, $limit, $options);
 
         return $this->transformer->hybridTransform($results);
     }
 
-    public function findRaw($query, ?int $limit = null, array $options = []): array
+    public function findRaw(mixed $query, ?int $limit = null, array $options = []): array
     {
         return $this->search($query, $limit, $options);
     }
 
-    public function findPaginated($query, array $options = [])
+    public function findPaginated(mixed $query, array $options = []): Pagerfanta
     {
         $paginatorAdapter = $this->createPaginatorAdapter($query, $options);
 
         return new Pagerfanta(new FantaPaginatorAdapter($paginatorAdapter));
     }
 
-    public function findHybridPaginated($query, array $options = [])
+    public function findHybridPaginated(mixed $query, array $options = []): Pagerfanta
     {
         $paginatorAdapter = $this->createHybridPaginatorAdapter($query, $options);
 
         return new Pagerfanta(new FantaPaginatorAdapter($paginatorAdapter));
     }
 
-    public function findRawPaginated($query, array $options = [])
+    public function findRawPaginated(mixed $query, array $options = []): Pagerfanta
     {
         $paginatorAdapter = $this->createRawPaginatorAdapter($query, $options);
 
         return new Pagerfanta(new FantaPaginatorAdapter($paginatorAdapter));
     }
 
-    public function createPaginatorAdapter($query, array $options = []): TransformedPaginatorAdapter
+    public function createPaginatorAdapter(mixed $query, array $options = []): TransformedPaginatorAdapter
     {
         $query = Query::create($query);
 
         return new TransformedPaginatorAdapter($this->searchable, $query, $options, $this->transformer);
     }
 
-    public function createHybridPaginatorAdapter($query, array $options = []): HybridPaginatorAdapter
+    public function createHybridPaginatorAdapter(mixed $query, array $options = []): HybridPaginatorAdapter
     {
         $query = Query::create($query);
 
         return new HybridPaginatorAdapter($this->searchable, $query, $options, $this->transformer);
     }
 
-    public function createRawPaginatorAdapter($query, array $options = []): RawPaginatorAdapter
+    public function createRawPaginatorAdapter(mixed $query, array $options = []): RawPaginatorAdapter
     {
         $query = Query::create($query);
 
@@ -103,7 +100,7 @@ class TransformedFinder implements PaginatedFinderInterface, PaginatedRawFinderI
      *
      * @return Result[]
      */
-    protected function search($query, ?int $limit = null, array $options = [])
+    protected function search(mixed $query, ?int $limit = null, array $options = []): array
     {
         $queryObject = Query::create($query);
         if (null !== $limit) {

--- a/src/Finder/TransformedFinder.php
+++ b/src/Finder/TransformedFinder.php
@@ -30,12 +30,10 @@ use Pagerfanta\Pagerfanta;
 class TransformedFinder implements PaginatedFinderInterface, PaginatedRawFinderInterface, PaginatedHybridFinderInterface
 {
     protected SearchableInterface $searchable;
-    protected ElasticaToModelTransformerInterface $transformer;
 
-    public function __construct(SearchableInterface $searchable, ElasticaToModelTransformerInterface $transformer)
+    public function __construct(SearchableInterface $searchable, protected ElasticaToModelTransformerInterface $transformer)
     {
         $this->searchable = $searchable;
-        $this->transformer = $transformer;
     }
 
     public function find($query, ?int $limit = null, array $options = [])
@@ -78,21 +76,21 @@ class TransformedFinder implements PaginatedFinderInterface, PaginatedRawFinderI
         return new Pagerfanta(new FantaPaginatorAdapter($paginatorAdapter));
     }
 
-    public function createPaginatorAdapter($query, array $options = [])
+    public function createPaginatorAdapter($query, array $options = []): TransformedPaginatorAdapter
     {
         $query = Query::create($query);
 
         return new TransformedPaginatorAdapter($this->searchable, $query, $options, $this->transformer);
     }
 
-    public function createHybridPaginatorAdapter($query, array $options = [])
+    public function createHybridPaginatorAdapter($query, array $options = []): HybridPaginatorAdapter
     {
         $query = Query::create($query);
 
         return new HybridPaginatorAdapter($this->searchable, $query, $options, $this->transformer);
     }
 
-    public function createRawPaginatorAdapter($query, array $options = [])
+    public function createRawPaginatorAdapter($query, array $options = []): RawPaginatorAdapter
     {
         $query = Query::create($query);
 

--- a/src/HybridResult.php
+++ b/src/HybridResult.php
@@ -22,18 +22,13 @@ class HybridResult
      * @var Result
      */
     protected $result;
-    /**
-     * @var T|null
-     */
-    protected $transformed;
 
     /**
      * @param T|null $transformed
      */
-    public function __construct(Result $result, $transformed = null)
+    public function __construct(Result $result, protected $transformed = null)
     {
         $this->result = $result;
-        $this->transformed = $transformed;
     }
 
     /**

--- a/src/HybridResult.php
+++ b/src/HybridResult.php
@@ -19,22 +19,16 @@ use Elastica\Result;
 class HybridResult
 {
     /**
-     * @var Result
-     */
-    protected $result;
-
-    /**
      * @param T|null $transformed
      */
-    public function __construct(Result $result, protected $transformed = null)
+    public function __construct(protected Result $result, protected ?object $transformed = null)
     {
-        $this->result = $result;
     }
 
     /**
      * @return T|null
      */
-    public function getTransformed()
+    public function getTransformed(): ?object
     {
         return $this->transformed;
     }

--- a/src/Index/AliasProcessor.php
+++ b/src/Index/AliasProcessor.php
@@ -21,10 +21,8 @@ class AliasProcessor
 {
     /**
      * Sets the randomised root name for an index.
-     *
-     * @return void
      */
-    public function setRootName(IndexConfig $indexConfig, Index $index)
+    public function setRootName(IndexConfig $indexConfig, Index $index): void
     {
         $index->overrideName(
             \sprintf(
@@ -41,11 +39,9 @@ class AliasProcessor
      *
      * $force will delete an index encountered where an alias is expected.
      *
-     * @return void
-     *
      * @throws AliasIsIndexException
      */
-    public function switchIndexAlias(IndexConfig $indexConfig, Index $index, bool $force = false, bool $delete = true)
+    public function switchIndexAlias(IndexConfig $indexConfig, Index $index, bool $force = false, bool $delete = true): void
     {
         $client = $index->getClient();
 

--- a/src/Index/IndexManager.php
+++ b/src/Index/IndexManager.php
@@ -15,20 +15,11 @@ use FOS\ElasticaBundle\Elastica\Index;
 
 class IndexManager
 {
-    private Index $defaultIndex;
-
-    /**
-     * @var array<string, Index>
-     */
-    private $indexes;
-
     /**
      * @param array<string, Index> $indexes
      */
-    public function __construct(array $indexes, Index $defaultIndex)
+    public function __construct(private array $indexes, private readonly Index $defaultIndex)
     {
-        $this->defaultIndex = $defaultIndex;
-        $this->indexes = $indexes;
     }
 
     /**

--- a/src/Index/IndexTemplateManager.php
+++ b/src/Index/IndexTemplateManager.php
@@ -21,18 +21,14 @@ use Elastica\IndexTemplate;
 class IndexTemplateManager
 {
     /**
-     * Templates.
-     *
-     * @var array<string, IndexTemplate>
-     */
-    private $templates;
-
-    /**
      * @param array<string, IndexTemplate> $templates
      */
-    public function __construct(array $templates)
-    {
-        $this->templates = $templates;
+    public function __construct(
+        /**
+         * Templates.
+         */
+        private array $templates
+    ) {
     }
 
     /**

--- a/src/Index/IndexTemplateManager.php
+++ b/src/Index/IndexTemplateManager.php
@@ -34,13 +34,9 @@ class IndexTemplateManager
     /**
      * Gets an index template by its name.
      *
-     * @param string $name Index template to return
-     *
-     * @return IndexTemplate
-     *
      * @throws \InvalidArgumentException if no index template exists for the given name
      */
-    public function getIndexTemplate($name)
+    public function getIndexTemplate(string $name): IndexTemplate
     {
         if (!isset($this->templates[$name])) {
             throw new \InvalidArgumentException(\sprintf('The index template "%s" does not exist', $name));

--- a/src/Index/MappingBuilder.php
+++ b/src/Index/MappingBuilder.php
@@ -22,11 +22,8 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
  */
 class MappingBuilder
 {
-    private readonly EventDispatcherInterface $dispatcher;
-
-    public function __construct(EventDispatcherInterface $eventDispatcher)
+    public function __construct(private readonly EventDispatcherInterface $dispatcher)
     {
-        $this->dispatcher = $eventDispatcher;
     }
 
     /**

--- a/src/Index/MappingBuilder.php
+++ b/src/Index/MappingBuilder.php
@@ -22,7 +22,7 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
  */
 class MappingBuilder
 {
-    private EventDispatcherInterface $dispatcher;
+    private readonly EventDispatcherInterface $dispatcher;
 
     public function __construct(EventDispatcherInterface $eventDispatcher)
     {
@@ -43,11 +43,11 @@ class MappingBuilder
         $mapping = $event->getMapping();
         $settings = $indexConfig->getSettings();
 
-        if ($mapping) {
+        if ([] !== $mapping) {
             $mappingIndex['mappings'] = $mapping;
         }
 
-        if ($settings) {
+        if ([] !== $settings) {
             $mappingIndex['settings'] = $settings;
         }
 
@@ -120,9 +120,9 @@ class MappingBuilder
      */
     private function fixProperties(array &$properties): void
     {
-        foreach ($properties as $name => &$property) {
+        foreach ($properties as &$property) {
             unset($property['property_path']);
-            $property['type'] = $property['type'] ?? 'text';
+            $property['type'] ??= 'text';
 
             if (isset($property['fields'])) {
                 $this->fixProperties($property['fields']);

--- a/src/Index/Resetter.php
+++ b/src/Index/Resetter.php
@@ -22,24 +22,16 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
  */
 class Resetter implements ResetterInterface
 {
-    private AliasProcessor $aliasProcessor;
-    private ManagerInterface $configManager;
-    private EventDispatcherInterface $dispatcher;
-    private IndexManager $indexManager;
-    private MappingBuilder $mappingBuilder;
+    private readonly EventDispatcherInterface $dispatcher;
 
     public function __construct(
-        ManagerInterface $configManager,
-        IndexManager $indexManager,
-        AliasProcessor $aliasProcessor,
-        MappingBuilder $mappingBuilder,
+        private readonly ManagerInterface $configManager,
+        private readonly IndexManager $indexManager,
+        private readonly AliasProcessor $aliasProcessor,
+        private readonly MappingBuilder $mappingBuilder,
         EventDispatcherInterface $eventDispatcher,
     ) {
-        $this->aliasProcessor = $aliasProcessor;
-        $this->configManager = $configManager;
         $this->dispatcher = $eventDispatcher;
-        $this->indexManager = $indexManager;
-        $this->mappingBuilder = $mappingBuilder;
     }
 
     /**
@@ -62,7 +54,7 @@ class Resetter implements ResetterInterface
     {
         $indexConfig = $this->configManager->getIndexConfiguration($indexName);
         if (!$indexConfig instanceof IndexConfig) {
-            throw new \RuntimeException(\sprintf('Incorrect index configuration object. Expecting IndexConfig, but got: %s ', \get_class($indexConfig)));
+            throw new \RuntimeException(\sprintf('Incorrect index configuration object. Expecting IndexConfig, but got: %s ', $indexConfig::class));
         }
         $index = $this->indexManager->getIndex($indexName);
 
@@ -91,7 +83,7 @@ class Resetter implements ResetterInterface
     {
         $indexConfig = $this->configManager->getIndexConfiguration($indexName);
         if (!$indexConfig instanceof IndexConfig) {
-            throw new \RuntimeException(\sprintf('Incorrect index configuration object. Expecting IndexConfig, but got: %s ', \get_class($indexConfig)));
+            throw new \RuntimeException(\sprintf('Incorrect index configuration object. Expecting IndexConfig, but got: %s ', $indexConfig::class));
         }
 
         if ($indexConfig->isUseAlias()) {

--- a/src/Index/Resetter.php
+++ b/src/Index/Resetter.php
@@ -22,16 +22,8 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
  */
 class Resetter implements ResetterInterface
 {
-    private readonly EventDispatcherInterface $dispatcher;
-
-    public function __construct(
-        private readonly ManagerInterface $configManager,
-        private readonly IndexManager $indexManager,
-        private readonly AliasProcessor $aliasProcessor,
-        private readonly MappingBuilder $mappingBuilder,
-        EventDispatcherInterface $eventDispatcher,
-    ) {
-        $this->dispatcher = $eventDispatcher;
+    public function __construct(private readonly ManagerInterface $configManager, private readonly IndexManager $indexManager, private readonly AliasProcessor $aliasProcessor, private readonly MappingBuilder $mappingBuilder, private readonly EventDispatcherInterface $dispatcher)
+    {
     }
 
     /**

--- a/src/Index/ResetterInterface.php
+++ b/src/Index/ResetterInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the FOSElasticaBundle package.
  *

--- a/src/Index/TemplateResetter.php
+++ b/src/Index/TemplateResetter.php
@@ -23,18 +23,8 @@ use Symfony\Component\HttpFoundation\Response;
  */
 class TemplateResetter implements ResetterInterface
 {
-    private ManagerInterface $configManager;
-    private MappingBuilder $mappingBuilder;
-    private IndexTemplateManager $indexTemplateManager;
-
-    public function __construct(
-        ManagerInterface $configManager,
-        MappingBuilder $mappingBuilder,
-        IndexTemplateManager $indexTemplateManager,
-    ) {
-        $this->configManager = $configManager;
-        $this->mappingBuilder = $mappingBuilder;
-        $this->indexTemplateManager = $indexTemplateManager;
+    public function __construct(private readonly ManagerInterface $configManager, private readonly MappingBuilder $mappingBuilder, private readonly IndexTemplateManager $indexTemplateManager)
+    {
     }
 
     public function resetAllIndexes(bool $deleteIndexes = false): void
@@ -48,7 +38,7 @@ class TemplateResetter implements ResetterInterface
     {
         $indexTemplateConfig = $this->configManager->getIndexConfiguration($indexName);
         if (!$indexTemplateConfig instanceof IndexTemplateConfig) {
-            throw new \RuntimeException(\sprintf('Incorrect index configuration object. Expecting IndexTemplateConfig, but got: %s ', \get_class($indexTemplateConfig)));
+            throw new \RuntimeException(\sprintf('Incorrect index configuration object. Expecting IndexTemplateConfig, but got: %s ', $indexTemplateConfig::class));
         }
         $indexTemplate = $this->indexTemplateManager->getIndexTemplate($indexName);
 

--- a/src/Logger/ElasticaLogger.php
+++ b/src/Logger/ElasticaLogger.php
@@ -24,17 +24,13 @@ use Psr\Log\LoggerInterface;
  */
 class ElasticaLogger extends AbstractLogger
 {
-    protected ?LoggerInterface $logger;
     /**
      * @var list<array<string, mixed>>
      */
     protected array $queries = [];
-    protected bool $debug;
 
-    public function __construct(?LoggerInterface $logger = null, bool $debug = false)
+    public function __construct(protected ?LoggerInterface $logger = null, protected bool $debug = false)
     {
-        $this->logger = $logger;
-        $this->debug = $debug;
     }
 
     /**
@@ -47,10 +43,8 @@ class ElasticaLogger extends AbstractLogger
      * @param array<mixed>        $connection Host, port, transport, and headers of the query
      * @param array<mixed>        $query      Arguments
      * @param int                 $engineTime
-     *
-     * @return void
      */
-    public function logQuery(string $path, string $method, $data, $queryTime, $connection = [], $query = [], $engineTime = 0, int $itemCount = 0)
+    public function logQuery(string $path, string $method, $data, $queryTime, $connection = [], $query = [], $engineTime = 0, int $itemCount = 0): void
     {
         $executionMS = $queryTime * 1000;
 
@@ -60,7 +54,7 @@ class ElasticaLogger extends AbstractLogger
                 $jsonStrings = \explode("\n", $data);
                 $data = [];
                 foreach ($jsonStrings as $json) {
-                    if ('' != $json) {
+                    if ('' !== $json) {
                         $data[] = \json_decode($json, true);
                     }
                 }
@@ -81,7 +75,7 @@ class ElasticaLogger extends AbstractLogger
             ];
         }
 
-        if (null !== $this->logger) {
+        if ($this->logger instanceof LoggerInterface) {
             $message = \sprintf('%s (%s) %0.2f ms', $path, $method, $executionMS);
             $this->logger->info($message, (array) $data);
         }

--- a/src/Manager/RepositoryManager.php
+++ b/src/Manager/RepositoryManager.php
@@ -27,7 +27,7 @@ class RepositoryManager implements RepositoryManagerInterface
     /**
      * @var array<string, array{finder: FinderInterface, repositoryName: ?class-string}>
      */
-    private $indexes = [];
+    private array $indexes = [];
 
     /**
      * @var array<string, Repository>

--- a/src/Manager/RepositoryManager.php
+++ b/src/Manager/RepositoryManager.php
@@ -32,7 +32,7 @@ class RepositoryManager implements RepositoryManagerInterface
     /**
      * @var array<string, Repository>
      */
-    private $repositories = [];
+    private array $repositories = [];
 
     private ContainerInterface $repositoryLocator;
 
@@ -84,10 +84,7 @@ class RepositoryManager implements RepositoryManagerInterface
         return $this->indexes[$indexName]['repositoryName'] ?? Repository::class;
     }
 
-    /**
-     * @return Repository
-     */
-    private function createRepository(string $indexName)
+    private function createRepository(string $indexName): Repository
     {
         if ($this->repositoryLocator->has($indexName)) {
             return $this->repositoryLocator->get($indexName);

--- a/src/Manager/RepositoryManagerInterface.php
+++ b/src/Manager/RepositoryManagerInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the FOSElasticaBundle package.
  *

--- a/src/Message/AsyncPersistPage.php
+++ b/src/Message/AsyncPersistPage.php
@@ -19,24 +19,15 @@ use FOS\ElasticaBundle\Event\AbstractIndexPopulateEvent;
 class AsyncPersistPage
 {
     /**
-     * @var int
-     */
-    private $page;
-
-    /**
-     * @var array
-     *
-     * @phpstan-var TOptions
-     */
-    private $options;
-
-    /**
      * @phpstan-param TOptions $options
      */
-    public function __construct(int $page, array $options)
-    {
-        $this->page = $page;
-        $this->options = $options;
+    public function __construct(
+        private readonly int $page,
+        /**
+         * @phpstan-var TOptions
+         */
+        private readonly array $options
+    ) {
     }
 
     public function getPage(): int

--- a/src/Message/Handler/AsyncPersistPageHandler.php
+++ b/src/Message/Handler/AsyncPersistPageHandler.php
@@ -18,11 +18,8 @@ use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 #[AsMessageHandler]
 class AsyncPersistPageHandler
 {
-    private AsyncPagerPersister $persister;
-
-    public function __construct(AsyncPagerPersister $persister)
+    public function __construct(private readonly AsyncPagerPersister $persister)
     {
-        $this->persister = $persister;
     }
 
     public function __invoke(AsyncPersistPage $message): void

--- a/src/Paginator/FantaPaginatorAdapter.php
+++ b/src/Paginator/FantaPaginatorAdapter.php
@@ -21,20 +21,16 @@ use Pagerfanta\Adapter\AdapterInterface;
 class FantaPaginatorAdapter implements AdapterInterface
 {
     /**
-     * @var PaginatorAdapterInterface<T>
-     *
-     * @phpstan-ignore-next-line todo: make PaginatorAdapterInterface generic
-     */
-    private $adapter;
-
-    /**
      * @param PaginatorAdapterInterface<T> $adapter
      *
      * @phpstan-ignore-next-line todo: make PaginatorAdapterInterface generic
      */
-    public function __construct(PaginatorAdapterInterface $adapter)
-    {
-        $this->adapter = $adapter;
+    public function __construct(
+        /**
+         * @phpstan-ignore-next-line todo: make PaginatorAdapterInterface generic
+         */
+        private readonly PaginatorAdapterInterface $adapter
+    ) {
     }
 
     /**

--- a/src/Paginator/FantaPaginatorAdapter.php
+++ b/src/Paginator/FantaPaginatorAdapter.php
@@ -48,7 +48,7 @@ class FantaPaginatorAdapter implements AdapterInterface
      *
      * @api
      */
-    public function getAggregations()
+    public function getAggregations(): array
     {
         return $this->adapter->getAggregations();
     }
@@ -60,26 +60,20 @@ class FantaPaginatorAdapter implements AdapterInterface
      *
      * @api
      */
-    public function getSuggests()
+    public function getSuggests(): array
     {
         return $this->adapter->getSuggests();
     }
 
     /**
      * Returns a slice of the results.
-     *
-     * @param int $offset The offset
-     * @param int $length The length
      */
-    public function getSlice($offset, $length): iterable
+    public function getSlice(int $offset, int $length): iterable
     {
         return $this->adapter->getResults($offset, $length)->toArray();
     }
 
-    /**
-     * @return float
-     */
-    public function getMaxScore()
+    public function getMaxScore(): float
     {
         return $this->adapter->getMaxScore();
     }

--- a/src/Paginator/HybridPaginatorAdapter.php
+++ b/src/Paginator/HybridPaginatorAdapter.php
@@ -20,21 +20,17 @@ use FOS\ElasticaBundle\Transformer\ElasticaToModelTransformerInterface;
  */
 class HybridPaginatorAdapter extends RawPaginatorAdapter
 {
-    private $transformer;
-
     /**
      * @param SearchableInterface                 $searchable  the object to search in
      * @param Query                               $query       the query to search
      * @param ElasticaToModelTransformerInterface $transformer the transformer for fetching the results
      */
-    public function __construct(SearchableInterface $searchable, Query $query, array $options, ElasticaToModelTransformerInterface $transformer)
+    public function __construct(SearchableInterface $searchable, Query $query, array $options, private readonly ElasticaToModelTransformerInterface $transformer)
     {
         parent::__construct($searchable, $query, $options);
-
-        $this->transformer = $transformer;
     }
 
-    public function getResults($offset, $length)
+    public function getResults($offset, $length): HybridPartialResults
     {
         return new HybridPartialResults($this->getElasticaResults($offset, $length), $this->transformer);
     }

--- a/src/Paginator/HybridPartialResults.php
+++ b/src/Paginator/HybridPartialResults.php
@@ -20,16 +20,9 @@ use FOS\ElasticaBundle\Transformer\ElasticaToModelTransformerInterface;
  */
 class HybridPartialResults extends RawPartialResults
 {
-    /**
-     * @var ElasticaToModelTransformerInterface
-     */
-    protected $transformer;
-
-    public function __construct(ResultSet $resultSet, ElasticaToModelTransformerInterface $transformer)
+    public function __construct(ResultSet $resultSet, protected ElasticaToModelTransformerInterface $transformer)
     {
         parent::__construct($resultSet);
-
-        $this->transformer = $transformer;
     }
 
     /**

--- a/src/Paginator/PaginatorAdapterInterface.php
+++ b/src/Paginator/PaginatorAdapterInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the FOSElasticaBundle package.
  *

--- a/src/Paginator/PaginatorAdapterInterface.php
+++ b/src/Paginator/PaginatorAdapterInterface.php
@@ -17,39 +17,30 @@ interface PaginatorAdapterInterface
 {
     /**
      * Returns the number of results.
-     *
-     * @return int The number of results
      */
-    public function getTotalHits();
+    public function getTotalHits(): int;
 
     /**
      * Returns an slice of the results.
-     *
-     * @param int $offset The offset
-     * @param int $length The length
-     *
-     * @return PartialResultsInterface
      */
-    public function getResults($offset, $length);
+    public function getResults(int $offset, int $length): PartialResultsInterface;
 
     /**
      * Returns Aggregations.
      *
      * @return array<string, mixed>
      */
-    public function getAggregations();
+    public function getAggregations(): array;
 
     /**
      * Returns Suggests.
      *
      * @return array<string, mixed>
      */
-    public function getSuggests();
+    public function getSuggests(): array;
 
     /**
      * Returns the max score.
-     *
-     * @return float
      */
-    public function getMaxScore();
+    public function getMaxScore(): float;
 }

--- a/src/Paginator/PartialResultsInterface.php
+++ b/src/Paginator/PartialResultsInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the FOSElasticaBundle package.
  *

--- a/src/Paginator/RawPaginatorAdapter.php
+++ b/src/Paginator/RawPaginatorAdapter.php
@@ -20,35 +20,19 @@ use Elastica\SearchableInterface;
  */
 class RawPaginatorAdapter implements PaginatorAdapterInterface
 {
-    /**
-     * @var SearchableInterface the object to search in
-     */
-    private $searchable;
-
-    /**
-     * @var Query the query to search
-     */
-    private $query;
-
-    /**
-     * @var ?int the number of hits
-     */
-    private $totalHits;
+    private ?int $totalHits = null;
 
     /**
      * @var array<string, mixed>|null for the aggregations
      */
-    private $aggregations;
+    private ?array $aggregations = null;
 
     /**
      * @var array<string, mixed>|null for the suggesters
      */
-    private $suggests;
+    private ?array $suggests = null;
 
-    /**
-     * @var ?float
-     */
-    private $maxScore;
+    private ?float $maxScore = null;
 
     /**
      * @see PaginatorAdapterInterface::__construct
@@ -57,13 +41,11 @@ class RawPaginatorAdapter implements PaginatorAdapterInterface
      * @param Query                $query      the query to search
      * @param array<string, mixed> $options
      */
-    public function __construct(SearchableInterface $searchable, Query $query, private readonly array $options = [])
+    public function __construct(private readonly SearchableInterface $searchable, private readonly Query $query, private readonly array $options = [])
     {
-        $this->searchable = $searchable;
-        $this->query = $query;
     }
 
-    public function getResults($offset, $itemCountPerPage): RawPartialResults
+    public function getResults(int $offset, int $itemCountPerPage): RawPartialResults
     {
         return new RawPartialResults($this->getElasticaResults($offset, $itemCountPerPage));
     }
@@ -74,12 +56,8 @@ class RawPaginatorAdapter implements PaginatorAdapterInterface
      * If genuineTotal is provided as true, total hits is returned from the
      * `hits.total` value from the search results instead of just returning
      * the requested size.
-     *
-     * {@inheritdoc}
-     *
-     * @param bool $genuineTotal
      */
-    public function getTotalHits($genuineTotal = false)
+    public function getTotalHits(bool $genuineTotal = false): int
     {
         if (null === $this->totalHits) {
             $this->totalHits = $this->searchable->count($this->query);
@@ -90,7 +68,7 @@ class RawPaginatorAdapter implements PaginatorAdapterInterface
             : $this->totalHits;
     }
 
-    public function getAggregations()
+    public function getAggregations(): array
     {
         if (null === $this->aggregations) {
             $this->aggregations = $this->searchable->search($this->query)->getAggregations();
@@ -99,7 +77,7 @@ class RawPaginatorAdapter implements PaginatorAdapterInterface
         return $this->aggregations;
     }
 
-    public function getSuggests()
+    public function getSuggests(): array
     {
         if (null === $this->suggests) {
             $this->suggests = $this->searchable->search($this->query)->getSuggests();
@@ -108,10 +86,7 @@ class RawPaginatorAdapter implements PaginatorAdapterInterface
         return $this->suggests;
     }
 
-    /**
-     * @return float
-     */
-    public function getMaxScore()
+    public function getMaxScore(): float
     {
         if (null === $this->maxScore) {
             $this->maxScore = $this->searchable->search($this->query)->getMaxScore();
@@ -122,10 +97,8 @@ class RawPaginatorAdapter implements PaginatorAdapterInterface
 
     /**
      * Returns the Query.
-     *
-     * @return Query the search query
      */
-    public function getQuery()
+    public function getQuery(): Query
     {
         return $this->query;
     }
@@ -133,17 +106,10 @@ class RawPaginatorAdapter implements PaginatorAdapterInterface
     /**
      * Returns the paginated results.
      *
-     * @param int $offset
-     * @param int $itemCountPerPage
-     *
-     * @return ResultSet
-     *
      * @throws \InvalidArgumentException
      */
-    protected function getElasticaResults($offset, $itemCountPerPage)
+    protected function getElasticaResults(int $offset, int $itemCountPerPage): ResultSet
     {
-        $offset = (int) $offset;
-        $itemCountPerPage = (int) $itemCountPerPage;
         $size = $this->query->hasParam('size')
             ? (int) $this->query->getParam('size')
             : null;

--- a/src/Paginator/RawPaginatorAdapter.php
+++ b/src/Paginator/RawPaginatorAdapter.php
@@ -31,11 +31,6 @@ class RawPaginatorAdapter implements PaginatorAdapterInterface
     private $query;
 
     /**
-     * @var array<string, mixed> search options
-     */
-    private $options;
-
-    /**
      * @var ?int the number of hits
      */
     private $totalHits;
@@ -62,14 +57,13 @@ class RawPaginatorAdapter implements PaginatorAdapterInterface
      * @param Query                $query      the query to search
      * @param array<string, mixed> $options
      */
-    public function __construct(SearchableInterface $searchable, Query $query, array $options = [])
+    public function __construct(SearchableInterface $searchable, Query $query, private readonly array $options = [])
     {
         $this->searchable = $searchable;
         $this->query = $query;
-        $this->options = $options;
     }
 
-    public function getResults($offset, $itemCountPerPage)
+    public function getResults($offset, $itemCountPerPage): RawPartialResults
     {
         return new RawPartialResults($this->getElasticaResults($offset, $itemCountPerPage));
     }
@@ -87,7 +81,7 @@ class RawPaginatorAdapter implements PaginatorAdapterInterface
      */
     public function getTotalHits($genuineTotal = false)
     {
-        if (!isset($this->totalHits)) {
+        if (null === $this->totalHits) {
             $this->totalHits = $this->searchable->count($this->query);
         }
 
@@ -98,7 +92,7 @@ class RawPaginatorAdapter implements PaginatorAdapterInterface
 
     public function getAggregations()
     {
-        if (!isset($this->aggregations)) {
+        if (null === $this->aggregations) {
             $this->aggregations = $this->searchable->search($this->query)->getAggregations();
         }
 
@@ -107,7 +101,7 @@ class RawPaginatorAdapter implements PaginatorAdapterInterface
 
     public function getSuggests()
     {
-        if (!isset($this->suggests)) {
+        if (null === $this->suggests) {
             $this->suggests = $this->searchable->search($this->query)->getSuggests();
         }
 
@@ -119,7 +113,7 @@ class RawPaginatorAdapter implements PaginatorAdapterInterface
      */
     public function getMaxScore()
     {
-        if (!isset($this->maxScore)) {
+        if (null === $this->maxScore) {
             $this->maxScore = $this->searchable->search($this->query)->getMaxScore();
         }
 

--- a/src/Paginator/RawPartialResults.php
+++ b/src/Paginator/RawPartialResults.php
@@ -34,9 +34,7 @@ class RawPartialResults implements PartialResultsInterface
      */
     public function toArray(): array
     {
-        return \array_map(static function (Result $result) {
-            return $result->getSource();
-        }, $this->resultSet->getResults());
+        return \array_map(static fn (Result $result) => $result->getSource(), $this->resultSet->getResults());
     }
 
     public function getTotalHits(): int

--- a/src/Paginator/RawPartialResults.php
+++ b/src/Paginator/RawPartialResults.php
@@ -19,14 +19,8 @@ use Elastica\ResultSet;
  */
 class RawPartialResults implements PartialResultsInterface
 {
-    /**
-     * @var ResultSet
-     */
-    protected $resultSet;
-
-    public function __construct(ResultSet $resultSet)
+    public function __construct(protected ResultSet $resultSet)
     {
-        $this->resultSet = $resultSet;
     }
 
     /**
@@ -34,7 +28,7 @@ class RawPartialResults implements PartialResultsInterface
      */
     public function toArray(): array
     {
-        return \array_map(static fn (Result $result) => $result->getSource(), $this->resultSet->getResults());
+        return \array_map(static fn (Result $result): array => $result->getSource(), $this->resultSet->getResults());
     }
 
     public function getTotalHits(): int

--- a/src/Paginator/TransformedPaginatorAdapter.php
+++ b/src/Paginator/TransformedPaginatorAdapter.php
@@ -20,21 +20,17 @@ use FOS\ElasticaBundle\Transformer\ElasticaToModelTransformerInterface;
  */
 class TransformedPaginatorAdapter extends RawPaginatorAdapter
 {
-    private $transformer;
-
     /**
      * @param SearchableInterface                 $searchable  the object to search in
      * @param Query                               $query       the query to search
      * @param ElasticaToModelTransformerInterface $transformer the transformer for fetching the results
      */
-    public function __construct(SearchableInterface $searchable, Query $query, array $options, ElasticaToModelTransformerInterface $transformer)
+    public function __construct(SearchableInterface $searchable, Query $query, array $options, private readonly ElasticaToModelTransformerInterface $transformer)
     {
         parent::__construct($searchable, $query, $options);
-
-        $this->transformer = $transformer;
     }
 
-    public function getResults($offset, $length)
+    public function getResults($offset, $length): TransformedPartialResults
     {
         return new TransformedPartialResults($this->getElasticaResults($offset, $length), $this->transformer);
     }

--- a/src/Paginator/TransformedPartialResults.php
+++ b/src/Paginator/TransformedPartialResults.php
@@ -19,16 +19,9 @@ use FOS\ElasticaBundle\Transformer\ElasticaToModelTransformerInterface;
  */
 class TransformedPartialResults extends RawPartialResults
 {
-    /**
-     * @var ElasticaToModelTransformerInterface
-     */
-    protected $transformer;
-
-    public function __construct(ResultSet $resultSet, ElasticaToModelTransformerInterface $transformer)
+    public function __construct(ResultSet $resultSet, protected ElasticaToModelTransformerInterface $transformer)
     {
         parent::__construct($resultSet);
-
-        $this->transformer = $transformer;
     }
 
     /**

--- a/src/Persister/AsyncPagerPersister.php
+++ b/src/Persister/AsyncPagerPersister.php
@@ -25,27 +25,15 @@ final class AsyncPagerPersister implements PagerPersisterInterface
     private const DEFAULT_PAGE_SIZE = 100;
 
     /**
-     * @var PagerPersisterRegistry
-     */
-    private $pagerPersisterRegistry;
-
-    /**
-     * @var PagerProviderRegistry
-     */
-    private $pagerProviderRegistry;
-
-    /**
      * @var MessageBusInterface
      */
     private $messageBus;
 
     public function __construct(
-        PagerPersisterRegistry $pagerPersisterRegistry,
-        PagerProviderRegistry $pagerProviderRegistry,
+        private readonly PagerPersisterRegistry $pagerPersisterRegistry,
+        private readonly PagerProviderRegistry $pagerProviderRegistry,
         MessageBusInterface $messageBus,
     ) {
-        $this->pagerPersisterRegistry = $pagerPersisterRegistry;
-        $this->pagerProviderRegistry = $pagerProviderRegistry;
         $this->messageBus = $messageBus;
     }
 

--- a/src/Persister/AsyncPagerPersister.php
+++ b/src/Persister/AsyncPagerPersister.php
@@ -24,17 +24,8 @@ final class AsyncPagerPersister implements PagerPersisterInterface
     public const NAME = 'async';
     private const DEFAULT_PAGE_SIZE = 100;
 
-    /**
-     * @var MessageBusInterface
-     */
-    private $messageBus;
-
-    public function __construct(
-        private readonly PagerPersisterRegistry $pagerPersisterRegistry,
-        private readonly PagerProviderRegistry $pagerProviderRegistry,
-        MessageBusInterface $messageBus,
-    ) {
-        $this->messageBus = $messageBus;
+    public function __construct(private readonly PagerPersisterRegistry $pagerPersisterRegistry, private readonly PagerProviderRegistry $pagerProviderRegistry, private readonly MessageBusInterface $messageBus)
+    {
     }
 
     public function insert(PagerInterface $pager, array $options = []): void

--- a/src/Persister/Event/OnExceptionEvent.php
+++ b/src/Persister/Event/OnExceptionEvent.php
@@ -17,52 +17,14 @@ use Symfony\Contracts\EventDispatcher\Event;
 
 final class OnExceptionEvent extends Event implements PersistEvent
 {
-    /**
-     * @var PagerInterface
-     */
-    private $pager;
-
-    /**
-     * @var ObjectPersisterInterface
-     */
-    private $objectPersister;
-
-    /**
-     * @var \Exception
-     */
-    private $exception;
-
-    /**
-     * @var array<string, mixed>
-     */
-    private $options;
-
-    /**
-     * @var list<object>
-     */
-    private $objects;
-
-    /**
-     * @var bool
-     */
-    private $ignored = false;
+    private bool $ignored = false;
 
     /**
      * @param list<object>         $objects
      * @param array<string, mixed> $options
      */
-    public function __construct(
-        PagerInterface $pager,
-        ObjectPersisterInterface $objectPersister,
-        \Exception $exception,
-        array $objects,
-        array $options,
-    ) {
-        $this->pager = $pager;
-        $this->objectPersister = $objectPersister;
-        $this->exception = $exception;
-        $this->options = $options;
-        $this->objects = $objects;
+    public function __construct(private readonly PagerInterface $pager, private readonly ObjectPersisterInterface $objectPersister, private \Exception $exception, private readonly array $objects, private readonly array $options)
+    {
     }
 
     public function getPager(): PagerInterface
@@ -85,10 +47,7 @@ final class OnExceptionEvent extends Event implements PersistEvent
         return $this->exception;
     }
 
-    /**
-     * @return void
-     */
-    public function setException(\Exception $exception)
+    public function setException(\Exception $exception): void
     {
         $this->exception = $exception;
     }
@@ -98,10 +57,7 @@ final class OnExceptionEvent extends Event implements PersistEvent
         return $this->ignored;
     }
 
-    /**
-     * @return void
-     */
-    public function setIgnored(bool $ignored)
+    public function setIgnored(bool $ignored): void
     {
         $this->ignored = $ignored;
     }

--- a/src/Persister/Event/PersistEvent.php
+++ b/src/Persister/Event/PersistEvent.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the FOSElasticaBundle package.
  *

--- a/src/Persister/Event/PostAsyncInsertObjectsEvent.php
+++ b/src/Persister/Event/PostAsyncInsertObjectsEvent.php
@@ -23,40 +23,10 @@ use Symfony\Contracts\EventDispatcher\Event;
 final class PostAsyncInsertObjectsEvent extends Event implements PersistEvent
 {
     /**
-     * @var PagerInterface
-     */
-    private $pager;
-
-    /**
-     * @var ObjectPersisterInterface
-     */
-    private $objectPersister;
-
-    /**
-     * @var int
-     */
-    private $objectsCount;
-
-    /**
-     * @var string|null
-     */
-    private $errorMessage;
-
-    /**
-     * @var array<string, mixed>
-     */
-    private $options;
-
-    /**
      * @param array<string, mixed> $options
      */
-    public function __construct(PagerInterface $pager, ObjectPersisterInterface $objectPersister, int $objectsCount, ?string $errorMessage, array $options)
+    public function __construct(private readonly PagerInterface $pager, private readonly ObjectPersisterInterface $objectPersister, private readonly int $objectsCount, private readonly ?string $errorMessage, private readonly array $options)
     {
-        $this->pager = $pager;
-        $this->objectPersister = $objectPersister;
-        $this->objectsCount = $objectsCount;
-        $this->errorMessage = $errorMessage;
-        $this->options = $options;
     }
 
     public function getPager(): PagerInterface

--- a/src/Persister/Event/PostInsertObjectsEvent.php
+++ b/src/Persister/Event/PostInsertObjectsEvent.php
@@ -18,38 +18,11 @@ use Symfony\Contracts\EventDispatcher\Event;
 final class PostInsertObjectsEvent extends Event implements PersistEvent
 {
     /**
-     * @var PagerInterface
-     */
-    private $pager;
-
-    /**
-     * @var ObjectPersisterInterface
-     */
-    private $objectPersister;
-
-    /**
-     * @var list<object>
-     */
-    private $objects;
-
-    /**
-     * @var array<string, mixed>
-     */
-    private $options;
-
-    private int $filteredObjectCount;
-
-    /**
      * @param list<object>         $objects
      * @param array<string, mixed> $options
      */
-    public function __construct(PagerInterface $pager, ObjectPersisterInterface $objectPersister, array $objects, array $options, int $filteredObjectCount = 0)
+    public function __construct(private readonly PagerInterface $pager, private readonly ObjectPersisterInterface $objectPersister, private readonly array $objects, private readonly array $options, private readonly int $filteredObjectCount = 0)
     {
-        $this->pager = $pager;
-        $this->objectPersister = $objectPersister;
-        $this->objects = $objects;
-        $this->options = $options;
-        $this->filteredObjectCount = $filteredObjectCount;
     }
 
     public function getPager(): PagerInterface

--- a/src/Persister/Event/PostPersistEvent.php
+++ b/src/Persister/Event/PostPersistEvent.php
@@ -18,28 +18,10 @@ use Symfony\Contracts\EventDispatcher\Event;
 final class PostPersistEvent extends Event implements PersistEvent
 {
     /**
-     * @var PagerInterface
-     */
-    private $pager;
-
-    /**
-     * @var ObjectPersisterInterface
-     */
-    private $objectPersister;
-
-    /**
-     * @var array<string, mixed>
-     */
-    private $options;
-
-    /**
      * @param array<string, mixed> $options
      */
-    public function __construct(PagerInterface $pager, ObjectPersisterInterface $objectPersister, array $options)
+    public function __construct(private readonly PagerInterface $pager, private readonly ObjectPersisterInterface $objectPersister, private readonly array $options)
     {
-        $this->pager = $pager;
-        $this->objectPersister = $objectPersister;
-        $this->options = $options;
     }
 
     public function getPager(): PagerInterface

--- a/src/Persister/Event/PreFetchObjectsEvent.php
+++ b/src/Persister/Event/PreFetchObjectsEvent.php
@@ -18,28 +18,10 @@ use Symfony\Contracts\EventDispatcher\Event;
 final class PreFetchObjectsEvent extends Event implements PersistEvent
 {
     /**
-     * @var PagerInterface
-     */
-    private $pager;
-
-    /**
-     * @var ObjectPersisterInterface
-     */
-    private $objectPersister;
-
-    /**
-     * @var array<string, mixed>
-     */
-    private $options;
-
-    /**
      * @param array<string, mixed> $options
      */
-    public function __construct(PagerInterface $pager, ObjectPersisterInterface $objectPersister, array $options)
+    public function __construct(private PagerInterface $pager, private ObjectPersisterInterface $objectPersister, private array $options)
     {
-        $this->pager = $pager;
-        $this->objectPersister = $objectPersister;
-        $this->options = $options;
     }
 
     public function getPager(): PagerInterface
@@ -47,10 +29,7 @@ final class PreFetchObjectsEvent extends Event implements PersistEvent
         return $this->pager;
     }
 
-    /**
-     * @return void
-     */
-    public function setPager(PagerInterface $pager)
+    public function setPager(PagerInterface $pager): void
     {
         $this->pager = $pager;
     }
@@ -62,10 +41,8 @@ final class PreFetchObjectsEvent extends Event implements PersistEvent
 
     /**
      * @param array<string, mixed> $options
-     *
-     * @return void
      */
-    public function setOptions(array $options)
+    public function setOptions(array $options): void
     {
         $this->options = $options;
     }
@@ -75,10 +52,7 @@ final class PreFetchObjectsEvent extends Event implements PersistEvent
         return $this->objectPersister;
     }
 
-    /**
-     * @return void
-     */
-    public function setObjectPersister(ObjectPersisterInterface $objectPersister)
+    public function setObjectPersister(ObjectPersisterInterface $objectPersister): void
     {
         $this->objectPersister = $objectPersister;
     }

--- a/src/Persister/Event/PreInsertObjectsEvent.php
+++ b/src/Persister/Event/PreInsertObjectsEvent.php
@@ -17,38 +17,14 @@ use Symfony\Contracts\EventDispatcher\Event;
 
 final class PreInsertObjectsEvent extends Event implements PersistEvent
 {
-    /**
-     * @var PagerInterface
-     */
-    private $pager;
-
-    /**
-     * @var ObjectPersisterInterface
-     */
-    private $objectPersister;
-
-    /**
-     * @var list<object>
-     */
-    private $objects;
-
-    /**
-     * @var array<string, mixed>
-     */
-    private $options;
-
     private int $filteredObjectCount = 0;
 
     /**
      * @param list<object>         $objects
      * @param array<string, mixed> $options
      */
-    public function __construct(PagerInterface $pager, ObjectPersisterInterface $objectPersister, array $objects, array $options)
+    public function __construct(private PagerInterface $pager, private ObjectPersisterInterface $objectPersister, private array $objects, private array $options)
     {
-        $this->pager = $pager;
-        $this->objectPersister = $objectPersister;
-        $this->objects = $objects;
-        $this->options = $options;
     }
 
     public function getPager(): PagerInterface
@@ -56,10 +32,7 @@ final class PreInsertObjectsEvent extends Event implements PersistEvent
         return $this->pager;
     }
 
-    /**
-     * @return void
-     */
-    public function setPager(PagerInterface $pager)
+    public function setPager(PagerInterface $pager): void
     {
         $this->pager = $pager;
     }
@@ -71,10 +44,8 @@ final class PreInsertObjectsEvent extends Event implements PersistEvent
 
     /**
      * @param array<string, mixed> $options
-     *
-     * @return void
      */
-    public function setOptions(array $options)
+    public function setOptions(array $options): void
     {
         $this->options = $options;
     }
@@ -84,10 +55,7 @@ final class PreInsertObjectsEvent extends Event implements PersistEvent
         return $this->objectPersister;
     }
 
-    /**
-     * @return void
-     */
-    public function setObjectPersister(ObjectPersisterInterface $objectPersister)
+    public function setObjectPersister(ObjectPersisterInterface $objectPersister): void
     {
         $this->objectPersister = $objectPersister;
     }
@@ -102,10 +70,8 @@ final class PreInsertObjectsEvent extends Event implements PersistEvent
 
     /**
      * @param list<object> $objects
-     *
-     * @return void
      */
-    public function setObjects($objects)
+    public function setObjects($objects): void
     {
         $this->objects = $objects;
     }

--- a/src/Persister/Event/PreInsertObjectsEvent.php
+++ b/src/Persister/Event/PreInsertObjectsEvent.php
@@ -63,7 +63,7 @@ final class PreInsertObjectsEvent extends Event implements PersistEvent
     /**
      * @return list<object>
      */
-    public function getObjects()
+    public function getObjects(): array
     {
         return $this->objects;
     }
@@ -71,7 +71,7 @@ final class PreInsertObjectsEvent extends Event implements PersistEvent
     /**
      * @param list<object> $objects
      */
-    public function setObjects($objects): void
+    public function setObjects(array $objects): void
     {
         $this->objects = $objects;
     }

--- a/src/Persister/Event/PrePersistEvent.php
+++ b/src/Persister/Event/PrePersistEvent.php
@@ -18,28 +18,10 @@ use Symfony\Contracts\EventDispatcher\Event;
 final class PrePersistEvent extends Event implements PersistEvent
 {
     /**
-     * @var PagerInterface
-     */
-    private $pager;
-
-    /**
-     * @var ObjectPersisterInterface
-     */
-    private $objectPersister;
-
-    /**
-     * @var array<string, mixed>
-     */
-    private $options;
-
-    /**
      * @param array<string, mixed> $options
      */
-    public function __construct(PagerInterface $pager, ObjectPersisterInterface $objectPersister, array $options)
+    public function __construct(private PagerInterface $pager, private ObjectPersisterInterface $objectPersister, private array $options)
     {
-        $this->pager = $pager;
-        $this->objectPersister = $objectPersister;
-        $this->options = $options;
     }
 
     public function getPager(): PagerInterface
@@ -47,10 +29,7 @@ final class PrePersistEvent extends Event implements PersistEvent
         return $this->pager;
     }
 
-    /**
-     * @return void
-     */
-    public function setPager(PagerInterface $pager)
+    public function setPager(PagerInterface $pager): void
     {
         $this->pager = $pager;
     }
@@ -62,10 +41,8 @@ final class PrePersistEvent extends Event implements PersistEvent
 
     /**
      * @param array<string, mixed> $options
-     *
-     * @return void
      */
-    public function setOptions(array $options)
+    public function setOptions(array $options): void
     {
         $this->options = $options;
     }
@@ -75,10 +52,7 @@ final class PrePersistEvent extends Event implements PersistEvent
         return $this->objectPersister;
     }
 
-    /**
-     * @return void
-     */
-    public function setObjectPersister(ObjectPersisterInterface $objectPersister)
+    public function setObjectPersister(ObjectPersisterInterface $objectPersister): void
     {
         $this->objectPersister = $objectPersister;
     }

--- a/src/Persister/InPlacePagerPersister.php
+++ b/src/Persister/InPlacePagerPersister.php
@@ -26,11 +26,9 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 final class InPlacePagerPersister implements PagerPersisterInterface
 {
     public const NAME = 'in_place';
-    private readonly EventDispatcherInterface $dispatcher;
 
-    public function __construct(private readonly PersisterRegistry $registry, EventDispatcherInterface $dispatcher)
+    public function __construct(private readonly PersisterRegistry $registry, private readonly EventDispatcherInterface $dispatcher)
     {
-        $this->dispatcher = $dispatcher;
     }
 
     public function insert(PagerInterface $pager, array $options = []): void

--- a/src/Persister/InPlacePagerPersister.php
+++ b/src/Persister/InPlacePagerPersister.php
@@ -26,17 +26,14 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 final class InPlacePagerPersister implements PagerPersisterInterface
 {
     public const NAME = 'in_place';
+    private readonly EventDispatcherInterface $dispatcher;
 
-    private PersisterRegistry $registry;
-    private EventDispatcherInterface $dispatcher;
-
-    public function __construct(PersisterRegistry $registry, EventDispatcherInterface $dispatcher)
+    public function __construct(private readonly PersisterRegistry $registry, EventDispatcherInterface $dispatcher)
     {
-        $this->registry = $registry;
         $this->dispatcher = $dispatcher;
     }
 
-    public function insert(PagerInterface $pager, array $options = [])
+    public function insert(PagerInterface $pager, array $options = []): void
     {
         $pager->setMaxPerPage(empty($options['max_per_page']) ? 100 : $options['max_per_page']);
 

--- a/src/Persister/Listener/FilterObjectsListener.php
+++ b/src/Persister/Listener/FilterObjectsListener.php
@@ -17,17 +17,14 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class FilterObjectsListener implements EventSubscriberInterface
 {
-    private IndexableInterface $indexable;
-
-    public function __construct(IndexableInterface $indexable)
+    public function __construct(private readonly IndexableInterface $indexable)
     {
-        $this->indexable = $indexable;
     }
 
     public function filterObjects(PreInsertObjectsEvent $event): void
     {
         $options = $event->getOptions();
-        if (false == empty($options['skip_indexable_check'])) {
+        if (false === empty($options['skip_indexable_check'])) {
             return;
         }
 

--- a/src/Persister/ObjectPersister.php
+++ b/src/Persister/ObjectPersister.php
@@ -36,29 +36,9 @@ class ObjectPersister implements ObjectPersisterInterface
      */
     protected $index;
     /**
-     * @var ModelToElasticaTransformerInterface
-     */
-    protected $transformer;
-    /**
-     * @var class-string
-     */
-    protected $objectClass;
-    /**
-     * @var array
-     *
-     * @phpstan-var TFields
-     */
-    protected $fields;
-    /**
      * @var ?LoggerInterface
      */
     protected $logger;
-    /**
-     * @var array
-     *
-     * @phpstan-var TOptions
-     */
-    private $options;
 
     /**
      * @param class-string $objectClass
@@ -66,13 +46,15 @@ class ObjectPersister implements ObjectPersisterInterface
      * @phpstan-param TFields $fields
      * @phpstan-param TOptions $options
      */
-    public function __construct(Index $index, ModelToElasticaTransformerInterface $transformer, string $objectClass, array $fields, array $options = [])
+    public function __construct(Index $index, protected ModelToElasticaTransformerInterface $transformer, protected string $objectClass, /**
+     * @phpstan-var TFields
+     */
+        protected array $fields, /**
+     * @phpstan-var TOptions
+     */
+        private readonly array $options = [])
     {
         $this->index = $index;
-        $this->transformer = $transformer;
-        $this->objectClass = $objectClass;
-        $this->fields = $fields;
-        $this->options = $options;
     }
 
     public function handlesObject($object): bool
@@ -80,35 +62,32 @@ class ObjectPersister implements ObjectPersisterInterface
         return $object instanceof $this->objectClass;
     }
 
-    /**
-     * @return void
-     */
-    public function setLogger(LoggerInterface $logger)
+    public function setLogger(LoggerInterface $logger): void
     {
         $this->logger = $logger;
     }
 
-    public function insertOne($object)
+    public function insertOne($object): void
     {
         $this->insertMany([$object]);
     }
 
-    public function replaceOne($object)
+    public function replaceOne($object): void
     {
         $this->replaceMany([$object]);
     }
 
-    public function deleteOne($object)
+    public function deleteOne($object): void
     {
         $this->deleteMany([$object]);
     }
 
-    public function deleteById($id, $routing = false)
+    public function deleteById($id, $routing = false): void
     {
         $this->deleteManyByIdentifiers([(string) $id], $routing);
     }
 
-    public function insertMany(array $objects)
+    public function insertMany(array $objects): void
     {
         $documents = [];
         foreach ($objects as $object) {
@@ -121,7 +100,7 @@ class ObjectPersister implements ObjectPersisterInterface
         }
     }
 
-    public function replaceMany(array $objects)
+    public function replaceMany(array $objects): void
     {
         $documents = [];
         foreach ($objects as $object) {
@@ -137,7 +116,7 @@ class ObjectPersister implements ObjectPersisterInterface
         }
     }
 
-    public function deleteMany(array $objects)
+    public function deleteMany(array $objects): void
     {
         $documents = [];
         foreach ($objects as $object) {
@@ -150,7 +129,7 @@ class ObjectPersister implements ObjectPersisterInterface
         }
     }
 
-    public function deleteManyByIdentifiers(array $identifiers, $routing = false)
+    public function deleteManyByIdentifiers(array $identifiers, $routing = false): void
     {
         try {
             $this->index->getClient()->deleteIds($identifiers, $this->index->getName(), $routing);
@@ -170,11 +149,9 @@ class ObjectPersister implements ObjectPersisterInterface
     /**
      * Log exception if logger defined for persister belonging to the current listener, otherwise re-throw.
      *
-     * @return void
-     *
      * @throws BulkException
      */
-    private function log(BulkException $e)
+    private function log(BulkException $e): void
     {
         if (!$this->logger) {
             throw $e;

--- a/src/Persister/ObjectPersister.php
+++ b/src/Persister/ObjectPersister.php
@@ -32,10 +32,6 @@ use Psr\Log\LoggerInterface;
 class ObjectPersister implements ObjectPersisterInterface
 {
     /**
-     * @var Index
-     */
-    protected $index;
-    /**
      * @var ?LoggerInterface
      */
     protected $logger;
@@ -46,15 +42,19 @@ class ObjectPersister implements ObjectPersisterInterface
      * @phpstan-param TFields $fields
      * @phpstan-param TOptions $options
      */
-    public function __construct(Index $index, protected ModelToElasticaTransformerInterface $transformer, protected string $objectClass, /**
-     * @phpstan-var TFields
-     */
-        protected array $fields, /**
-     * @phpstan-var TOptions
-     */
-        private readonly array $options = [])
-    {
-        $this->index = $index;
+    public function __construct(
+        protected Index $index,
+        protected ModelToElasticaTransformerInterface $transformer,
+        protected string $objectClass,
+        /**
+         * @phpstan-var TFields
+         */
+        protected array $fields,
+        /**
+         * @phpstan-var TOptions
+         */
+        private readonly array $options = []
+    ) {
     }
 
     public function handlesObject($object): bool

--- a/src/Persister/ObjectPersisterInterface.php
+++ b/src/Persister/ObjectPersisterInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the FOSElasticaBundle package.
  *

--- a/src/Persister/ObjectPersisterInterface.php
+++ b/src/Persister/ObjectPersisterInterface.php
@@ -23,83 +23,56 @@ interface ObjectPersisterInterface
 {
     /**
      * Checks if this persister can handle the given object or not.
-     *
-     * @param object $object
      */
-    public function handlesObject($object): bool;
+    public function handlesObject(object $object): bool;
 
     /**
      * Insert one object into the type
      * The object will be transformed to an elastica document.
-     *
-     * @param object $object
-     *
-     * @return void
      */
-    public function insertOne($object);
+    public function insertOne(object $object): void;
 
     /**
      * Replaces one object in the type.
-     *
-     * @param object $object
-     *
-     * @return void
      */
-    public function replaceOne($object);
+    public function replaceOne(object $object): void;
 
     /**
      * Deletes one object in the type.
-     *
-     * @param object $object
-     *
-     * @return void
      */
-    public function deleteOne($object);
+    public function deleteOne(object $object): void;
 
     /**
      * Deletes one object in the type by id.
-     *
-     * @param string      $id
-     * @param string|bool $routing
-     *
-     * @return void
      */
-    public function deleteById($id, $routing = false);
+    public function deleteById(string $id, string|bool $routing = false): void;
 
     /**
      * Bulk inserts an array of objects in the type.
      *
      * @param list<object> $objects array of domain model objects
-     *
-     * @return void
      */
-    public function insertMany(array $objects);
+    public function insertMany(array $objects): void;
 
     /**
      * Bulk updates an array of objects in the type.
      *
      * @param list<object> $objects array of domain model objects
-     *
-     * @return void
      */
-    public function replaceMany(array $objects);
+    public function replaceMany(array $objects): void;
 
     /**
      * Bulk deletes an array of objects in the type.
      *
      * @param list<object> $objects array of domain model objects
-     *
-     * @return void
      */
-    public function deleteMany(array $objects);
+    public function deleteMany(array $objects): void;
 
     /**
      * Bulk deletes records from an array of identifiers.
      *
      * @param list<string> $identifiers array of domain model object identifiers
      * @param string|bool  $routing     optional routing key for all identifiers
-     *
-     * @return void
      */
-    public function deleteManyByIdentifiers(array $identifiers, $routing = false);
+    public function deleteManyByIdentifiers(array $identifiers, string|bool $routing = false): void;
 }

--- a/src/Persister/PagerPersisterInterface.php
+++ b/src/Persister/PagerPersisterInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the FOSElasticaBundle package.
  *

--- a/src/Persister/PagerPersisterInterface.php
+++ b/src/Persister/PagerPersisterInterface.php
@@ -25,8 +25,6 @@ interface PagerPersisterInterface
 {
     /**
      * @phpstan-param TPagerPersisterOptions $options
-     *
-     * @return void
      */
-    public function insert(PagerInterface $pager, array $options = []);
+    public function insert(PagerInterface $pager, array $options = []): void;
 }

--- a/src/Persister/PagerPersisterRegistry.php
+++ b/src/Persister/PagerPersisterRegistry.php
@@ -15,7 +15,7 @@ use Symfony\Component\DependencyInjection\ServiceLocator;
 
 final class PagerPersisterRegistry
 {
-    private ServiceLocator $persisters;
+    private readonly ServiceLocator $persisters;
 
     public function __construct(ServiceLocator $persisters)
     {

--- a/src/Persister/PersisterRegistry.php
+++ b/src/Persister/PersisterRegistry.php
@@ -15,7 +15,7 @@ use Symfony\Component\DependencyInjection\ServiceLocator;
 
 class PersisterRegistry
 {
-    private ServiceLocator $persisters;
+    private readonly ServiceLocator $persisters;
 
     public function __construct(ServiceLocator $persisters)
     {

--- a/src/Provider/Indexable.php
+++ b/src/Provider/Indexable.php
@@ -17,19 +17,10 @@ use Symfony\Component\ExpressionLanguage\SyntaxError;
 
 /**
  * @phpstan-type TCallbackInput = string|(callable(object):bool)
- * @phpstan-type TCallbackInternal = callable|string|ExpressionLanguage|null
+ * @phpstan-type TCallbackInternal = callable|string|Expression|null
  */
 class Indexable implements IndexableInterface
 {
-    /**
-     * An array of raw configured callbacks for all types.
-     *
-     * @var array
-     *
-     * @phpstan-var array<string, TCallbackInput>
-     */
-    private $callbacks = [];
-
     /**
      * An instance of ExpressionLanguage.
      *
@@ -40,18 +31,21 @@ class Indexable implements IndexableInterface
     /**
      * An array of initialised callbacks.
      *
-     * @var array
-     *
      * @phpstan-var array<string, TCallbackInternal>
      */
-    private $initialisedCallbacks = [];
+    private array $initialisedCallbacks = [];
 
     /**
      * @phpstan-param array<string, TCallbackInput> $callbacks
      */
-    public function __construct(array $callbacks)
-    {
-        $this->callbacks = $callbacks;
+    public function __construct(
+        /**
+         * An array of raw configured callbacks for all types.
+         *
+         * @phpstan-var array<string, TCallbackInput>
+         */
+        private array $callbacks
+    ) {
     }
 
     /**
@@ -78,11 +72,9 @@ class Indexable implements IndexableInterface
     /**
      * Builds and initialises a callback.
      *
-     * @return callable|string|ExpressionLanguage|null
-     *
      * @phpstan-return TCallbackInternal
      */
-    private function buildCallback(string $index, object $object)
+    private function buildCallback(string $index, object $object): callable|string|Expression|null
     {
         if (!\array_key_exists($index, $this->callbacks)) {
             return null;
@@ -107,7 +99,7 @@ class Indexable implements IndexableInterface
     private function buildExpressionCallback(string $index, object $object, string $callback): Expression
     {
         $expression = $this->getExpressionLanguage();
-        if (!$expression) {
+        if (!$expression instanceof ExpressionLanguage) {
             throw new \RuntimeException('Unable to process an expression without the ExpressionLanguage component.');
         }
 

--- a/src/Provider/Indexable.php
+++ b/src/Provider/Indexable.php
@@ -23,10 +23,8 @@ class Indexable implements IndexableInterface
 {
     /**
      * An instance of ExpressionLanguage.
-     *
-     * @var ExpressionLanguage
      */
-    private $expressionLanguage;
+    private ?ExpressionLanguage $expressionLanguage = null;
 
     /**
      * An array of initialised callbacks.
@@ -120,7 +118,7 @@ class Indexable implements IndexableInterface
      *
      * @phpstan-return TCallbackInternal
      */
-    private function getCallback(string $index, object $object)
+    private function getCallback(string $index, object $object): callable|string|Expression|null
     {
         if (!\array_key_exists($index, $this->initialisedCallbacks)) {
             $this->initialisedCallbacks[$index] = $this->buildCallback($index, $object);

--- a/src/Provider/IndexableInterface.php
+++ b/src/Provider/IndexableInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the FOSElasticaBundle package.
  *

--- a/src/Provider/PagerInterface.php
+++ b/src/Provider/PagerInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the FOSElasticaBundle package.
  *

--- a/src/Provider/PagerInterface.php
+++ b/src/Provider/PagerInterface.php
@@ -21,20 +21,14 @@ interface PagerInterface
 
     public function getCurrentPage(): int;
 
-    /**
-     * @return void
-     */
-    public function setCurrentPage(int $page);
+    public function setCurrentPage(int $page): void;
 
     public function getMaxPerPage(): int;
 
-    /**
-     * @return void
-     */
-    public function setMaxPerPage(int $perPage);
+    public function setMaxPerPage(int $perPage): void;
 
     /**
      * @return array<object>|\Traversable<object>
      */
-    public function getCurrentPageResults();
+    public function getCurrentPageResults(): iterable;
 }

--- a/src/Provider/PagerProviderInterface.php
+++ b/src/Provider/PagerProviderInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the FOSElasticaBundle package.
  *

--- a/src/Provider/PagerProviderRegistry.php
+++ b/src/Provider/PagerProviderRegistry.php
@@ -18,7 +18,7 @@ use Symfony\Component\DependencyInjection\ServiceLocator;
  */
 class PagerProviderRegistry
 {
-    private ServiceLocator $providers;
+    private readonly ServiceLocator $providers;
 
     public function __construct(ServiceLocator $providers)
     {
@@ -34,9 +34,7 @@ class PagerProviderRegistry
      */
     public function getProviders(): array
     {
-        return \array_reduce(\array_keys($this->providers->getProvidedServices()), function ($carry, $index) {
-            return $carry + [$index => $this->providers->get($index)];
-        }, []);
+        return \array_reduce(\array_keys($this->providers->getProvidedServices()), fn ($carry, int|string $index) => $carry + [$index => $this->providers->get($index)], []);
     }
 
     /**

--- a/src/Provider/PagerProviderRegistry.php
+++ b/src/Provider/PagerProviderRegistry.php
@@ -34,7 +34,7 @@ class PagerProviderRegistry
      */
     public function getProviders(): array
     {
-        return \array_reduce(\array_keys($this->providers->getProvidedServices()), fn ($carry, int|string $index) => $carry + [$index => $this->providers->get($index)], []);
+        return \array_reduce(\array_keys($this->providers->getProvidedServices()), fn (array $carry, int|string $index) => $carry + [$index => $this->providers->get($index)], []);
     }
 
     /**

--- a/src/Provider/PagerProviderRegistry.php
+++ b/src/Provider/PagerProviderRegistry.php
@@ -34,7 +34,7 @@ class PagerProviderRegistry
      */
     public function getProviders(): array
     {
-        return \array_reduce(\array_keys($this->providers->getProvidedServices()), fn (array $carry, int|string $index) => $carry + [$index => $this->providers->get($index)], []);
+        return \array_reduce(\array_keys($this->providers->getProvidedServices()), fn (array $carry, int|string $index): array => $carry + [$index => $this->providers->get($index)], []);
     }
 
     /**

--- a/src/Provider/PagerfantaPager.php
+++ b/src/Provider/PagerfantaPager.php
@@ -46,7 +46,7 @@ class PagerfantaPager implements PagerInterface
         return $this->pagerfanta->getCurrentPage();
     }
 
-    public function setCurrentPage(int $page)
+    public function setCurrentPage(int $page): void
     {
         $this->pagerfanta->setCurrentPage($page);
     }
@@ -56,7 +56,7 @@ class PagerfantaPager implements PagerInterface
         return $this->pagerfanta->getMaxPerPage();
     }
 
-    public function setMaxPerPage(int $perPage)
+    public function setMaxPerPage(int $perPage): void
     {
         $this->pagerfanta->setMaxPerPage($perPage);
     }

--- a/src/Provider/PagerfantaPager.php
+++ b/src/Provider/PagerfantaPager.php
@@ -19,16 +19,10 @@ use Pagerfanta\Pagerfanta;
 class PagerfantaPager implements PagerInterface
 {
     /**
-     * @var Pagerfanta<T>
-     */
-    private $pagerfanta;
-
-    /**
      * @param Pagerfanta<T> $pagerfanta
      */
-    public function __construct(Pagerfanta $pagerfanta)
+    public function __construct(private readonly Pagerfanta $pagerfanta)
     {
-        $this->pagerfanta = $pagerfanta;
     }
 
     public function getNbResults(): int
@@ -64,7 +58,7 @@ class PagerfantaPager implements PagerInterface
     /**
      * @phpstan-return iterable<array-key, T>
      */
-    public function getCurrentPageResults()
+    public function getCurrentPageResults(): iterable
     {
         return $this->pagerfanta->getCurrentPageResults();
     }

--- a/src/Repository.php
+++ b/src/Repository.php
@@ -35,7 +35,7 @@ class Repository
      *
      * @return array<object>
      */
-    public function find($query, ?int $limit = null, array $options = [])
+    public function find(mixed $query, ?int $limit = null, array $options = []): array
     {
         return $this->finder->find($query, $limit, $options);
     }
@@ -46,7 +46,7 @@ class Repository
      *
      * @return list<HybridResult>
      */
-    public function findHybrid($query, ?int $limit = null, array $options = [])
+    public function findHybrid(mixed $query, ?int $limit = null, array $options = []): array
     {
         return $this->finder->findHybrid($query, $limit, $options);
     }
@@ -57,7 +57,7 @@ class Repository
      *
      * @return \Pagerfanta\Pagerfanta<object>
      */
-    public function findPaginated($query, array $options = [])
+    public function findPaginated(mixed $query, array $options = []): \Pagerfanta\Pagerfanta
     {
         return $this->finder->findPaginated($query, $options);
     }
@@ -65,10 +65,8 @@ class Repository
     /**
      * @phpstan-param TQuery $query
      * @phpstan-param TOptions $options
-     *
-     * @return Paginator\PaginatorAdapterInterface
      */
-    public function createPaginatorAdapter($query, array $options = [])
+    public function createPaginatorAdapter(mixed $query, array $options = []): Paginator\PaginatorAdapterInterface
     {
         return $this->finder->createPaginatorAdapter($query, $options);
     }
@@ -76,10 +74,8 @@ class Repository
     /**
      * @phpstan-param TQuery $query
      * @phpstan-param TOptions $options
-     *
-     * @return Paginator\PaginatorAdapterInterface
      */
-    public function createHybridPaginatorAdapter($query, array $options = [])
+    public function createHybridPaginatorAdapter(mixed $query, array $options = []): Paginator\PaginatorAdapterInterface
     {
         return $this->finder->createHybridPaginatorAdapter($query, $options);
     }

--- a/src/Repository.php
+++ b/src/Repository.php
@@ -25,11 +25,8 @@ use FOS\ElasticaBundle\Finder\PaginatedFinderInterface;
  */
 class Repository
 {
-    protected PaginatedFinderInterface $finder;
-
-    public function __construct(PaginatedFinderInterface $finder)
+    public function __construct(protected PaginatedFinderInterface $finder)
     {
-        $this->finder = $finder;
     }
 
     /**

--- a/src/Serializer/Callback.php
+++ b/src/Serializer/Callback.php
@@ -53,7 +53,7 @@ class Callback
     {
         $this->groups = $groups;
 
-        if (!empty($this->groups) && !$this->serializer instanceof SerializerInterface && !$this->serializer instanceof JMSSerializer) {
+        if ([] !== $this->groups && !$this->serializer instanceof SerializerInterface && !$this->serializer instanceof JMSSerializer) {
             throw new \RuntimeException(\sprintf('Setting serialization groups requires using a "%s" or "%s" serializer instance.', SerializerInterface::class, JMSSerializer::class));
         }
 
@@ -75,7 +75,7 @@ class Callback
     {
         $this->serializeNull = $serializeNull;
 
-        if (true === $this->serializeNull && !$this->serializer instanceof SerializerInterface && !$this->serializer instanceof JMSSerializer) {
+        if ($this->serializeNull && !$this->serializer instanceof SerializerInterface && !$this->serializer instanceof JMSSerializer) {
             throw new \RuntimeException(\sprintf('Setting null value serialization option requires using a "%s" or "%s" serializer instance.', SerializerInterface::class, JMSSerializer::class));
         }
 
@@ -86,7 +86,7 @@ class Callback
     {
         $context = $this->serializer instanceof JMSSerializer ? SerializationContext::create()->enableMaxDepthChecks() : [AbstractObjectNormalizer::ENABLE_MAX_DEPTH => true];
 
-        if (!empty($this->groups)) {
+        if ([] !== $this->groups) {
             if ($context instanceof SerializationContext) {
                 $context->setGroups($this->groups);
             } else {

--- a/src/Subscriber/PaginateElasticaQuerySubscriber.php
+++ b/src/Subscriber/PaginateElasticaQuerySubscriber.php
@@ -19,7 +19,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
 
 class PaginateElasticaQuerySubscriber implements EventSubscriberInterface
 {
-    public function __construct(private RequestStack $requestStack)
+    public function __construct(private readonly RequestStack $requestStack)
     {
     }
 
@@ -109,7 +109,7 @@ class PaginateElasticaQuerySubscriber implements EventSubscriberInterface
             $sortDirection = $options['defaultSortDirection'];
         }
 
-        if (null !== $sortDirection && 'desc' === \strtolower($sortDirection)) {
+        if (null !== $sortDirection && 'desc' === \strtolower((string) $sortDirection)) {
             $dir = 'desc';
         }
 
@@ -128,7 +128,7 @@ class PaginateElasticaQuerySubscriber implements EventSubscriberInterface
 
     private function getFromRequest(?string $key): mixed
     {
-        if (null !== $key && null !== $request = $this->getRequest()) {
+        if (null !== $key && ($request = $this->getRequest()) instanceof Request) {
             return $request->query->get($key);
         }
 

--- a/src/Test/ClientLocator.php
+++ b/src/Test/ClientLocator.php
@@ -15,10 +15,4 @@ namespace FOS\ElasticaBundle\Test;
 
 class ClientLocator
 {
-    private array $clients; // @phpstan-ignore-line is never read, only written. Used only in tests to forbid container to remove clients.
-
-    public function __construct(array $clients)
-    {
-        $this->clients = $clients;
-    }
 }

--- a/src/Transformer/AbstractElasticaToModelTransformer.php
+++ b/src/Transformer/AbstractElasticaToModelTransformer.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the FOSElasticaBundle package.
  *
@@ -24,10 +26,8 @@ abstract class AbstractElasticaToModelTransformer implements ElasticaToModelTran
 
     /**
      * Set the PropertyAccessor instance.
-     *
-     * @return void
      */
-    public function setPropertyAccessor(PropertyAccessorInterface $propertyAccessor)
+    public function setPropertyAccessor(PropertyAccessorInterface $propertyAccessor): void
     {
         $this->propertyAccessor = $propertyAccessor;
     }

--- a/src/Transformer/ElasticaToModelTransformerInterface.php
+++ b/src/Transformer/ElasticaToModelTransformerInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the FOSElasticaBundle package.
  *

--- a/src/Transformer/ElasticaToModelTransformerInterface.php
+++ b/src/Transformer/ElasticaToModelTransformerInterface.php
@@ -31,14 +31,14 @@ interface ElasticaToModelTransformerInterface
      *
      * @return array<object> of model objects
      */
-    public function transform(array $elasticaObjects);
+    public function transform(array $elasticaObjects): array;
 
     /**
      * @param Result[] $elasticaObjects
      *
      * @return list<HybridResult>
      */
-    public function hybridTransform(array $elasticaObjects);
+    public function hybridTransform(array $elasticaObjects): array;
 
     /**
      * Returns the object class used by the transformer.

--- a/src/Transformer/HighlightableModelInterface.php
+++ b/src/Transformer/HighlightableModelInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the FOSElasticaBundle package.
  *

--- a/src/Transformer/HighlightableModelInterface.php
+++ b/src/Transformer/HighlightableModelInterface.php
@@ -23,7 +23,7 @@ interface HighlightableModelInterface
     /**
      * Returns a unique identifier for the model.
      */
-    public function getId();
+    public function getId(): mixed;
 
     /**
      * Set ElasticSearch highlight data.
@@ -31,8 +31,6 @@ interface HighlightableModelInterface
      * @param array $highlights array of highlight strings
      *
      * @phpstan-param list<THighlight> $highlights
-     *
-     * @return void
      */
-    public function setElasticHighlights(array $highlights);
+    public function setElasticHighlights(array $highlights): void;
 }

--- a/src/Transformer/ModelToElasticaAutoTransformer.php
+++ b/src/Transformer/ModelToElasticaAutoTransformer.php
@@ -106,10 +106,8 @@ class ModelToElasticaAutoTransformer implements ModelToElasticaTransformerInterf
 
     /**
      * Attempts to convert any type to a string or an array of strings.
-     *
-     * @return string|list<string>
      */
-    protected function normalizeValue($value)
+    protected function normalizeValue(mixed $value): mixed
     {
         $normalizeValue = static function (mixed &$v): void {
             if ($v instanceof \DateTimeInterface) {
@@ -142,7 +140,7 @@ class ModelToElasticaAutoTransformer implements ModelToElasticaTransformerInterf
     {
         $document = new Document($identifier, [], $this->options['index']);
 
-        if ($this->dispatcher) {
+        if ($this->dispatcher instanceof EventDispatcherInterface) {
             $this->dispatcher->dispatch($event = new PreTransformEvent($document, $fields, $object));
 
             $document = $event->getDocument();
@@ -181,7 +179,7 @@ class ModelToElasticaAutoTransformer implements ModelToElasticaTransformerInterf
             $document->set($key, $this->normalizeValue($value));
         }
 
-        if ($this->dispatcher) {
+        if ($this->dispatcher instanceof EventDispatcherInterface) {
             $this->dispatcher->dispatch($event = new PostTransformEvent($document, $fields, $object));
 
             $document = $event->getDocument();

--- a/src/Transformer/ModelToElasticaAutoTransformer.php
+++ b/src/Transformer/ModelToElasticaAutoTransformer.php
@@ -111,7 +111,7 @@ class ModelToElasticaAutoTransformer implements ModelToElasticaTransformerInterf
      */
     protected function normalizeValue($value)
     {
-        $normalizeValue = static function (&$v): void {
+        $normalizeValue = static function (mixed &$v): void {
             if ($v instanceof \DateTimeInterface) {
                 $v = $v->format('c');
             } elseif ($v instanceof \DateInterval) {

--- a/src/Transformer/ModelToElasticaAutoTransformer.php
+++ b/src/Transformer/ModelToElasticaAutoTransformer.php
@@ -29,18 +29,11 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 class ModelToElasticaAutoTransformer implements ModelToElasticaTransformerInterface
 {
     /**
-     * @var ?EventDispatcherInterface
-     */
-    protected $dispatcher;
-
-    /**
      * Optional parameters.
-     *
-     * @var array
      *
      * @phpstan-var TOptions
      */
-    protected $options = [
+    protected array $options = [
         'identifier' => 'id',
         'index' => '',
     ];
@@ -57,10 +50,9 @@ class ModelToElasticaAutoTransformer implements ModelToElasticaTransformerInterf
      *
      * @phpstan-param array<string, mixed> $options
      */
-    public function __construct(array $options = [], ?EventDispatcherInterface $dispatcher = null)
+    public function __construct(array $options = [], protected ?EventDispatcherInterface $dispatcher = null)
     {
         $this->options = \array_merge($this->options, $options);
-        $this->dispatcher = $dispatcher;
     }
 
     /**
@@ -119,7 +111,7 @@ class ModelToElasticaAutoTransformer implements ModelToElasticaTransformerInterf
      */
     protected function normalizeValue($value)
     {
-        $normalizeValue = static function (&$v) {
+        $normalizeValue = static function (&$v): void {
             if ($v instanceof \DateTimeInterface) {
                 $v = $v->format('c');
             } elseif ($v instanceof \DateInterval) {

--- a/src/Transformer/ModelToElasticaTransformerInterface.php
+++ b/src/Transformer/ModelToElasticaTransformerInterface.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the FOSElasticaBundle package.
  *

--- a/tests/Functional/ClientTest.php
+++ b/tests/Functional/ClientTest.php
@@ -21,7 +21,7 @@ use FOS\ElasticaBundle\Elastica\Client;
  */
 class ClientTest extends WebTestCase
 {
-    public function testContainerSource()
+    public function testContainerSource(): void
     {
         self::bootKernel(['test_case' => 'Basic']);
 

--- a/tests/Functional/ConfigurationManagerTest.php
+++ b/tests/Functional/ConfigurationManagerTest.php
@@ -21,7 +21,7 @@ use FOS\ElasticaBundle\Configuration\IndexConfig;
  */
 class ConfigurationManagerTest extends WebTestCase
 {
-    public function testContainerSource()
+    public function testContainerSource(): void
     {
         static::bootKernel(['test_case' => 'Basic']);
         /** @var ConfigManager $manager */

--- a/tests/Functional/IndexTemplatesTest.php
+++ b/tests/Functional/IndexTemplatesTest.php
@@ -26,7 +26,7 @@ use FOS\ElasticaBundle\Index\TemplateResetter;
  */
 class IndexTemplatesTest extends WebTestCase
 {
-    public function testContainer()
+    public function testContainer(): void
     {
         self::bootKernel(['test_case' => 'Basic']);
 

--- a/tests/Functional/IndexableCallbackTest.php
+++ b/tests/Functional/IndexableCallbackTest.php
@@ -27,7 +27,7 @@ class IndexableCallbackTest extends WebTestCase
      * key is respected, and
      * 2) To test the Extension's set up of the Indexable service.
      */
-    public function testIndexableCallback()
+    public function testIndexableCallback(): void
     {
         self::bootKernel(['test_case' => 'ORM']);
 

--- a/tests/Functional/MappingToElasticaTest.php
+++ b/tests/Functional/MappingToElasticaTest.php
@@ -22,7 +22,7 @@ use FOS\ElasticaBundle\Persister\ObjectPersisterInterface;
  */
 class MappingToElasticaTest extends WebTestCase
 {
-    public function testResetIndexAddsMappings()
+    public function testResetIndexAddsMappings(): void
     {
         self::bootKernel(['test_case' => 'Basic']);
         $resetter = $this->getResetter();
@@ -44,7 +44,7 @@ class MappingToElasticaTest extends WebTestCase
         $this->assertSame('true', $mapping['properties']['dynamic_allowed']['dynamic']);
     }
 
-    public function testORMResetIndexAddsMappings()
+    public function testORMResetIndexAddsMappings(): void
     {
         self::bootKernel(['test_case' => 'ORM']);
         $resetter = $this->getResetter();
@@ -56,7 +56,7 @@ class MappingToElasticaTest extends WebTestCase
         $this->assertNotEmpty($mapping, 'Mapping was populated');
     }
 
-    public function testMappingIteratorToArrayField()
+    public function testMappingIteratorToArrayField(): void
     {
         self::bootKernel(['test_case' => 'ORM']);
         /** @var ObjectPersisterInterface $persister */

--- a/tests/Functional/PersistenceRepositoryTest.php
+++ b/tests/Functional/PersistenceRepositoryTest.php
@@ -16,7 +16,7 @@ namespace FOS\ElasticaBundle\Tests\Functional;
  */
 class PersistenceRepositoryTest extends WebTestCase
 {
-    public function testRepositoryShouldBeSetCorrectly()
+    public function testRepositoryShouldBeSetCorrectly(): void
     {
         self::bootKernel(['test_case' => 'ORM']);
 

--- a/tests/Functional/ProfilerTest.php
+++ b/tests/Functional/ProfilerTest.php
@@ -35,8 +35,7 @@ class ProfilerTest extends WebTestCase
 {
     private ?ElasticaLogger $logger = null;
 
-    /** @var Environment */
-    private $twig;
+    private Environment $twig;
 
     private ?ElasticaDataCollector $collector = null;
 
@@ -76,7 +75,7 @@ class ProfilerTest extends WebTestCase
     /**
      * @dataProvider queryProvider
      */
-    public function testRender($query): void
+    public function testRender(string|array $query): void
     {
         $connection = [
             'host' => 'localhost',
@@ -100,7 +99,7 @@ class ProfilerTest extends WebTestCase
         $this->assertStringContainsString('localhost:9200', $output);
     }
 
-    public function queryProvider()
+    public function queryProvider(): array
     {
         return [
             [\json_decode('{"query":{"match_all":{}}}', true)],

--- a/tests/Functional/ProfilerTest.php
+++ b/tests/Functional/ProfilerTest.php
@@ -33,14 +33,12 @@ use Twig\RuntimeLoader\RuntimeLoaderInterface;
  */
 class ProfilerTest extends WebTestCase
 {
-    /** @var ElasticaLogger */
-    private $logger;
+    private ?ElasticaLogger $logger = null;
 
     /** @var Environment */
     private $twig;
 
-    /** @var ElasticaDataCollector */
-    private $collector;
+    private ?ElasticaDataCollector $collector = null;
 
     public function setUp(): void
     {
@@ -78,7 +76,7 @@ class ProfilerTest extends WebTestCase
     /**
      * @dataProvider queryProvider
      */
-    public function testRender($query)
+    public function testRender($query): void
     {
         $connection = [
             'host' => 'localhost',

--- a/tests/Functional/PropertyPathTest.php
+++ b/tests/Functional/PropertyPathTest.php
@@ -22,7 +22,7 @@ use FOS\ElasticaBundle\Persister\ObjectPersisterInterface;
  */
 class PropertyPathTest extends WebTestCase
 {
-    public function testContainerSource()
+    public function testContainerSource(): void
     {
         self::bootKernel(['test_case' => 'ORM']);
         /** @var ObjectPersisterInterface $persister */

--- a/tests/Functional/ResetTemplatesCommandTest.php
+++ b/tests/Functional/ResetTemplatesCommandTest.php
@@ -41,7 +41,7 @@ class ResetTemplatesCommandTest extends WebTestCase
         $this->elasticClient = self::getContainer()->get('fos_elastica.client');
     }
 
-    public function testResetAllTemplates()
+    public function testResetAllTemplates(): void
     {
         $this->clearTemplates();
 
@@ -59,7 +59,7 @@ class ResetTemplatesCommandTest extends WebTestCase
         $this->assertArrayHasKey('index_template_1_name', $templates);
     }
 
-    public function testResetAllTemplatesAndForceDelete()
+    public function testResetAllTemplatesAndForceDelete(): void
     {
         $this->clearTemplates();
 
@@ -83,7 +83,7 @@ class ResetTemplatesCommandTest extends WebTestCase
         $this->assertArrayHasKey('index_template_1_name', $templates);
     }
 
-    public function testResetExactTemplate()
+    public function testResetExactTemplate(): void
     {
         $this->clearTemplates();
 
@@ -102,7 +102,7 @@ class ResetTemplatesCommandTest extends WebTestCase
         $this->assertArrayHasKey('index_template_1_name', $templates);
     }
 
-    public function testResetExactTemplateAndForceDelete()
+    public function testResetExactTemplateAndForceDelete(): void
     {
         $this->clearTemplates();
 
@@ -124,7 +124,7 @@ class ResetTemplatesCommandTest extends WebTestCase
         $this->assertArrayHasKey('index_template_3_name', $templates);
     }
 
-    private function clearTemplates()
+    private function clearTemplates(): void
     {
         $this->elasticClient->indices()->deleteTemplate(['name' => '*']);
     }

--- a/tests/Functional/ResetTemplatesCommandTest.php
+++ b/tests/Functional/ResetTemplatesCommandTest.php
@@ -26,10 +26,8 @@ class ResetTemplatesCommandTest extends WebTestCase
 
     /**
      * Application.
-     *
-     * @var Application
      */
-    private $application;
+    private Application $application;
 
     protected function setUp(): void
     {
@@ -129,7 +127,7 @@ class ResetTemplatesCommandTest extends WebTestCase
         $this->elasticClient->indices()->deleteTemplate(['name' => '*']);
     }
 
-    private function fetchAllTemplates()
+    private function fetchAllTemplates(): array
     {
         $reponse = $this->elasticClient->indices()->getTemplate();
 

--- a/tests/Functional/SerializerTest.php
+++ b/tests/Functional/SerializerTest.php
@@ -18,7 +18,7 @@ namespace FOS\ElasticaBundle\Tests\Functional;
  */
 class SerializerTest extends WebTestCase
 {
-    public function testMappingIteratorToArrayField()
+    public function testMappingIteratorToArrayField(): void
     {
         static::bootKernel(['test_case' => 'Serializer']);
         $persister = self::getContainer()->get('fos_elastica.object_persister.index');
@@ -37,7 +37,7 @@ class SerializerTest extends WebTestCase
     /**
      * Tests that the serialize_null configuration attribute works.
      */
-    public function testWithNullValues()
+    public function testWithNullValues(): void
     {
         static::bootKernel(['test_case' => 'Serializer']);
 
@@ -62,7 +62,7 @@ class SerializerTest extends WebTestCase
         $this->assertNull($documentData['field1']);
     }
 
-    public function testUnmappedType()
+    public function testUnmappedType(): void
     {
         static::bootKernel(['test_case' => 'Serializer']);
         $resetter = self::getContainer()->get('fos_elastica.resetter');

--- a/tests/Functional/TypeObj.php
+++ b/tests/Functional/TypeObj.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the FOSElasticaBundle package.
  *
@@ -18,12 +20,12 @@ class TypeObj
     public $field1;
     public $field2;
 
-    public function isIndexable()
+    public function isIndexable(): bool
     {
         return true;
     }
 
-    public function isntIndexable()
+    public function isntIndexable(): bool
     {
         return false;
     }

--- a/tests/Functional/TypeObject.php
+++ b/tests/Functional/TypeObject.php
@@ -19,17 +19,17 @@ class TypeObject
     public $field2;
     public $field3;
 
-    public function isIndexable()
+    public function isIndexable(): bool
     {
         return true;
     }
 
-    public function isntIndexable()
+    public function isntIndexable(): bool
     {
         return false;
     }
 
-    public function getSerializableColl()
+    public function getSerializableColl(): array
     {
         return \iterator_to_array($this->coll, false);
     }

--- a/tests/Functional/TypeObjectRepository.php
+++ b/tests/Functional/TypeObjectRepository.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the FOSElasticaBundle package.
  *

--- a/tests/Functional/WebTestCase.php
+++ b/tests/Functional/WebTestCase.php
@@ -41,7 +41,7 @@ class WebTestCase extends BaseKernelTestCase
         return AppKernel::class;
     }
 
-    protected static function deleteTmpDir()
+    protected static function deleteTmpDir(): void
     {
         if (!\file_exists($dir = \sys_get_temp_dir().'/'.static::getVarDir())) {
             return;
@@ -67,7 +67,7 @@ class WebTestCase extends BaseKernelTestCase
         );
     }
 
-    protected static function getVarDir()
+    protected static function getVarDir(): string
     {
         return \substr(\strrchr(static::class, '\\'), 1);
     }
@@ -75,7 +75,7 @@ class WebTestCase extends BaseKernelTestCase
     /**
      * To be removed when dropping support of Symfony < 5.3.
      */
-    public static function __callStatic(string $name, $arguments)
+    public static function __callStatic(string $name, array $arguments): mixed
     {
         if ('getContainer' === $name) {
             if (\method_exists(BaseKernelTestCase::class, $name)) {

--- a/tests/Functional/app/AppKernel.php
+++ b/tests/Functional/app/AppKernel.php
@@ -26,7 +26,7 @@ class AppKernel extends Kernel
     private $testCase;
     private $rootConfig;
 
-    public function __construct(private $varDir, $testCase, $rootConfig, $environment, $debug)
+    public function __construct(private $varDir, $testCase, $rootConfig, string $environment, bool $debug)
     {
         if (!\is_dir(__DIR__.'/'.$testCase)) {
             throw new \InvalidArgumentException(\sprintf('The test case "%s" does not exist.', $testCase));

--- a/tests/Functional/app/AppKernel.php
+++ b/tests/Functional/app/AppKernel.php
@@ -23,16 +23,14 @@ use Symfony\Component\HttpKernel\Kernel;
  */
 class AppKernel extends Kernel
 {
-    private $varDir;
     private $testCase;
     private $rootConfig;
 
-    public function __construct($varDir, $testCase, $rootConfig, $environment, $debug)
+    public function __construct(private $varDir, $testCase, $rootConfig, $environment, $debug)
     {
         if (!\is_dir(__DIR__.'/'.$testCase)) {
             throw new \InvalidArgumentException(\sprintf('The test case "%s" does not exist.', $testCase));
         }
-        $this->varDir = $varDir;
         $this->testCase = $testCase;
 
         $fs = new Filesystem();
@@ -70,7 +68,7 @@ class AppKernel extends Kernel
 
     public function registerContainerConfiguration(LoaderInterface $loader): void
     {
-        $loader->load(function (ContainerBuilder $container) {
+        $loader->load(function (ContainerBuilder $container): void {
             $container->setParameter('fos_elastica.host', $_SERVER['FOS_ELASTICA_HOST']);
             $container->setParameter('fos_elastica.port', $_SERVER['FOS_ELASTICA_PORT']);
         });

--- a/tests/Functional/app/ORM/IndexableService.php
+++ b/tests/Functional/app/ORM/IndexableService.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the FOSElasticaBundle package.
  *
@@ -13,12 +15,12 @@ namespace FOS\ElasticaBundle\Tests\Functional\app\ORM;
 
 class IndexableService
 {
-    public function isIndexable()
+    public function isIndexable(): bool
     {
         return true;
     }
 
-    public static function isntIndexable()
+    public static function isntIndexable(): bool
     {
         return false;
     }

--- a/tests/Unit/Command/CreateCommandTest.php
+++ b/tests/Unit/Command/CreateCommandTest.php
@@ -32,37 +32,34 @@ class CreateCommandTest extends TestCase
     /**
      * @var IndexManager|\PHPUnit\Framework\MockObject\MockObject
      */
-    private $indexManager;
+    private \PHPUnit\Framework\MockObject\MockObject $indexManager;
 
     /**
      * @var MappingBuilder|\PHPUnit\Framework\MockObject\MockObject
      */
-    private $mappingBuilder;
+    private \PHPUnit\Framework\MockObject\MockObject $mappingBuilder;
 
     /**
      * @var ConfigManager|\PHPUnit\Framework\MockObject\MockObject
      */
-    private $configManager;
+    private \PHPUnit\Framework\MockObject\MockObject $configManager;
 
     /**
      * @var AliasProcessor|\PHPUnit\Framework\MockObject\MockObject
      */
-    private $aliasProcessor;
+    private \PHPUnit\Framework\MockObject\MockObject $aliasProcessor;
 
-    /**
-     * @var CreateCommand
-     */
-    private $command;
+    private CreateCommand $command;
 
     /**
      * @var IndexConfig|\PHPUnit\Framework\MockObject\MockObject
      */
-    private $indexConfig;
+    private \PHPUnit\Framework\MockObject\MockObject $indexConfig;
 
     /**
      * @var Index|\PHPUnit\Framework\MockObject\MockObject
      */
-    private $index;
+    private \PHPUnit\Framework\MockObject\MockObject $index;
 
     protected function setUp(): void
     {
@@ -81,7 +78,7 @@ class CreateCommandTest extends TestCase
         );
     }
 
-    public function testExecuteWithIndexProvidedAndWithAlias()
+    public function testExecuteWithIndexProvidedAndWithAlias(): void
     {
         $input = $this->createMock(InputInterface::class);
         $output = $this->createMock(OutputInterface::class);
@@ -108,7 +105,7 @@ class CreateCommandTest extends TestCase
         $this->command->run($input, $output);
     }
 
-    public function testExecuteWithIndexProvidedAndWithAliasButDisabled()
+    public function testExecuteWithIndexProvidedAndWithAliasButDisabled(): void
     {
         $input = $this->createMock(InputInterface::class);
         $output = $this->createMock(OutputInterface::class);
@@ -134,7 +131,7 @@ class CreateCommandTest extends TestCase
         $this->command->run($input, $output);
     }
 
-    public function testExecuteWithIndexProvidedAndWithoutAlias()
+    public function testExecuteWithIndexProvidedAndWithoutAlias(): void
     {
         $input = $this->createMock(InputInterface::class);
         $output = $this->createMock(OutputInterface::class);
@@ -155,7 +152,7 @@ class CreateCommandTest extends TestCase
         $this->command->run($input, $output);
     }
 
-    public function testExecuteAllIndices()
+    public function testExecuteAllIndices(): void
     {
         $input = $this->createMock(InputInterface::class);
         $output = $this->createMock(OutputInterface::class);

--- a/tests/Unit/Command/DeleteCommandTest.php
+++ b/tests/Unit/Command/DeleteCommandTest.php
@@ -23,20 +23,17 @@ use Symfony\Component\Console\Output\NullOutput;
  */
 class DeleteCommandTest extends TestCase
 {
-    /**
-     * @var DeleteCommand
-     */
-    private $command;
+    private DeleteCommand $command;
 
     /**
      * @var IndexManager|\PHPUnit\Framework\MockObject\MockObject
      */
-    private $indexManagerMock;
+    private \PHPUnit\Framework\MockObject\MockObject $indexManagerMock;
 
     /**
      * @var Index|\PHPUnit\Framework\MockObject\MockObject
      */
-    private $indexMock;
+    private \PHPUnit\Framework\MockObject\MockObject $indexMock;
 
     protected function setUp(): void
     {
@@ -46,7 +43,7 @@ class DeleteCommandTest extends TestCase
         $this->command = new DeleteCommand($this->indexManagerMock);
     }
 
-    public function testDeleteAllIndexes()
+    public function testDeleteAllIndexes(): void
     {
         $input = $this->createMock(InputInterface::class);
         $input->expects($this->once())->method('getOption')->with('index')->willReturn(null);
@@ -80,7 +77,7 @@ class DeleteCommandTest extends TestCase
         );
     }
 
-    public function testDeleteIndex()
+    public function testDeleteIndex(): void
     {
         $input = $this->createMock(InputInterface::class);
         $input->expects($this->once())->method('getOption')->with('index')->willReturn('index_name');

--- a/tests/Unit/Command/ResetCommandTest.php
+++ b/tests/Unit/Command/ResetCommandTest.php
@@ -23,20 +23,17 @@ use Symfony\Component\Console\Output\NullOutput;
  */
 class ResetCommandTest extends TestCase
 {
-    /**
-     * @var ResetCommand
-     */
-    private $command;
+    private ResetCommand $command;
 
     /**
      * @var Resetter|\PHPUnit\Framework\MockObject\MockObject
      */
-    private $resetter;
+    private \PHPUnit\Framework\MockObject\MockObject $resetter;
 
     /**
      * @var IndexManager|\PHPUnit\Framework\MockObject\MockObject
      */
-    private $indexManager;
+    private \PHPUnit\Framework\MockObject\MockObject $indexManager;
 
     protected function setUp(): void
     {
@@ -46,7 +43,7 @@ class ResetCommandTest extends TestCase
         $this->command = new ResetCommand($this->indexManager, $this->resetter);
     }
 
-    public function testResetAllIndexes()
+    public function testResetAllIndexes(): void
     {
         $this->indexManager->expects($this->any())
             ->method('getAllIndexes')
@@ -67,7 +64,7 @@ class ResetCommandTest extends TestCase
         );
     }
 
-    public function testResetIndex()
+    public function testResetIndex(): void
     {
         $this->indexManager->expects($this->never())
             ->method('getAllIndexes')

--- a/tests/Unit/Configuration/IndexTemplateConfigTest.php
+++ b/tests/Unit/Configuration/IndexTemplateConfigTest.php
@@ -19,7 +19,7 @@ use PHPUnit\Framework\TestCase;
  */
 class IndexTemplateConfigTest extends TestCase
 {
-    public function testInstantiate()
+    public function testInstantiate(): void
     {
         $name = 'index_template1';
         $config = [
@@ -45,7 +45,7 @@ class IndexTemplateConfigTest extends TestCase
         );
     }
 
-    public function testIncorrectInstantiate()
+    public function testIncorrectInstantiate(): void
     {
         $config = [
             'elasticsearch_name' => 'index_template1',

--- a/tests/Unit/Configuration/Source/TemplateContainerSourceTest.php
+++ b/tests/Unit/Configuration/Source/TemplateContainerSourceTest.php
@@ -22,14 +22,14 @@ use PHPUnit\Framework\TestCase;
  */
 class TemplateContainerSourceTest extends TestCase
 {
-    public function testGetEmptyConfiguration()
+    public function testGetEmptyConfiguration(): void
     {
         $containerSource = new TemplateContainerSource([]);
         $indexes = $containerSource->getConfiguration();
         $this->assertSame([], $indexes);
     }
 
-    public function testGetConfiguration()
+    public function testGetConfiguration(): void
     {
         $containerSource = new TemplateContainerSource(
             [

--- a/tests/Unit/DataCollector/ElasticaDataCollectorTest.php
+++ b/tests/Unit/DataCollector/ElasticaDataCollectorTest.php
@@ -24,7 +24,7 @@ use Symfony\Component\HttpFoundation\Response;
  */
 class ElasticaDataCollectorTest extends UnitTestHelper
 {
-    public function testCorrectAmountOfQueries()
+    public function testCorrectAmountOfQueries(): void
     {
         /** @var \PHPUnit\Framework\MockObject\MockObject|Request $requestMock */
         $requestMock = $this->createMock(Request::class);
@@ -35,7 +35,7 @@ class ElasticaDataCollectorTest extends UnitTestHelper
         /** @var \PHPUnit\Framework\MockObject\MockObject|ElasticaLogger $loggerMock */
         $loggerMock = $this->createMock(ElasticaLogger::class);
 
-        $totalQueries = \rand();
+        $totalQueries = \random_int(0, \mt_getrandmax());
 
         $loggerMock->expects($this->once())
             ->method('getNbQueries')
@@ -47,7 +47,7 @@ class ElasticaDataCollectorTest extends UnitTestHelper
         $this->assertSame($totalQueries, $elasticaDataCollector->getQueryCount());
     }
 
-    public function testCorrectQueriesReturned()
+    public function testCorrectQueriesReturned(): void
     {
         /** @var \PHPUnit\Framework\MockObject\MockObject|Request $requestMock */
         $requestMock = $this->createMock(Request::class);
@@ -70,7 +70,7 @@ class ElasticaDataCollectorTest extends UnitTestHelper
         $this->assertSame($queries, $elasticaDataCollector->getQueries());
     }
 
-    public function testCorrectQueriesTime()
+    public function testCorrectQueriesTime(): void
     {
         /** @var \PHPUnit\Framework\MockObject\MockObject|Request $requestMock */
         $requestMock = $this->createMock(Request::class);
@@ -99,7 +99,7 @@ class ElasticaDataCollectorTest extends UnitTestHelper
         $this->assertSame(40, $elasticaDataCollector->getTime());
     }
 
-    public function testName()
+    public function testName(): void
     {
         /** @var \PHPUnit\Framework\MockObject\MockObject|ElasticaLogger $loggerMock */
         $loggerMock = $this->createMock(ElasticaLogger::class);
@@ -109,7 +109,7 @@ class ElasticaDataCollectorTest extends UnitTestHelper
         $this->assertSame('elastica', $elasticaDataCollector->getName());
     }
 
-    public function testReset()
+    public function testReset(): void
     {
         /** @var \PHPUnit\Framework\MockObject\MockObject|ElasticaLogger $loggerMock */
         $loggerMock = $this->createMock(ElasticaLogger::class);

--- a/tests/Unit/DependencyInjection/ConfigSourcePassTest.php
+++ b/tests/Unit/DependencyInjection/ConfigSourcePassTest.php
@@ -24,15 +24,14 @@ use Symfony\Component\DependencyInjection\Reference;
  */
 class ConfigSourcePassTest extends TestCase
 {
-    /** @var ContainerBuilder */
-    private $container;
+    private ContainerBuilder $container;
 
     protected function setUp(): void
     {
         $this->container = new ContainerBuilder();
     }
 
-    public function testProcessWithoutConfigManager()
+    public function testProcessWithoutConfigManager(): void
     {
         $configManagerDefinition = new Definition(ConfigManager::class);
         $configManagerDefinition->addArgument([]);
@@ -49,7 +48,7 @@ class ConfigSourcePassTest extends TestCase
         $this->assertSame([], $this->container->getDefinition('fos_elastica.config_manager.index_templates')->getArgument(0));
     }
 
-    public function testProcessWithConfigManager()
+    public function testProcessWithConfigManager(): void
     {
         $configManagerDefinition = new Definition(ConfigManager::class);
         $configManagerDefinition->addArgument([]);

--- a/tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -257,7 +257,7 @@ class ConfigurationTest extends TestCase
         $this->assertArrayHasKey('some_field', $indexTemplate['properties']);
     }
 
-    private function getConfigs(array $configArray)
+    private function getConfigs(array $configArray): array
     {
         $configuration = new Configuration(true);
 

--- a/tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -20,17 +20,14 @@ use Symfony\Component\Config\Definition\Processor;
  */
 class ConfigurationTest extends TestCase
 {
-    /**
-     * @var Processor
-     */
-    private $processor;
+    private Processor $processor;
 
     protected function setUp(): void
     {
         $this->processor = new Processor();
     }
 
-    public function testUnconfiguredConfiguration()
+    public function testUnconfiguredConfiguration(): void
     {
         $configuration = $this->getConfigs([]);
 
@@ -46,7 +43,7 @@ class ConfigurationTest extends TestCase
         ], $configuration);
     }
 
-    public function testClientConfiguration()
+    public function testClientConfiguration(): void
     {
         $configuration = $this->getConfigs([
             'clients' => [
@@ -77,7 +74,7 @@ class ConfigurationTest extends TestCase
         $this->assertSame('Authorization: Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==', $configuration['clients']['clustered']['headers'][0]);
     }
 
-    public function testLogging()
+    public function testLogging(): void
     {
         $configuration = $this->getConfigs([
             'clients' => [
@@ -107,7 +104,7 @@ class ConfigurationTest extends TestCase
         $this->assertSame('custom.service', $configuration['clients']['logging_custom']['logger']);
     }
 
-    public function testSlashIsAddedAtTheEndOfServerUrl()
+    public function testSlashIsAddedAtTheEndOfServerUrl(): void
     {
         $config = [
             'clients' => [
@@ -119,7 +116,7 @@ class ConfigurationTest extends TestCase
         $this->assertSame('http://www.github.com/', $configuration['clients']['default']['hosts'][0]);
     }
 
-    public function testIndexConfig()
+    public function testIndexConfig(): void
     {
         $this->getConfigs([
             'clients' => [
@@ -153,7 +150,7 @@ class ConfigurationTest extends TestCase
         ]);
     }
 
-    public function testUnconfiguredIndex()
+    public function testUnconfiguredIndex(): void
     {
         $configuration = $this->getConfigs([
             'clients' => [
@@ -167,7 +164,7 @@ class ConfigurationTest extends TestCase
         $this->assertArrayHasKey('properties', $configuration['indexes']['test']);
     }
 
-    public function testNestedProperties()
+    public function testNestedProperties(): void
     {
         $this->getConfigs([
             'clients' => [
@@ -200,7 +197,7 @@ class ConfigurationTest extends TestCase
         ]);
     }
 
-    public function testTimeoutConfig()
+    public function testTimeoutConfig(): void
     {
         $configuration = $this->getConfigs([
             'clients' => [
@@ -214,7 +211,7 @@ class ConfigurationTest extends TestCase
         $this->assertSame(123, $configuration['clients']['simple_timeout']['timeout']);
     }
 
-    public function testHttpErrorCodesConfig()
+    public function testHttpErrorCodesConfig(): void
     {
         // test defaults
         $configuration = $this->getConfigs([
@@ -238,7 +235,7 @@ class ConfigurationTest extends TestCase
         $this->assertSame(['HTTP_ERROR_CODE'], $connection['http_error_codes']);
     }
 
-    public function testIndexTemplates()
+    public function testIndexTemplates(): void
     {
         $configuration = $this->getConfigs(
             [

--- a/tests/Unit/DependencyInjection/FOSElasticaExtensionTest.php
+++ b/tests/Unit/DependencyInjection/FOSElasticaExtensionTest.php
@@ -36,7 +36,7 @@ use Symfony\Component\Yaml\Yaml;
  */
 class FOSElasticaExtensionTest extends TestCase
 {
-    public function testExtensionSupportsDriverlessTypePersistence()
+    public function testExtensionSupportsDriverlessTypePersistence(): void
     {
         $config = Yaml::parse(\file_get_contents(__DIR__.'/fixtures/driverless_type.yml'));
 
@@ -51,7 +51,7 @@ class FOSElasticaExtensionTest extends TestCase
         $this->assertFalse($containerBuilder->hasDefinition('fos_elastica.object_persister.test_index'));
     }
 
-    public function testYamlConfiguration()
+    public function testYamlConfiguration(): void
     {
         $containerBuilder = new ContainerBuilder();
         $containerBuilder->registerExtension($extension = new FOSElasticaExtension());
@@ -79,7 +79,7 @@ class FOSElasticaExtensionTest extends TestCase
         ], $defaultClientDefinition->getArgument('$config')['transport_config']);
     }
 
-    public function testShouldRegisterDoctrineORMPagerProviderIfEnabled()
+    public function testShouldRegisterDoctrineORMPagerProviderIfEnabled(): void
     {
         $container = new ContainerBuilder();
         $container->setParameter('kernel.debug', true);
@@ -140,7 +140,7 @@ class FOSElasticaExtensionTest extends TestCase
         );
     }
 
-    public function testShouldRegisterDoctrineMongoDBPagerProviderIfEnabled()
+    public function testShouldRegisterDoctrineMongoDBPagerProviderIfEnabled(): void
     {
         if (!\class_exists(\Doctrine\ODM\MongoDB\DocumentManager::class)) {
             $this->markTestSkipped('Doctrine MongoDB ODM is not available.');
@@ -205,7 +205,7 @@ class FOSElasticaExtensionTest extends TestCase
         );
     }
 
-    public function testShouldRegisterDoctrinePHPCRPagerProviderIfEnabled()
+    public function testShouldRegisterDoctrinePHPCRPagerProviderIfEnabled(): void
     {
         if (!\class_exists(\Doctrine\ODM\PHPCR\DocumentManager::class)) {
             $this->markTestSkipped('Doctrine PHPCR is not present');
@@ -270,7 +270,7 @@ class FOSElasticaExtensionTest extends TestCase
         );
     }
 
-    public function testShouldRegisterInPlacePagerPersister()
+    public function testShouldRegisterInPlacePagerPersister(): void
     {
         $container = new ContainerBuilder();
         $container->setParameter('kernel.debug', true);
@@ -318,7 +318,7 @@ class FOSElasticaExtensionTest extends TestCase
         );
     }
 
-    public function testShouldRegisterRegisterListenersServiceForDoctrineProvider()
+    public function testShouldRegisterRegisterListenersServiceForDoctrineProvider(): void
     {
         $container = new ContainerBuilder();
         $container->setParameter('kernel.debug', true);
@@ -356,7 +356,7 @@ class FOSElasticaExtensionTest extends TestCase
         $this->assertSame('event_dispatcher', (string) $definition->getArgument(0));
     }
 
-    public function testShouldRegisterFilterObjectsListener()
+    public function testShouldRegisterFilterObjectsListener(): void
     {
         $container = new ContainerBuilder();
         $container->setParameter('kernel.debug', true);
@@ -396,7 +396,7 @@ class FOSElasticaExtensionTest extends TestCase
         $this->assertEquals(['kernel.event_subscriber' => [[]]], $listener->getTags());
     }
 
-    public function testShouldRegisterPagerPersisterRegisterService()
+    public function testShouldRegisterPagerPersisterRegisterService(): void
     {
         $container = new ContainerBuilder();
         $container->setParameter('kernel.debug', true);
@@ -432,7 +432,7 @@ class FOSElasticaExtensionTest extends TestCase
         $this->assertCount(0, $registry->getArgument(0)->getTaggedIteratorArgument()->getValues());
     }
 
-    public function testShouldRegisterDoctrineORMListener()
+    public function testShouldRegisterDoctrineORMListener(): void
     {
         $container = new ContainerBuilder();
         $container->setParameter('kernel.debug', true);
@@ -464,7 +464,7 @@ class FOSElasticaExtensionTest extends TestCase
         $this->assertTrue($container->hasDefinition('fos_elastica.listener.acme_index'));
     }
 
-    public function testShouldNotRegisterDoctrineORMListenerIfDisabled()
+    public function testShouldNotRegisterDoctrineORMListenerIfDisabled(): void
     {
         $container = new ContainerBuilder();
         $container->setParameter('kernel.debug', true);
@@ -498,7 +498,7 @@ class FOSElasticaExtensionTest extends TestCase
         $this->assertFalse($container->hasDefinition('fos_elastica.listener.acme_index'));
     }
 
-    public function testIndexTemplates()
+    public function testIndexTemplates(): void
     {
         $container = new ContainerBuilder();
         $container->setParameter('kernel.debug', true);

--- a/tests/Unit/Doctrine/AbstractElasticaToModelTransformerTest.php
+++ b/tests/Unit/Doctrine/AbstractElasticaToModelTransformerTest.php
@@ -234,9 +234,9 @@ class AbstractElasticaToModelTransformerTest extends TestCase
         $this->assertSame('id', $transformer->getIdentifierField());
     }
 
-    private function createMockPropertyAccessor()
+    private function createMockPropertyAccessor(): \PHPUnit\Framework\MockObject\MockObject
     {
-        $callback = (fn (object $object, string $identifier) => $object->{$identifier});
+        $callback = (fn (object $object, string $identifier): mixed => $object->{$identifier});
 
         $propertyAccessor = $this->createMock(PropertyAccessorInterface::class);
         $propertyAccessor
@@ -252,7 +252,7 @@ class AbstractElasticaToModelTransformerTest extends TestCase
     /**
      * @return \PHPUnit\Framework\MockObject\MockObject|AbstractElasticaToModelTransformer
      */
-    private function createMockTransformer(array $options = [])
+    private function createMockTransformer(array $options = []): \PHPUnit\Framework\MockObject\MockObject
     {
         $objectClass = Foo::class;
         $propertyAccessor = $this->createMockPropertyAccessor();
@@ -276,7 +276,7 @@ class Foo implements HighlightableModelInterface
     {
     }
 
-    public function getId()
+    public function getId(): mixed
     {
         return $this->id;
     }

--- a/tests/Unit/Doctrine/AbstractElasticaToModelTransformerTest.php
+++ b/tests/Unit/Doctrine/AbstractElasticaToModelTransformerTest.php
@@ -236,7 +236,7 @@ class AbstractElasticaToModelTransformerTest extends TestCase
 
     private function createMockPropertyAccessor()
     {
-        $callback = (fn ($object, $identifier) => $object->{$identifier});
+        $callback = (fn (object $object, string $identifier) => $object->{$identifier});
 
         $propertyAccessor = $this->createMock(PropertyAccessorInterface::class);
         $propertyAccessor

--- a/tests/Unit/Doctrine/AbstractElasticaToModelTransformerTest.php
+++ b/tests/Unit/Doctrine/AbstractElasticaToModelTransformerTest.php
@@ -29,7 +29,7 @@ class AbstractElasticaToModelTransformerTest extends TestCase
     /**
      * @var ManagerRegistry|\PHPUnit\Framework\MockObject\MockObject
      */
-    protected $registry;
+    protected \PHPUnit\Framework\MockObject\MockObject $registry;
 
     /**
      * @var string
@@ -44,7 +44,7 @@ class AbstractElasticaToModelTransformerTest extends TestCase
     /**
      * Tests if ignore_missing option is properly handled in transformHybrid() method.
      */
-    public function testIgnoreMissingOptionDuringTransformHybrid()
+    public function testIgnoreMissingOptionDuringTransformHybrid(): void
     {
         $transformer = $this->getMockBuilder(ElasticaToModelTransformer::class)
             ->setMethods(['findByIdentifiers'])
@@ -77,13 +77,13 @@ class AbstractElasticaToModelTransformerTest extends TestCase
         $this->assertSame($thirdElasticaResult, $hybridResults[1]->getResult());
     }
 
-    public function testObjectClassCanBeSet()
+    public function testObjectClassCanBeSet(): void
     {
         $transformer = $this->createMockTransformer();
         $this->assertSame(Foo::class, $transformer->getObjectClass());
     }
 
-    public function resultsWithMatchingObjects()
+    public function resultsWithMatchingObjects(): array
     {
         $elasticaResults = $doctrineObjects = [];
         for ($i = 1; $i < 4; ++$i) {
@@ -99,7 +99,7 @@ class AbstractElasticaToModelTransformerTest extends TestCase
     /**
      * @dataProvider resultsWithMatchingObjects
      */
-    public function testObjectsAreTransformedByFindingThemByTheirIdentifiers($elasticaResults, $doctrineObjects)
+    public function testObjectsAreTransformedByFindingThemByTheirIdentifiers(array $elasticaResults, array $doctrineObjects): void
     {
         $transformer = $this->createMockTransformer();
 
@@ -119,9 +119,9 @@ class AbstractElasticaToModelTransformerTest extends TestCase
      * @dataProvider resultsWithMatchingObjects
      */
     public function testAnExceptionIsThrownWhenTheNumberOfFoundObjectsIsLessThanTheNumberOfResults(
-        $elasticaResults,
-        $doctrineObjects,
-    ) {
+        array $elasticaResults,
+        array $doctrineObjects,
+    ): void {
         $transformer = $this->createMockTransformer();
 
         $transformer
@@ -141,9 +141,9 @@ class AbstractElasticaToModelTransformerTest extends TestCase
      * @dataProvider resultsWithMatchingObjects
      */
     public function testAnExceptionIsNotThrownWhenTheNumberOfFoundObjectsIsLessThanTheNumberOfResultsIfOptionSet(
-        $elasticaResults,
-        $doctrineObjects,
-    ) {
+        array $elasticaResults,
+        array $doctrineObjects,
+    ): void {
         $transformer = $this->createMockTransformer(['ignore_missing' => true]);
 
         $transformer
@@ -161,7 +161,7 @@ class AbstractElasticaToModelTransformerTest extends TestCase
     /**
      * @dataProvider resultsWithMatchingObjects
      */
-    public function testHighlightsAreSetOnTransformedObjects($elasticaResults, $doctrineObjects)
+    public function testHighlightsAreSetOnTransformedObjects(array $elasticaResults, array $doctrineObjects): void
     {
         $transformer = $this->createMockTransformer();
 
@@ -183,7 +183,7 @@ class AbstractElasticaToModelTransformerTest extends TestCase
     /**
      * @dataProvider resultsWithMatchingObjects
      */
-    public function testResultsAreSortedByIdentifier($elasticaResults, $doctrineObjects)
+    public function testResultsAreSortedByIdentifier(array $elasticaResults, array $doctrineObjects): void
     {
         \rsort($doctrineObjects);
 
@@ -206,7 +206,7 @@ class AbstractElasticaToModelTransformerTest extends TestCase
     /**
      * @dataProvider resultsWithMatchingObjects
      */
-    public function testHybridTransformReturnsDecoratedResults($elasticaResults, $doctrineObjects)
+    public function testHybridTransformReturnsDecoratedResults(array $elasticaResults, array $doctrineObjects): void
     {
         $transformer = $this->createMockTransformer();
 
@@ -228,7 +228,7 @@ class AbstractElasticaToModelTransformerTest extends TestCase
         }
     }
 
-    public function testIdentifierFieldDefaultsToId()
+    public function testIdentifierFieldDefaultsToId(): void
     {
         $transformer = $this->createMockTransformer();
         $this->assertSame('id', $transformer->getIdentifierField());
@@ -236,9 +236,7 @@ class AbstractElasticaToModelTransformerTest extends TestCase
 
     private function createMockPropertyAccessor()
     {
-        $callback = function ($object, $identifier) {
-            return $object->{$identifier};
-        };
+        $callback = (fn ($object, $identifier) => $object->{$identifier});
 
         $propertyAccessor = $this->createMock(PropertyAccessorInterface::class);
         $propertyAccessor
@@ -254,7 +252,7 @@ class AbstractElasticaToModelTransformerTest extends TestCase
     /**
      * @return \PHPUnit\Framework\MockObject\MockObject|AbstractElasticaToModelTransformer
      */
-    private function createMockTransformer($options = [])
+    private function createMockTransformer(array $options = [])
     {
         $objectClass = Foo::class;
         $propertyAccessor = $this->createMockPropertyAccessor();
@@ -272,12 +270,10 @@ class AbstractElasticaToModelTransformerTest extends TestCase
 
 class Foo implements HighlightableModelInterface
 {
-    public $id;
     public $highlights;
 
-    public function __construct($id)
+    public function __construct(public $id)
     {
-        $this->id = $id;
     }
 
     public function getId()
@@ -285,7 +281,7 @@ class Foo implements HighlightableModelInterface
         return $this->id;
     }
 
-    public function setElasticHighlights(array $highlights)
+    public function setElasticHighlights(array $highlights): void
     {
         $this->highlights = $highlights;
     }

--- a/tests/Unit/Doctrine/AbstractListenerTestCase.php
+++ b/tests/Unit/Doctrine/AbstractListenerTestCase.php
@@ -20,14 +20,11 @@ class Entity
 {
     public $identifier;
 
-    /**
-     * @param int $id
-     */
-    public function __construct(private $id)
+    public function __construct(private readonly int $id)
     {
     }
 
-    public function getId()
+    public function getId(): int
     {
         return $this->id;
     }
@@ -347,19 +344,13 @@ abstract class AbstractListenerTestCase extends TestCase
         $listener->postFlush($eventArgs);
     }
 
-    abstract protected function getLifecycleEventArgsClass();
+    abstract protected function getLifecycleEventArgsClass(): string;
 
-    abstract protected function getListenerClass();
+    abstract protected function getListenerClass(): string;
 
-    /**
-     * @return string
-     */
-    abstract protected function getObjectManagerClass();
+    abstract protected function getObjectManagerClass(): string;
 
-    /**
-     * @return string
-     */
-    abstract protected function getClassMetadataClass();
+    abstract protected function getClassMetadataClass(): string;
 
     private function createLifecycleEventArgs(): object
     {
@@ -385,7 +376,7 @@ abstract class AbstractListenerTestCase extends TestCase
         return $this->createMock($this->getObjectManagerClass());
     }
 
-    private function getMockPersister(Entity $object, string $indexName)
+    private function getMockPersister(Entity $object, string $indexName): \PHPUnit\Framework\MockObject\MockObject
     {
         $mock = $this->createMock(ObjectPersister::class);
 
@@ -404,7 +395,7 @@ abstract class AbstractListenerTestCase extends TestCase
         return $mock;
     }
 
-    private function getMockIndexable(?string $indexName, ?Entity $object = null, ?bool $return = null)
+    private function getMockIndexable(?string $indexName, ?Entity $object = null, ?bool $return = null): \PHPUnit\Framework\MockObject\MockObject
     {
         $mock = $this->createMock(IndexableInterface::class);
 

--- a/tests/Unit/Doctrine/AbstractListenerTestCase.php
+++ b/tests/Unit/Doctrine/AbstractListenerTestCase.php
@@ -19,14 +19,12 @@ use PHPUnit\Framework\TestCase;
 class Entity
 {
     public $identifier;
-    private $id;
 
     /**
      * @param int $id
      */
-    public function __construct($id)
+    public function __construct(private $id)
     {
-        $this->id = $id;
     }
 
     public function getId()
@@ -37,12 +35,8 @@ class Entity
 
 class ConditionalUpdateEntity extends Entity
 {
-    private $shouldBeUpdated;
-
-    public function __construct($id, $shouldBeUpdated)
+    public function __construct($id, private $shouldBeUpdated)
     {
-        parent::__construct($id);
-        $this->shouldBeUpdated = $shouldBeUpdated;
     }
 
     public function shouldBeUpdated(): bool
@@ -58,7 +52,7 @@ class ConditionalUpdateEntity extends Entity
  */
 abstract class AbstractListenerTestCase extends TestCase
 {
-    public function testObjectInsertedOnPersist()
+    public function testObjectInsertedOnPersist(): void
     {
         $entity = new Entity(1);
         $persister = $this->getMockPersister($entity, 'index');
@@ -78,7 +72,7 @@ abstract class AbstractListenerTestCase extends TestCase
         $listener->postFlush($eventArgs);
     }
 
-    public function testPersistDeferred()
+    public function testPersistDeferred(): void
     {
         $entity = new Entity(1);
         $persister = $this->getMockPersister($entity, 'index');
@@ -95,7 +89,7 @@ abstract class AbstractListenerTestCase extends TestCase
         $listener->postFlush($eventArgs);
     }
 
-    public function testNonIndexableObjectNotInsertedOnPersist()
+    public function testNonIndexableObjectNotInsertedOnPersist(): void
     {
         $entity = new Entity(1);
         $persister = $this->getMockPersister($entity, 'index');
@@ -117,7 +111,7 @@ abstract class AbstractListenerTestCase extends TestCase
         $listener->postFlush($eventArgs);
     }
 
-    public function testObjectReplacedOnUpdate()
+    public function testObjectReplacedOnUpdate(): void
     {
         $entity = new Entity(1);
         $persister = $this->getMockPersister($entity, 'index');
@@ -140,7 +134,7 @@ abstract class AbstractListenerTestCase extends TestCase
         $listener->postFlush($eventArgs);
     }
 
-    public function testNonIndexableObjectRemovedOnUpdate()
+    public function testNonIndexableObjectRemovedOnUpdate(): void
     {
         $classMetadata = $this->getMockClassMetadata();
         $objectManager = $this->getMockObjectManager();
@@ -152,7 +146,7 @@ abstract class AbstractListenerTestCase extends TestCase
 
         $objectManager->expects($this->any())
             ->method('getClassMetadata')
-            ->with(\get_class($entity))
+            ->with($entity::class)
             ->will($this->returnValue($classMetadata))
         ;
 
@@ -179,7 +173,7 @@ abstract class AbstractListenerTestCase extends TestCase
         $listener->postFlush($eventArgs);
     }
 
-    public function testObjectDeletedOnRemove()
+    public function testObjectDeletedOnRemove(): void
     {
         $classMetadata = $this->getMockClassMetadata();
         $objectManager = $this->getMockObjectManager();
@@ -191,7 +185,7 @@ abstract class AbstractListenerTestCase extends TestCase
 
         $objectManager->expects($this->any())
             ->method('getClassMetadata')
-            ->with(\get_class($entity))
+            ->with($entity::class)
             ->will($this->returnValue($classMetadata))
         ;
 
@@ -214,7 +208,7 @@ abstract class AbstractListenerTestCase extends TestCase
         $listener->postFlush($eventArgs);
     }
 
-    public function testObjectWithNonStandardIdentifierDeletedOnRemove()
+    public function testObjectWithNonStandardIdentifierDeletedOnRemove(): void
     {
         $classMetadata = $this->getMockClassMetadata();
         $objectManager = $this->getMockObjectManager();
@@ -227,7 +221,7 @@ abstract class AbstractListenerTestCase extends TestCase
 
         $objectManager->expects($this->any())
             ->method('getClassMetadata')
-            ->with(\get_class($entity))
+            ->with($entity::class)
             ->will($this->returnValue($classMetadata))
         ;
 
@@ -250,11 +244,11 @@ abstract class AbstractListenerTestCase extends TestCase
         $listener->postFlush($eventArgs);
     }
 
-    public function testShouldPersistOnKernelTerminateIfDeferIsTrue()
+    public function testShouldPersistOnKernelTerminateIfDeferIsTrue(): void
     {
         $entity = new Entity(1);
         $persister = $this->getMockPersister($entity, 'index');
-        $indexable = $this->getMockIndexable(null, null, null);
+        $indexable = $this->getMockIndexable(null);
         $listener = $this->createListener(
             $persister,
             $indexable,
@@ -263,14 +257,13 @@ abstract class AbstractListenerTestCase extends TestCase
         $scheduledForInsertion = ['data'];
         $refListener = new \ReflectionObject($listener);
         $refScheduledForInsertion = $refListener->getProperty('scheduledForInsertion');
-        $refScheduledForInsertion->setAccessible(true);
         $refScheduledForInsertion->setValue($listener, $scheduledForInsertion);
         $persister->expects($this->once())->method('insertMany')->with($scheduledForInsertion);
 
         $listener->onTerminate();
     }
 
-    public function testConditionalUpdateObjectInsertedOnPersistWhenShouldBeUpdatedIsTrue()
+    public function testConditionalUpdateObjectInsertedOnPersistWhenShouldBeUpdatedIsTrue(): void
     {
         $entity = new ConditionalUpdateEntity(1, true);
         $persister = $this->getMockPersister($entity, 'index');
@@ -290,7 +283,7 @@ abstract class AbstractListenerTestCase extends TestCase
         $listener->postFlush($eventArgs);
     }
 
-    public function testConditionalUpdateObjectNotInsertedOnPersistWhenShouldBeUpdatedIsFalse()
+    public function testConditionalUpdateObjectNotInsertedOnPersistWhenShouldBeUpdatedIsFalse(): void
     {
         $entity = new ConditionalUpdateEntity(1, false);
         $persister = $this->getMockPersister($entity, 'index');
@@ -309,7 +302,7 @@ abstract class AbstractListenerTestCase extends TestCase
         $listener->postFlush($eventArgs);
     }
 
-    public function testConditionalUpdateObjectReplacedOnUpdateWhenShouldBeUpdatedIsTrue()
+    public function testConditionalUpdateObjectReplacedOnUpdateWhenShouldBeUpdatedIsTrue(): void
     {
         $entity = new ConditionalUpdateEntity(1, true);
         $persister = $this->getMockPersister($entity, 'index');
@@ -332,7 +325,7 @@ abstract class AbstractListenerTestCase extends TestCase
         $listener->postFlush($eventArgs);
     }
 
-    public function testConditionalUpdateObjectNotReplacedOnUpdateWhenShouldBeUpdatedIsFalse()
+    public function testConditionalUpdateObjectNotReplacedOnUpdateWhenShouldBeUpdatedIsFalse(): void
     {
         $entity = new ConditionalUpdateEntity(1, false);
         $persister = $this->getMockPersister($entity, 'index');
@@ -368,31 +361,31 @@ abstract class AbstractListenerTestCase extends TestCase
      */
     abstract protected function getClassMetadataClass();
 
-    private function createLifecycleEventArgs()
+    private function createLifecycleEventArgs(): object
     {
         $refl = new \ReflectionClass($this->getLifecycleEventArgsClass());
 
         return $refl->newInstanceArgs(\func_get_args());
     }
 
-    private function createListener()
+    private function createListener(): object
     {
         $refl = new \ReflectionClass($this->getListenerClass());
 
         return $refl->newInstanceArgs(\func_get_args());
     }
 
-    private function getMockClassMetadata()
+    private function getMockClassMetadata(): \PHPUnit\Framework\MockObject\MockObject
     {
         return $this->createMock($this->getClassMetadataClass());
     }
 
-    private function getMockObjectManager()
+    private function getMockObjectManager(): \PHPUnit\Framework\MockObject\MockObject
     {
         return $this->createMock($this->getObjectManagerClass());
     }
 
-    private function getMockPersister(Entity $object, $indexName)
+    private function getMockPersister(Entity $object, string $indexName)
     {
         $mock = $this->createMock(ObjectPersister::class);
 
@@ -411,7 +404,7 @@ abstract class AbstractListenerTestCase extends TestCase
         return $mock;
     }
 
-    private function getMockIndexable($indexName, ?Entity $object = null, $return = null)
+    private function getMockIndexable(?string $indexName, ?Entity $object = null, ?bool $return = null)
     {
         $mock = $this->createMock(IndexableInterface::class);
 

--- a/tests/Unit/Doctrine/ConditionalUpdateEntity.php
+++ b/tests/Unit/Doctrine/ConditionalUpdateEntity.php
@@ -17,11 +17,11 @@ class ConditionalUpdateEntity implements ConditionalUpdate
 {
     public $identifier;
 
-    public function __construct(private $id, private $shouldBeUpdated = true)
+    public function __construct(private readonly mixed $id, private bool $shouldBeUpdated = true)
     {
     }
 
-    public function getId()
+    public function getId(): mixed
     {
         return $this->id;
     }

--- a/tests/Unit/Doctrine/ConditionalUpdateEntity.php
+++ b/tests/Unit/Doctrine/ConditionalUpdateEntity.php
@@ -16,13 +16,9 @@ use FOS\ElasticaBundle\Doctrine\ConditionalUpdate;
 class ConditionalUpdateEntity implements ConditionalUpdate
 {
     public $identifier;
-    private $id;
-    private $shouldBeUpdated = true;
 
-    public function __construct($id, $shouldBeUpdated = true)
+    public function __construct(private $id, private $shouldBeUpdated = true)
     {
-        $this->id = $id;
-        $this->shouldBeUpdated = $shouldBeUpdated;
     }
 
     public function getId()

--- a/tests/Unit/Doctrine/ConditionalUpdateListenerTest.php
+++ b/tests/Unit/Doctrine/ConditionalUpdateListenerTest.php
@@ -23,7 +23,7 @@ use PHPUnit\Framework\TestCase;
  */
 class ConditionalUpdateListenerTest extends TestCase
 {
-    public function testEntityWithConditionalUpdateTrueIsIndexed()
+    public function testEntityWithConditionalUpdateTrueIsIndexed(): void
     {
         $entity = $this->createMock(ConditionalUpdate::class);
         $entity->expects($this->once())
@@ -58,7 +58,7 @@ class ConditionalUpdateListenerTest extends TestCase
         $this->assertContains($entity, $listener->scheduledForInsertion);
     }
 
-    public function testEntityWithConditionalUpdateFalseIsNotIndexed()
+    public function testEntityWithConditionalUpdateFalseIsNotIndexed(): void
     {
         // Create a mock entity implementing ConditionalUpdate that returns false
         $entity = $this->createMock(ConditionalUpdate::class);
@@ -99,7 +99,7 @@ class ConditionalUpdateListenerTest extends TestCase
         $this->assertEmpty($listener->scheduledForInsertion);
     }
 
-    public function testEntityWithConditionalUpdateTrueIsUpdated()
+    public function testEntityWithConditionalUpdateTrueIsUpdated(): void
     {
         // Create a mock entity implementing ConditionalUpdate that returns true
         $entity = $this->createMock(ConditionalUpdate::class);
@@ -140,7 +140,7 @@ class ConditionalUpdateListenerTest extends TestCase
         $this->assertContains($entity, $listener->scheduledForUpdate);
     }
 
-    public function testEntityWithConditionalUpdateFalseIsNotUpdated()
+    public function testEntityWithConditionalUpdateFalseIsNotUpdated(): void
     {
         // Create a mock entity implementing ConditionalUpdate that returns false
         $entity = $this->createMock(ConditionalUpdate::class);

--- a/tests/Unit/Doctrine/MongoDB/ListenerTestCase.php
+++ b/tests/Unit/Doctrine/MongoDB/ListenerTestCase.php
@@ -25,22 +25,22 @@ class ListenerTestCase extends AbstractListenerTestCase
         }
     }
 
-    protected function getClassMetadataClass()
+    protected function getClassMetadataClass(): string
     {
         return \Doctrine\ODM\MongoDB\Mapping\ClassMetadata::class;
     }
 
-    protected function getLifecycleEventArgsClass()
+    protected function getLifecycleEventArgsClass(): string
     {
         return \Doctrine\ODM\MongoDB\Event\LifecycleEventArgs::class;
     }
 
-    protected function getListenerClass()
+    protected function getListenerClass(): string
     {
         return \FOS\ElasticaBundle\Doctrine\Listener::class;
     }
 
-    protected function getObjectManagerClass()
+    protected function getObjectManagerClass(): string
     {
         return \Doctrine\ODM\MongoDB\DocumentManager::class;
     }

--- a/tests/Unit/Doctrine/MongoDBPagerProviderTest.php
+++ b/tests/Unit/Doctrine/MongoDBPagerProviderTest.php
@@ -36,14 +36,14 @@ class MongoDBPagerProviderTest extends TestCase
         }
     }
 
-    public function testShouldImplementPagerProviderInterface()
+    public function testShouldImplementPagerProviderInterface(): void
     {
         $rc = new \ReflectionClass(MongoDBPagerProvider::class);
 
         $this->assertTrue($rc->implementsInterface(PagerProviderInterface::class));
     }
 
-    public function testCouldBeConstructedWithExpectedArguments()
+    public function testCouldBeConstructedWithExpectedArguments(): void
     {
         $doctrine = $this->createDoctrineMock();
         $objectClass = 'anObjectClass';
@@ -52,7 +52,7 @@ class MongoDBPagerProviderTest extends TestCase
         new MongoDBPagerProvider($doctrine, $this->createRegisterListenersServiceMock(), $objectClass, $baseConfig);
     }
 
-    public function testShouldReturnPagerfanataPagerWithDoctrineODMMongoDBAdapter()
+    public function testShouldReturnPagerfanataPagerWithDoctrineODMMongoDBAdapter(): void
     {
         $objectClass = 'anObjectClass';
         $baseConfig = ['query_builder_method' => 'createQueryBuilder'];
@@ -92,7 +92,7 @@ class MongoDBPagerProviderTest extends TestCase
         $this->assertInstanceOf(QueryAdapter::class, $adapter);
     }
 
-    public function testShouldAllowCallCustomRepositoryMethod()
+    public function testShouldAllowCallCustomRepositoryMethod(): void
     {
         $objectClass = 'anObjectClass';
         $baseConfig = ['query_builder_method' => 'createQueryBuilder'];
@@ -125,7 +125,7 @@ class MongoDBPagerProviderTest extends TestCase
         $this->assertInstanceOf(PagerfantaPager::class, $pager);
     }
 
-    public function testShouldCallRegisterListenersService()
+    public function testShouldCallRegisterListenersService(): void
     {
         $objectClass = 'anObjectClass';
         $baseConfig = ['query_builder_method' => 'createQueryBuilder'];
@@ -166,7 +166,7 @@ class MongoDBPagerProviderTest extends TestCase
     /**
      * @return \PHPUnit\Framework\MockObject\MockObject|ManagerRegistry
      */
-    private function createDoctrineMock()
+    private function createDoctrineMock(): \PHPUnit\Framework\MockObject\MockObject
     {
         return $this->createMock(ManagerRegistry::class);
     }
@@ -174,7 +174,7 @@ class MongoDBPagerProviderTest extends TestCase
     /**
      * @return RegisterListenersService|\PHPUnit\Framework\MockObject\MockObject
      */
-    private function createRegisterListenersServiceMock()
+    private function createRegisterListenersServiceMock(): \PHPUnit\Framework\MockObject\MockObject
     {
         return $this->createMock(RegisterListenersService::class);
     }

--- a/tests/Unit/Doctrine/ORM/ElasticaToModelTransformerTest.php
+++ b/tests/Unit/Doctrine/ORM/ElasticaToModelTransformerTest.php
@@ -31,12 +31,12 @@ class ElasticaToModelTransformerTest extends TestCase
     /**
      * @var ManagerRegistry&MockObject
      */
-    protected $registry;
+    protected MockObject $registry;
 
     /**
      * @var ObjectManager&MockObject
      */
-    protected $manager;
+    protected MockObject $manager;
 
     /**
      * @var ObjectRepository&MockObject
@@ -78,7 +78,7 @@ class ElasticaToModelTransformerTest extends TestCase
      * Tests that the Transformer uses the query_builder_method configuration option
      * allowing configuration of createQueryBuilder call.
      */
-    public function testTransformUsesQueryBuilderMethodConfiguration()
+    public function testTransformUsesQueryBuilderMethodConfiguration(): void
     {
         $qb = $this->createMock(QueryBuilder::class);
 
@@ -97,7 +97,6 @@ class ElasticaToModelTransformerTest extends TestCase
 
         $class = new \ReflectionClass(ElasticaToModelTransformer::class);
         $method = $class->getMethod('getEntityQueryBuilder');
-        $method->setAccessible(true);
 
         $method->invokeArgs($transformer, []);
     }
@@ -106,7 +105,7 @@ class ElasticaToModelTransformerTest extends TestCase
      * Tests that the Transformer uses the query_builder_method configuration option
      * allowing configuration of createQueryBuilder call.
      */
-    public function testTransformUsesDefaultQueryBuilderMethodConfiguration()
+    public function testTransformUsesDefaultQueryBuilderMethodConfiguration(): void
     {
         $qb = $this->createMock(QueryBuilder::class);
 
@@ -123,7 +122,6 @@ class ElasticaToModelTransformerTest extends TestCase
 
         $class = new \ReflectionClass(ElasticaToModelTransformer::class);
         $method = $class->getMethod('getEntityQueryBuilder');
-        $method->setAccessible(true);
 
         $method->invokeArgs($transformer, []);
     }
@@ -131,7 +129,7 @@ class ElasticaToModelTransformerTest extends TestCase
     /**
      * Checks that the 'hints' parameter is used on the created query.
      */
-    public function testUsesHintsConfigurationIfGiven()
+    public function testUsesHintsConfigurationIfGiven(): void
     {
         $query = $this->getMockBuilder(Query::class)
             ->setMethods(['setHint', 'execute', 'setHydrationMode'])
@@ -164,7 +162,6 @@ class ElasticaToModelTransformerTest extends TestCase
 
         $class = new \ReflectionClass(ElasticaToModelTransformer::class);
         $method = $class->getMethod('findByIdentifiers');
-        $method->setAccessible(true);
 
         $method->invokeArgs($transformer, [[1, 2, 3], /* $hydrate */ true]);
     }

--- a/tests/Unit/Doctrine/ORM/ElasticaToModelTransformerTest.php
+++ b/tests/Unit/Doctrine/ORM/ElasticaToModelTransformerTest.php
@@ -41,7 +41,7 @@ class ElasticaToModelTransformerTest extends TestCase
     /**
      * @var ObjectRepository&MockObject
      */
-    protected $repository;
+    protected MockObject $repository;
 
     protected function setUp(): void
     {
@@ -137,6 +137,7 @@ class ElasticaToModelTransformerTest extends TestCase
             ->getMockForAbstractClass()
         ;
         $query->expects($this->any())->method('setHydrationMode')->willReturnSelf();
+        $query->expects($this->any())->method('execute')->willReturn([]);
         $query->expects($this->once())  //  check if the hint is set
             ->method('setHint')
             ->with('customHintName', 'Custom\Hint\Class')

--- a/tests/Unit/Doctrine/ORM/ListenerTestCase.php
+++ b/tests/Unit/Doctrine/ORM/ListenerTestCase.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the FOSElasticaBundle package.
  *
@@ -18,22 +20,22 @@ use FOS\ElasticaBundle\Tests\Unit\Doctrine\AbstractListenerTestCase;
  */
 class ListenerTestCase extends AbstractListenerTestCase
 {
-    protected function getClassMetadataClass()
+    protected function getClassMetadataClass(): string
     {
         return \Doctrine\ORM\Mapping\ClassMetadata::class;
     }
 
-    protected function getLifecycleEventArgsClass()
+    protected function getLifecycleEventArgsClass(): string
     {
         return \Doctrine\Persistence\Event\LifecycleEventArgs::class;
     }
 
-    protected function getListenerClass()
+    protected function getListenerClass(): string
     {
         return \FOS\ElasticaBundle\Doctrine\Listener::class;
     }
 
-    protected function getObjectManagerClass()
+    protected function getObjectManagerClass(): string
     {
         return \Doctrine\ORM\EntityManager::class;
     }

--- a/tests/Unit/Doctrine/ORMPagerProviderTest.php
+++ b/tests/Unit/Doctrine/ORMPagerProviderTest.php
@@ -30,14 +30,14 @@ use Symfony\Bridge\Doctrine\ManagerRegistry;
  */
 class ORMPagerProviderTest extends TestCase
 {
-    public function testShouldImplementPagerProviderInterface()
+    public function testShouldImplementPagerProviderInterface(): void
     {
         $rc = new \ReflectionClass(ORMPagerProvider::class);
 
         $this->assertTrue($rc->implementsInterface(PagerProviderInterface::class));
     }
 
-    public function testCouldBeConstructedWithExpectedArguments()
+    public function testCouldBeConstructedWithExpectedArguments(): void
     {
         $doctrine = $this->createDoctrineMock();
         $objectClass = 'anObjectClass';
@@ -46,7 +46,7 @@ class ORMPagerProviderTest extends TestCase
         new ORMPagerProvider($doctrine, $this->createRegisterListenersServiceMock(), $objectClass, $baseConfig);
     }
 
-    public function testShouldReturnPagerfantaPagerWithDoctrineORMAdapter()
+    public function testShouldReturnPagerfantaPagerWithDoctrineORMAdapter(): void
     {
         $objectClass = 'anObjectClass';
         $baseConfig = ['query_builder_method' => 'createQueryBuilder'];
@@ -90,7 +90,7 @@ class ORMPagerProviderTest extends TestCase
         $this->assertInstanceOf(QueryAdapter::class, $adapter);
     }
 
-    public function testShouldAllowCallCustomRepositoryMethod()
+    public function testShouldAllowCallCustomRepositoryMethod(): void
     {
         $objectClass = 'anObjectClass';
         $baseConfig = ['query_builder_method' => 'createQueryBuilder'];
@@ -131,7 +131,7 @@ class ORMPagerProviderTest extends TestCase
         $this->assertInstanceOf(PagerfantaPager::class, $pager);
     }
 
-    public function testShouldCallRegisterListenersService()
+    public function testShouldCallRegisterListenersService(): void
     {
         $objectClass = 'anObjectClass';
         $baseConfig = ['query_builder_method' => 'createQueryBuilder'];
@@ -180,7 +180,7 @@ class ORMPagerProviderTest extends TestCase
     /**
      * @return RegisterListenersService|\PHPUnit\Framework\MockObject\MockObject
      */
-    private function createRegisterListenersServiceMock()
+    private function createRegisterListenersServiceMock(): \PHPUnit\Framework\MockObject\MockObject
     {
         return $this->createMock(RegisterListenersService::class);
     }
@@ -188,7 +188,7 @@ class ORMPagerProviderTest extends TestCase
     /**
      * @return \PHPUnit\Framework\MockObject\MockObject|ManagerRegistry
      */
-    private function createDoctrineMock()
+    private function createDoctrineMock(): \PHPUnit\Framework\MockObject\MockObject
     {
         return $this->createMock(ManagerRegistry::class);
     }

--- a/tests/Unit/Doctrine/PHPCR/ElasticaToModelTransformerTest.php
+++ b/tests/Unit/Doctrine/PHPCR/ElasticaToModelTransformerTest.php
@@ -26,12 +26,12 @@ class ElasticaToModelTransformerTest extends TestCase
     /**
      * @var ManagerRegistry|\PHPUnit\Framework\MockObject\MockObject
      */
-    protected $registry;
+    protected \PHPUnit\Framework\MockObject\MockObject $registry;
 
     /**
      * @var DocumentManager|\PHPUnit\Framework\MockObject\MockObject
      */
-    protected $manager;
+    protected \PHPUnit\Framework\MockObject\MockObject $manager;
 
     /**
      * @var DocumentRepository|\PHPUnit\Framework\MockObject\MockObject
@@ -87,7 +87,7 @@ class ElasticaToModelTransformerTest extends TestCase
         ;
     }
 
-    public function testTransformUsesFindByIdentifier()
+    public function testTransformUsesFindByIdentifier(): void
     {
         $this->registry->expects($this->any())
             ->method('getManager')
@@ -98,7 +98,6 @@ class ElasticaToModelTransformerTest extends TestCase
 
         $class = new \ReflectionClass(ElasticaToModelTransformer::class);
         $method = $class->getMethod('findByIdentifiers');
-        $method->setAccessible(true);
 
         $method->invokeArgs($transformer, [
             ['c8f23994-d897-4c77-bcc3-bc6910e52a34', 'f1083287-a67e-480e-a426-e8427d00eae4'],

--- a/tests/Unit/Doctrine/PHPCR/ElasticaToModelTransformerTest.php
+++ b/tests/Unit/Doctrine/PHPCR/ElasticaToModelTransformerTest.php
@@ -36,7 +36,7 @@ class ElasticaToModelTransformerTest extends TestCase
     /**
      * @var DocumentRepository|\PHPUnit\Framework\MockObject\MockObject
      */
-    protected $repository;
+    protected \PHPUnit\Framework\MockObject\MockObject $repository;
 
     protected $objectClass = 'stdClass';
 

--- a/tests/Unit/Doctrine/PHPCR/ListenerTestCase.php
+++ b/tests/Unit/Doctrine/PHPCR/ListenerTestCase.php
@@ -25,22 +25,22 @@ class ListenerTestCase extends AbstractListenerTestCase
         }
     }
 
-    protected function getClassMetadataClass()
+    protected function getClassMetadataClass(): string
     {
         return \Doctrine\ODM\PHPCR\Mapping\ClassMetadata::class;
     }
 
-    protected function getLifecycleEventArgsClass()
+    protected function getLifecycleEventArgsClass(): string
     {
         return \Doctrine\Persistence\Event\LifecycleEventArgs::class;
     }
 
-    protected function getListenerClass()
+    protected function getListenerClass(): string
     {
         return \FOS\ElasticaBundle\Doctrine\Listener::class;
     }
 
-    protected function getObjectManagerClass()
+    protected function getObjectManagerClass(): string
     {
         return \Doctrine\ODM\PHPCR\DocumentManager::class;
     }

--- a/tests/Unit/Doctrine/PHPCRPagerProviderTest.php
+++ b/tests/Unit/Doctrine/PHPCRPagerProviderTest.php
@@ -36,14 +36,14 @@ class PHPCRPagerProviderTest extends TestCase
         }
     }
 
-    public function testShouldImplementPagerProviderInterface()
+    public function testShouldImplementPagerProviderInterface(): void
     {
         $rc = new \ReflectionClass(PHPCRPagerProvider::class);
 
         $this->assertTrue($rc->implementsInterface(PagerProviderInterface::class));
     }
 
-    public function testCouldBeConstructedWithExpectedArguments()
+    public function testCouldBeConstructedWithExpectedArguments(): void
     {
         $doctrine = $this->createDoctrineMock();
         $objectClass = 'anObjectClass';
@@ -52,7 +52,7 @@ class PHPCRPagerProviderTest extends TestCase
         new PHPCRPagerProvider($doctrine, $this->createRegisterListenersServiceMock(), $objectClass, $baseConfig);
     }
 
-    public function testShouldReturnPagerfanataPagerWithDoctrineODMMongoDBAdapter()
+    public function testShouldReturnPagerfanataPagerWithDoctrineODMMongoDBAdapter(): void
     {
         $objectClass = 'anObjectClass';
         $baseConfig = ['query_builder_method' => 'createQueryBuilder'];
@@ -92,7 +92,7 @@ class PHPCRPagerProviderTest extends TestCase
         $this->assertInstanceOf(QueryAdapter::class, $adapter);
     }
 
-    public function testShouldAllowCallCustomRepositoryMethod()
+    public function testShouldAllowCallCustomRepositoryMethod(): void
     {
         $objectClass = 'anObjectClass';
         $baseConfig = ['query_builder_method' => 'createQueryBuilder'];
@@ -125,7 +125,7 @@ class PHPCRPagerProviderTest extends TestCase
         $this->assertInstanceOf(PagerfantaPager::class, $pager);
     }
 
-    public function testShouldCallRegisterListenersService()
+    public function testShouldCallRegisterListenersService(): void
     {
         $objectClass = 'anObjectClass';
         $baseConfig = ['query_builder_method' => 'createQueryBuilder'];
@@ -168,7 +168,7 @@ class PHPCRPagerProviderTest extends TestCase
     /**
      * @return \PHPUnit\Framework\MockObject\MockObject|ManagerRegistry
      */
-    private function createDoctrineMock()
+    private function createDoctrineMock(): \PHPUnit\Framework\MockObject\MockObject
     {
         return $this->createMock(ManagerRegistry::class);
     }
@@ -176,7 +176,7 @@ class PHPCRPagerProviderTest extends TestCase
     /**
      * @return RegisterListenersService|\PHPUnit\Framework\MockObject\MockObject
      */
-    private function createRegisterListenersServiceMock()
+    private function createRegisterListenersServiceMock(): \PHPUnit\Framework\MockObject\MockObject
     {
         return $this->createMock(RegisterListenersService::class);
     }

--- a/tests/Unit/Doctrine/RegisterListenersServiceTest.php
+++ b/tests/Unit/Doctrine/RegisterListenersServiceTest.php
@@ -31,12 +31,12 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
  */
 class RegisterListenersServiceTest extends TestCase
 {
-    public function testCouldBeConstructedWithDispatcherArgument()
+    public function testCouldBeConstructedWithDispatcherArgument(): void
     {
         new RegisterListenersService($this->createDispatcherMock());
     }
 
-    public function testShouldRegisterClearObjectManagerListenerByDefaultAndDispatchOnPostPersistEvent()
+    public function testShouldRegisterClearObjectManagerListenerByDefaultAndDispatchOnPostPersistEvent(): void
     {
         $dispatcher = $this->createDispatcher();
 
@@ -57,7 +57,7 @@ class RegisterListenersServiceTest extends TestCase
         );
     }
 
-    public function testShouldNotRegisterClearObjectManagerListenerIfOptionFalse()
+    public function testShouldNotRegisterClearObjectManagerListenerIfOptionFalse(): void
     {
         $dispatcher = $this->createDispatcher();
 
@@ -80,7 +80,7 @@ class RegisterListenersServiceTest extends TestCase
         );
     }
 
-    public function testShouldNotCallClearObjectManagerListenerForAnotherPagers()
+    public function testShouldNotCallClearObjectManagerListenerForAnotherPagers(): void
     {
         $dispatcher = $this->createDispatcher();
 
@@ -104,7 +104,7 @@ class RegisterListenersServiceTest extends TestCase
         );
     }
 
-    public function testShouldNotRegisterSleepListenerByDefault()
+    public function testShouldNotRegisterSleepListenerByDefault(): void
     {
         $dispatcher = $this->createDispatcherMock();
         $dispatcher
@@ -124,7 +124,7 @@ class RegisterListenersServiceTest extends TestCase
         ]);
     }
 
-    public function testShouldRegisterSleepListenerIfOptionNotZero()
+    public function testShouldRegisterSleepListenerIfOptionNotZero(): void
     {
         $dispatcher = $this->createDispatcher();
 
@@ -147,7 +147,7 @@ class RegisterListenersServiceTest extends TestCase
         $this->assertGreaterThan(1.5, \microtime(true) - $time);
     }
 
-    public function testShouldNotCallSleepListenerForAnotherPagers()
+    public function testShouldNotCallSleepListenerForAnotherPagers(): void
     {
         $dispatcher = $this->createDispatcher();
 
@@ -171,7 +171,7 @@ class RegisterListenersServiceTest extends TestCase
         $this->assertLessThan(1, \microtime(true) - $time);
     }
 
-    public function testShouldRegisterDisableDebugLoggingByDefaultForEntityManager()
+    public function testShouldRegisterDisableDebugLoggingByDefaultForEntityManager(): void
     {
         if (!\interface_exists('Doctrine\DBAL\Logging\SQLLogger')) {
             $this->markTestSkipped('This is only possible on doctrine/orm 2.');
@@ -211,7 +211,7 @@ class RegisterListenersServiceTest extends TestCase
         ]);
     }
 
-    public function testShouldNotRegisterDisableDebugLoggingIfOptionTrueForEntityManager()
+    public function testShouldNotRegisterDisableDebugLoggingIfOptionTrueForEntityManager(): void
     {
         $dispatcher = $this->createDispatcherMock();
         $dispatcher
@@ -236,7 +236,7 @@ class RegisterListenersServiceTest extends TestCase
         ]);
     }
 
-    public function testShouldIgnoreDebugLoggingOptionForMongoDBDocumentManager()
+    public function testShouldIgnoreDebugLoggingOptionForMongoDBDocumentManager(): void
     {
         if (!\class_exists(\Doctrine\ODM\MongoDB\DocumentManager::class)) {
             $this->markTestSkipped('Doctrine MongoDB ODM is not available.');
@@ -261,7 +261,7 @@ class RegisterListenersServiceTest extends TestCase
         ]);
     }
 
-    public function testShouldIgnoreDebugLoggingOptionForPHPCRManager()
+    public function testShouldIgnoreDebugLoggingOptionForPHPCRManager(): void
     {
         if (!\interface_exists(\Doctrine\ODM\PHPCR\DocumentManagerInterface::class)) {
             $this->markTestSkipped('Doctrine PHPCR is not present');

--- a/tests/Unit/Doctrine/RepositoryManagerTest.php
+++ b/tests/Unit/Doctrine/RepositoryManagerTest.php
@@ -33,7 +33,7 @@ class NamespacedEntity
  */
 class RepositoryManagerTest extends TestCase
 {
-    public function testThatGetRepositoryCallsMainRepositoryManager()
+    public function testThatGetRepositoryCallsMainRepositoryManager(): void
     {
         $finderMock = $this->createMock(TransformedFinder::class);
         $registryMock = $this->createMock(ManagerRegistry::class);
@@ -50,7 +50,7 @@ class RepositoryManagerTest extends TestCase
         $this->assertInstanceOf(Repository::class, $repository);
     }
 
-    public function testGetRepositoryShouldResolveEntityShortName()
+    public function testGetRepositoryShouldResolveEntityShortName(): void
     {
         $finderMock = $this->createMock(TransformedFinder::class);
         $registryMock = $this->createMock(ManagerRegistry::class);

--- a/tests/Unit/Elastica/ClientTest.php
+++ b/tests/Unit/Elastica/ClientTest.php
@@ -71,7 +71,7 @@ class ClientTest extends TestCase
         $dispatcher = $this->createMock(EventDispatcherInterface::class);
         $dispatcher->expects($invoke = $this->exactly(2))
             ->method('dispatch')
-            ->with($this->callback(function ($o) use ($invoke): bool {
+            ->with($this->callback(function (object $o) use ($invoke): bool {
                 $counter = $invoke->getInvocationCount() - 1;
 
                 if ($counter > 1) {
@@ -150,7 +150,7 @@ class ClientTest extends TestCase
         $dispatcher = $this->createMock(EventDispatcherInterface::class);
         $dispatcher->expects($invoke = $this->exactly(2))
             ->method('dispatch')
-            ->with($this->callback(function ($o) use ($invoke): bool {
+            ->with($this->callback(function (object $o) use ($invoke): bool {
                 $counter = $invoke->getInvocationCount() - 1;
 
                 if ($counter > 1) {

--- a/tests/Unit/Elastica/ClientTest.php
+++ b/tests/Unit/Elastica/ClientTest.php
@@ -32,7 +32,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
  */
 class ClientTest extends TestCase
 {
-    public function testRequestsAreLogged()
+    public function testRequestsAreLogged(): void
     {
         $logger = $this->createMock(ElasticaLogger::class);
         $logger
@@ -95,7 +95,7 @@ class ClientTest extends TestCase
 
                     $request = $o->getRequest();
 
-                    $path = \ltrim($request->getUri()->getPath(), '/'); // to have the same result as in the 6.0
+                    $path = \ltrim((string) $request->getUri()->getPath(), '/'); // to have the same result as in the 6.0
                     $method = $request->getMethod();
                     try {
                         $data = \json_decode((string) $request->getBody(), true, 512, \JSON_THROW_ON_ERROR);
@@ -103,7 +103,7 @@ class ClientTest extends TestCase
                         $data = [];
                     }
                     $query = [];
-                    \parse_str($request->getUri()->getQuery(), $query);
+                    \parse_str((string) $request->getUri()->getQuery(), $query);
 
                     $this->assertEquals('event', $path);
                     $this->assertEquals(Request::GET, $method);
@@ -174,7 +174,7 @@ class ClientTest extends TestCase
 
                     $request = $o->getRequest();
 
-                    $path = \ltrim($request->getUri()->getPath(), '/'); // to have the same result as in the 6.0
+                    $path = \ltrim((string) $request->getUri()->getPath(), '/'); // to have the same result as in the 6.0
                     $method = $request->getMethod();
                     try {
                         $data = \json_decode((string) $request->getBody(), true, 512, \JSON_THROW_ON_ERROR);
@@ -182,7 +182,7 @@ class ClientTest extends TestCase
                         $data = [];
                     }
                     $query = [];
-                    \parse_str($request->getUri()->getQuery(), $query);
+                    \parse_str((string) $request->getUri()->getQuery(), $query);
 
                     $this->assertEquals('event', $path);
                     $this->assertEquals(Request::GET, $method);
@@ -207,7 +207,7 @@ class ClientTest extends TestCase
         ));
     }
 
-    public function testRequestsWithTransportInfoErrorsRaiseExceptions()
+    public function testRequestsWithTransportInfoErrorsRaiseExceptions(): void
     {
         $httpCode = 403;
         $responseString = JSON::stringify(['message' => 'some AWS error']);
@@ -228,7 +228,7 @@ class ClientTest extends TestCase
         ));
     }
 
-    public function testGetIndexTemplate()
+    public function testGetIndexTemplate(): void
     {
         $client = new Client();
         $template = $client->getIndexTemplate('some_index');

--- a/tests/Unit/Elastica/ClientTest.php
+++ b/tests/Unit/Elastica/ClientTest.php
@@ -95,7 +95,7 @@ class ClientTest extends TestCase
 
                     $request = $o->getRequest();
 
-                    $path = \ltrim((string) $request->getUri()->getPath(), '/'); // to have the same result as in the 6.0
+                    $path = \ltrim($request->getUri()->getPath(), '/'); // to have the same result as in the 6.0
                     $method = $request->getMethod();
                     try {
                         $data = \json_decode((string) $request->getBody(), true, 512, \JSON_THROW_ON_ERROR);
@@ -103,7 +103,7 @@ class ClientTest extends TestCase
                         $data = [];
                     }
                     $query = [];
-                    \parse_str((string) $request->getUri()->getQuery(), $query);
+                    \parse_str($request->getUri()->getQuery(), $query);
 
                     $this->assertEquals('event', $path);
                     $this->assertEquals(Request::GET, $method);
@@ -174,7 +174,7 @@ class ClientTest extends TestCase
 
                     $request = $o->getRequest();
 
-                    $path = \ltrim((string) $request->getUri()->getPath(), '/'); // to have the same result as in the 6.0
+                    $path = \ltrim($request->getUri()->getPath(), '/'); // to have the same result as in the 6.0
                     $method = $request->getMethod();
                     try {
                         $data = \json_decode((string) $request->getBody(), true, 512, \JSON_THROW_ON_ERROR);
@@ -182,7 +182,7 @@ class ClientTest extends TestCase
                         $data = [];
                     }
                     $query = [];
-                    \parse_str((string) $request->getUri()->getQuery(), $query);
+                    \parse_str($request->getUri()->getQuery(), $query);
 
                     $this->assertEquals('event', $path);
                     $this->assertEquals(Request::GET, $method);

--- a/tests/Unit/Elastica/IndexTemplateTest.php
+++ b/tests/Unit/Elastica/IndexTemplateTest.php
@@ -23,7 +23,7 @@ use PHPUnit\Framework\TestCase;
  */
 class IndexTemplateTest extends TestCase
 {
-    public function testInstantiate()
+    public function testInstantiate(): void
     {
         $template = new IndexTemplate($this->createStub(Client::class), 'some_name');
         $this->assertInstanceOf(BaseIndexTemplate::class, $template);

--- a/tests/Unit/Event/PostIndexPopulateEventTest.php
+++ b/tests/Unit/Event/PostIndexPopulateEventTest.php
@@ -19,7 +19,7 @@ use PHPUnit\Framework\TestCase;
  */
 class PostIndexPopulateEventTest extends TestCase
 {
-    public function testPopulate()
+    public function testPopulate(): void
     {
         $event = new PostIndexPopulateEvent('index', false, []);
 
@@ -28,14 +28,14 @@ class PostIndexPopulateEventTest extends TestCase
         $this->assertSame([], $event->getOptions());
     }
 
-    public function testPopulateReset()
+    public function testPopulateReset(): void
     {
         $event = new PostIndexPopulateEvent('index', true, []);
 
         $this->assertTrue($event->isReset());
     }
 
-    public function testPopulateOptions()
+    public function testPopulateOptions(): void
     {
         $event = new PostIndexPopulateEvent('index', false, [
             'option' => 'value',
@@ -45,7 +45,7 @@ class PostIndexPopulateEventTest extends TestCase
         $this->assertSame('value', $event->getOption('option'));
     }
 
-    public function testPopulateInvalidOption()
+    public function testPopulateInvalidOption(): void
     {
         $event = new PostIndexPopulateEvent('index', false, []);
 

--- a/tests/Unit/Event/PostIndexResetEventTest.php
+++ b/tests/Unit/Event/PostIndexResetEventTest.php
@@ -19,7 +19,7 @@ use PHPUnit\Framework\TestCase;
  */
 class PostIndexResetEventTest extends TestCase
 {
-    public function testReset()
+    public function testReset(): void
     {
         $event = new PostIndexResetEvent('index', false, false);
 
@@ -28,14 +28,14 @@ class PostIndexResetEventTest extends TestCase
         $this->assertFalse($event->isForce());
     }
 
-    public function testPopulatingReset()
+    public function testPopulatingReset(): void
     {
         $event = new PostIndexResetEvent('index', true, false);
 
         $this->assertTrue($event->isPopulating());
     }
 
-    public function testForceReset()
+    public function testForceReset(): void
     {
         $event = new PostIndexResetEvent('index', false, true);
 

--- a/tests/Unit/Event/PostTransformEventTest.php
+++ b/tests/Unit/Event/PostTransformEventTest.php
@@ -20,19 +20,19 @@ use PHPUnit\Framework\TestCase;
  */
 class PostTransformEventTest extends TestCase
 {
-    public function testDocument()
+    public function testDocument(): void
     {
         $event = new PostTransformEvent($document = new Document(), [], new \stdClass());
         $this->assertSame($document, $event->getDocument());
     }
 
-    public function testFields()
+    public function testFields(): void
     {
         $event = new PostTransformEvent(new Document(), $fields = ['abc', '123'], new \stdClass());
         $this->assertSame($fields, $event->getFields());
     }
 
-    public function testObject()
+    public function testObject(): void
     {
         $event = new PostTransformEvent(new Document(), [], $object = new \stdClass());
         $this->assertSame($object, $event->getObject());

--- a/tests/Unit/Event/PreIndexPopulateEventTest.php
+++ b/tests/Unit/Event/PreIndexPopulateEventTest.php
@@ -19,7 +19,7 @@ use PHPUnit\Framework\TestCase;
  */
 class PreIndexPopulateEventTest extends TestCase
 {
-    public function testPopulate()
+    public function testPopulate(): void
     {
         $event = new PreIndexPopulateEvent('index', false, []);
 
@@ -28,7 +28,7 @@ class PreIndexPopulateEventTest extends TestCase
         $this->assertSame([], $event->getOptions());
     }
 
-    public function testPopulateReset()
+    public function testPopulateReset(): void
     {
         $event = new PreIndexPopulateEvent('index', false, []);
         $this->assertFalse($event->isReset());
@@ -37,7 +37,7 @@ class PreIndexPopulateEventTest extends TestCase
         $this->assertTrue($event->isReset());
     }
 
-    public function testPopulateOptions()
+    public function testPopulateOptions(): void
     {
         $event = new PreIndexPopulateEvent('index', false, [
             'option_1' => 'value_1',
@@ -51,7 +51,7 @@ class PreIndexPopulateEventTest extends TestCase
         $this->assertSame('value_2', $event->getOption('option_2'));
     }
 
-    public function testPopulateInvalidOption()
+    public function testPopulateInvalidOption(): void
     {
         $event = new PreIndexPopulateEvent('index', false, []);
 

--- a/tests/Unit/Event/PreIndexResetEventTest.php
+++ b/tests/Unit/Event/PreIndexResetEventTest.php
@@ -19,7 +19,7 @@ use PHPUnit\Framework\TestCase;
  */
 class PreIndexResetEventTest extends TestCase
 {
-    public function testReset()
+    public function testReset(): void
     {
         $event = new PreIndexResetEvent('index', false, false);
 
@@ -28,14 +28,14 @@ class PreIndexResetEventTest extends TestCase
         $this->assertFalse($event->isForce());
     }
 
-    public function testPopulatingReset()
+    public function testPopulatingReset(): void
     {
         $event = new PreIndexResetEvent('index', true, false);
 
         $this->assertTrue($event->isPopulating());
     }
 
-    public function testForceReset()
+    public function testForceReset(): void
     {
         $event = new PreIndexResetEvent('index', false, true);
         $this->assertTrue($event->isForce());

--- a/tests/Unit/Event/PreTransformEventTest.php
+++ b/tests/Unit/Event/PreTransformEventTest.php
@@ -20,7 +20,7 @@ use PHPUnit\Framework\TestCase;
  */
 class PreTransformEventTest extends TestCase
 {
-    public function testDocument()
+    public function testDocument(): void
     {
         $event = new PreTransformEvent($document = new Document(), [], new \stdClass());
         $this->assertSame($document, $event->getDocument());
@@ -29,13 +29,13 @@ class PreTransformEventTest extends TestCase
         $this->assertSame($newDocument, $event->getDocument());
     }
 
-    public function testFields()
+    public function testFields(): void
     {
         $event = new PreTransformEvent(new Document(), $fields = ['abc', '123'], new \stdClass());
         $this->assertSame($fields, $event->getFields());
     }
 
-    public function testObject()
+    public function testObject(): void
     {
         $event = new PreTransformEvent(new Document(), [], $object = new \stdClass());
         $this->assertSame($object, $event->getObject());

--- a/tests/Unit/EventListener/PopulateListenerTest.php
+++ b/tests/Unit/EventListener/PopulateListenerTest.php
@@ -45,7 +45,7 @@ class PopulateListenerTest extends TestCase
         $listener->onPostIndexPopulate($event);
     }
 
-    private function mockResetter(int $numberOfCalls, string $indexName, bool $deleteOption)
+    private function mockResetter(int $numberOfCalls, string $indexName, bool $deleteOption): \PHPUnit\Framework\MockObject\MockObject
     {
         $stub = $this
             ->getMockBuilder(Resetter::class)

--- a/tests/Unit/EventListener/PopulateListenerTest.php
+++ b/tests/Unit/EventListener/PopulateListenerTest.php
@@ -21,7 +21,7 @@ use PHPUnit\Framework\TestCase;
  */
 class PopulateListenerTest extends TestCase
 {
-    public function testOnPostIndexPopulateWithReset()
+    public function testOnPostIndexPopulateWithReset(): void
     {
         $indexName = 'index';
         $deleteOption = true;
@@ -33,7 +33,7 @@ class PopulateListenerTest extends TestCase
         $listener->onPostIndexPopulate($event);
     }
 
-    public function testOnPostIndexPopulateWithoutReset()
+    public function testOnPostIndexPopulateWithoutReset(): void
     {
         $indexName = 'index';
         $deleteOption = true;
@@ -45,7 +45,7 @@ class PopulateListenerTest extends TestCase
         $listener->onPostIndexPopulate($event);
     }
 
-    private function mockResetter($numberOfCalls, $indexName, $deleteOption)
+    private function mockResetter(int $numberOfCalls, string $indexName, bool $deleteOption)
     {
         $stub = $this
             ->getMockBuilder(Resetter::class)

--- a/tests/Unit/Exception/AliasIsIndexExceptionTest.php
+++ b/tests/Unit/Exception/AliasIsIndexExceptionTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the FOSElasticaBundle package.
  *
@@ -19,8 +21,8 @@ use PHPUnit\Framework\TestCase;
  */
 class AliasIsIndexExceptionTest extends TestCase
 {
-    public function testConstruct()
+    public function testConstruct(): void
     {
-        $exception = new AliasIsIndexException('indexName');
+        new AliasIsIndexException('indexName');
     }
 }

--- a/tests/Unit/FOSElasticaBundleTest.php
+++ b/tests/Unit/FOSElasticaBundleTest.php
@@ -20,7 +20,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  */
 class FOSElasticaBundleTest extends TestCase
 {
-    public function testCompilerPassesAreRegistered()
+    public function testCompilerPassesAreRegistered(): void
     {
         $container = $this->createMock(ContainerBuilder::class);
 

--- a/tests/Unit/Finder/TransformedFinderTest.php
+++ b/tests/Unit/Finder/TransformedFinderTest.php
@@ -126,7 +126,7 @@ class TransformedFinderTest extends TestCase
         $this->assertInstanceOf(HybridPaginatorAdapter::class, $finder->createHybridPaginatorAdapter(''));
     }
 
-    private function createMockTransformer(string $transformMethod)
+    private function createMockTransformer(string $transformMethod): \PHPUnit\Framework\MockObject\MockObject
     {
         $transformer = $this->createMock(ElasticaToModelTransformerInterface::class);
 
@@ -139,7 +139,7 @@ class TransformedFinderTest extends TestCase
         return $transformer;
     }
 
-    private function createMockFinderForSearch($transformer, $query, int $limit)
+    private function createMockFinderForSearch(\PHPUnit\Framework\MockObject\MockObject $transformer, Query $query, int $limit): \PHPUnit\Framework\MockObject\MockObject
     {
         $searchable = $this->createMock(SearchableInterface::class);
 
@@ -159,7 +159,7 @@ class TransformedFinderTest extends TestCase
         return $finder;
     }
 
-    private function createMockResultSet()
+    private function createMockResultSet(): \PHPUnit\Framework\MockObject\MockObject
     {
         $resultSet = $this->createPartialMock(ResultSet::class, ['getResults']);
 

--- a/tests/Unit/Finder/TransformedFinderTest.php
+++ b/tests/Unit/Finder/TransformedFinderTest.php
@@ -26,7 +26,7 @@ use PHPUnit\Framework\TestCase;
  */
 class TransformedFinderTest extends TestCase
 {
-    public function testFindMethodTransformsSearchResults()
+    public function testFindMethodTransformsSearchResults(): void
     {
         $transformer = $this->createMockTransformer('transform');
         $query = Query::create('');
@@ -37,7 +37,7 @@ class TransformedFinderTest extends TestCase
         $finder->find($query, $limit);
     }
 
-    public function testFindHybridMethodTransformsSearchResults()
+    public function testFindHybridMethodTransformsSearchResults(): void
     {
         $transformer = $this->createMockTransformer('hybridTransform');
         $query = Query::create('');
@@ -48,7 +48,7 @@ class TransformedFinderTest extends TestCase
         $finder->findHybrid($query, $limit);
     }
 
-    public function testFindRawMethodTransformsSearchResults()
+    public function testFindRawMethodTransformsSearchResults(): void
     {
         $transformer = $this->createMock(ElasticaToModelTransformerInterface::class);
         $transformer->expects($this->never())
@@ -62,7 +62,7 @@ class TransformedFinderTest extends TestCase
         $finder->findRaw($query, $limit);
     }
 
-    public function testSearchMethodCreatesAQueryAndReturnsResultsFromSearchableDependency()
+    public function testSearchMethodCreatesAQueryAndReturnsResultsFromSearchableDependency(): void
     {
         $searchable = $this->createMock(SearchableInterface::class);
         $transformer = $this->createMock(ElasticaToModelTransformerInterface::class);
@@ -76,14 +76,13 @@ class TransformedFinderTest extends TestCase
         $finder = new TransformedFinder($searchable, $transformer);
 
         $method = new \ReflectionMethod($finder, 'search');
-        $method->setAccessible(true);
 
         $results = $method->invoke($finder, '', 10);
 
         $this->assertIsArray($results);
     }
 
-    public function testFindHybridPaginatedReturnsAConfiguredPagerfantaObject()
+    public function testFindHybridPaginatedReturnsAConfiguredPagerfantaObject(): void
     {
         $searchable = $this->createMock(SearchableInterface::class);
         $transformer = $this->createMock(ElasticaToModelTransformerInterface::class);
@@ -95,7 +94,7 @@ class TransformedFinderTest extends TestCase
         $this->assertInstanceOf(Pagerfanta::class, $pagerfanta);
     }
 
-    public function testFindPaginatedReturnsAConfiguredPagerfantaObject()
+    public function testFindPaginatedReturnsAConfiguredPagerfantaObject(): void
     {
         $searchable = $this->createMock(SearchableInterface::class);
         $transformer = $this->createMock(ElasticaToModelTransformerInterface::class);
@@ -107,7 +106,7 @@ class TransformedFinderTest extends TestCase
         $this->assertInstanceOf(Pagerfanta::class, $pagerfanta);
     }
 
-    public function testCreatePaginatorAdapter()
+    public function testCreatePaginatorAdapter(): void
     {
         $searchable = $this->createMock(SearchableInterface::class);
         $transformer = $this->createMock(ElasticaToModelTransformerInterface::class);
@@ -117,7 +116,7 @@ class TransformedFinderTest extends TestCase
         $this->assertInstanceOf(TransformedPaginatorAdapter::class, $finder->createPaginatorAdapter(''));
     }
 
-    public function testCreateHybridPaginatorAdapter()
+    public function testCreateHybridPaginatorAdapter(): void
     {
         $searchable = $this->createMock(SearchableInterface::class);
         $transformer = $this->createMock(ElasticaToModelTransformerInterface::class);
@@ -127,7 +126,7 @@ class TransformedFinderTest extends TestCase
         $this->assertInstanceOf(HybridPaginatorAdapter::class, $finder->createHybridPaginatorAdapter(''));
     }
 
-    private function createMockTransformer($transformMethod)
+    private function createMockTransformer(string $transformMethod)
     {
         $transformer = $this->createMock(ElasticaToModelTransformerInterface::class);
 
@@ -140,7 +139,7 @@ class TransformedFinderTest extends TestCase
         return $transformer;
     }
 
-    private function createMockFinderForSearch($transformer, $query, $limit)
+    private function createMockFinderForSearch($transformer, $query, int $limit)
     {
         $searchable = $this->createMock(SearchableInterface::class);
 

--- a/tests/Unit/HybridResultTest.php
+++ b/tests/Unit/HybridResultTest.php
@@ -20,7 +20,7 @@ use PHPUnit\Framework\TestCase;
  */
 class HybridResultTest extends TestCase
 {
-    public function testTransformedResultDefaultsToNull()
+    public function testTransformedResultDefaultsToNull(): void
     {
         $result = new Result([]);
 

--- a/tests/Unit/Index/AliasProcessorTest.php
+++ b/tests/Unit/Index/AliasProcessorTest.php
@@ -27,10 +27,7 @@ use PHPUnit\Framework\TestCase;
  */
 class AliasProcessorTest extends TestCase
 {
-    /**
-     * @var AliasProcessor
-     */
-    private $processor;
+    private AliasProcessor $processor;
 
     protected function setUp(): void
     {
@@ -39,11 +36,8 @@ class AliasProcessorTest extends TestCase
 
     /**
      * @dataProvider getSetRootNameData
-     *
-     * @param array  $configArray
-     * @param string $resultStartsWith
      */
-    public function testSetRootName($configArray, $resultStartsWith)
+    public function testSetRootName(array $configArray, string $resultStartsWith): void
     {
         $indexConfig = new IndexConfig($configArray);
         $index = $this->createMock(Index::class);
@@ -55,7 +49,7 @@ class AliasProcessorTest extends TestCase
         $this->processor->setRootName($indexConfig, $index);
     }
 
-    public function testSwitchAliasNoAliasSet()
+    public function testSwitchAliasNoAliasSet(): void
     {
         $indexConfig = new IndexConfig(['name' => 'name', 'config' => [], 'mapping' => [], 'model' => null]);
         $index = $this->getIndexMock('unique_name');
@@ -91,7 +85,7 @@ class AliasProcessorTest extends TestCase
         $this->processor->switchIndexAlias($indexConfig, $index, false);
     }
 
-    public function testSwitchAliasExistingAliasSet()
+    public function testSwitchAliasExistingAliasSet(): void
     {
         $indexConfig = new IndexConfig(['name' => 'name', 'config' => [], 'mapping' => [], 'model' => null]);
         $index = $this->getIndexMock('unique_name');
@@ -129,7 +123,7 @@ class AliasProcessorTest extends TestCase
         $this->processor->switchIndexAlias($indexConfig, $index, false);
     }
 
-    public function testSwitchAliasThrowsWhenMoreThanOneExists()
+    public function testSwitchAliasThrowsWhenMoreThanOneExists(): void
     {
         $indexConfig = new IndexConfig(['name' => 'name', 'config' => [], 'mapping' => [], 'model' => null]);
         $index = $this->getIndexMock('unique_name');
@@ -164,7 +158,7 @@ class AliasProcessorTest extends TestCase
         $this->processor->switchIndexAlias($indexConfig, $index, false);
     }
 
-    public function testSwitchAliasThrowsWhenAliasIsAnIndex()
+    public function testSwitchAliasThrowsWhenAliasIsAnIndex(): void
     {
         $indexConfig = new IndexConfig(['name' => 'name', 'config' => [], 'mapping' => [], 'model' => null]);
         $index = $this->getIndexMock('unique_name');
@@ -198,7 +192,7 @@ class AliasProcessorTest extends TestCase
         $this->processor->switchIndexAlias($indexConfig, $index, false);
     }
 
-    public function testSwitchAliasDeletesIndexCollisionIfForced()
+    public function testSwitchAliasDeletesIndexCollisionIfForced(): void
     {
         $indexConfig = new IndexConfig(['name' => 'name', 'config' => [], 'mapping' => [], 'model' => null]);
         $index = $this->getIndexMock('unique_name');
@@ -237,7 +231,7 @@ class AliasProcessorTest extends TestCase
         $this->processor->switchIndexAlias($indexConfig, $index, true);
     }
 
-    public function testSwitchAliasCloseOldIndex()
+    public function testSwitchAliasCloseOldIndex(): void
     {
         $indexConfig = new IndexConfig(['name' => 'name', 'config' => [], 'mapping' => [], 'model' => null]);
         $index = $this->getIndexMock('unique_name');
@@ -275,7 +269,7 @@ class AliasProcessorTest extends TestCase
         $this->processor->switchIndexAlias($indexConfig, $index, true, false);
     }
 
-    public function testSwitchAliasCleansUpOnRenameFailure()
+    public function testSwitchAliasCleansUpOnRenameFailure(): void
     {
         $indexConfig = new IndexConfig(['name' => 'name', 'config' => [], 'mapping' => [], 'model' => null]);
         $index = $this->getIndexMock('unique_name');
@@ -316,7 +310,7 @@ class AliasProcessorTest extends TestCase
         $this->processor->switchIndexAlias($indexConfig, $index, true);
     }
 
-    public function getSetRootNameData()
+    public function getSetRootNameData(): array
     {
         return [
             [['name' => 'name', 'config' => [], 'mapping' => [], 'model' => null], 'name_'],

--- a/tests/Unit/Index/IndexManagerTest.php
+++ b/tests/Unit/Index/IndexManagerTest.php
@@ -20,12 +20,9 @@ use PHPUnit\Framework\TestCase;
  */
 class IndexManagerTest extends TestCase
 {
-    private $indexes = [];
+    private array $indexes = [];
 
-    /**
-     * @var IndexManager
-     */
-    private $indexManager;
+    private IndexManager $indexManager;
 
     protected function setUp(): void
     {
@@ -43,25 +40,25 @@ class IndexManagerTest extends TestCase
         $this->indexManager = new IndexManager($this->indexes, $this->indexes['index2']);
     }
 
-    public function testGetAllIndexes()
+    public function testGetAllIndexes(): void
     {
         $this->assertSame($this->indexes, $this->indexManager->getAllIndexes());
     }
 
-    public function testGetIndex()
+    public function testGetIndex(): void
     {
         $this->assertSame($this->indexes['index1'], $this->indexManager->getIndex('index1'));
         $this->assertSame($this->indexes['index2'], $this->indexManager->getIndex('index2'));
         $this->assertSame($this->indexes['index3'], $this->indexManager->getIndex('index3'));
     }
 
-    public function testGetIndexShouldThrowExceptionForInvalidName()
+    public function testGetIndexShouldThrowExceptionForInvalidName(): void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->indexManager->getIndex('index4');
     }
 
-    public function testGetDefaultIndex()
+    public function testGetDefaultIndex(): void
     {
         $this->assertSame('index2', $this->indexManager->getIndex()->getName());
         $this->assertSame('index2', $this->indexManager->getDefaultIndex()->getName());

--- a/tests/Unit/Index/IndexTemplateManagerTest.php
+++ b/tests/Unit/Index/IndexTemplateManagerTest.php
@@ -25,14 +25,9 @@ class IndexTemplateManagerTest extends TestCase
     /**
      * Test get index template.
      *
-     * @param string      $name
-     * @param string|null $expectedException
-     *
-     * @return void
-     *
      * @dataProvider provideTestGetIndexTemplate
      */
-    public function testGetIndexTemplate(array $templates, $name, $expectedTemplate, $expectedException = null)
+    public function testGetIndexTemplate(array $templates, string $name, $expectedTemplate, ?string $expectedException = null): void
     {
         if (null !== $expectedException) {
             $this->expectException($expectedException);
@@ -41,7 +36,7 @@ class IndexTemplateManagerTest extends TestCase
         $this->assertSame($expectedTemplate, $templateManager->getIndexTemplate($name));
     }
 
-    public function provideTestGetIndexTemplate()
+    public function provideTestGetIndexTemplate(): array
     {
         return [
             'empty templates' => [

--- a/tests/Unit/Index/MappingBuilderTest.php
+++ b/tests/Unit/Index/MappingBuilderTest.php
@@ -22,40 +22,12 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
  */
 class MappingBuilderTest extends TestCase
 {
-    /**
-     * @var MappingBuilder
-     */
-    private $builder;
+    private MappingBuilder $builder;
 
-    /**
-     * @var array
-     */
-    private $mapping;
-
-    /**
-     * @var IndexConfig
-     */
-    private $indexConfig;
+    private IndexConfig $indexConfig;
 
     protected function setUp(): void
     {
-        $this->mapping = [
-            'mapping' => [
-                'properties' => [
-                    'storeless' => [
-                        'type' => 'text',
-                    ],
-                    'stored' => [
-                        'type' => 'text',
-                        'store' => true,
-                    ],
-                    'unstored' => [
-                        'type' => 'text',
-                        'store' => false,
-                    ],
-                ],
-            ],
-        ];
         $this->indexConfig = new IndexConfig(
             [
                 'name' => 'name',
@@ -83,7 +55,7 @@ class MappingBuilderTest extends TestCase
         $this->builder = new MappingBuilder($dispatcher);
     }
 
-    public function testMappingBuilderStoreProperty()
+    public function testMappingBuilderStoreProperty(): void
     {
         $mapping = $this->builder->buildMapping(null, $this->indexConfig);
 
@@ -94,7 +66,7 @@ class MappingBuilderTest extends TestCase
         $this->assertFalse($mapping['properties']['unstored']['store']);
     }
 
-    public function testBuildIndexTemplateMapping()
+    public function testBuildIndexTemplateMapping(): void
     {
         $config = new IndexTemplateConfig(
             ['index_patterns' => ['index_template_*'], 'name' => 'some_template', 'config' => [], 'mapping' => $this->indexConfig->getMapping()]

--- a/tests/Unit/Index/ResetterTest.php
+++ b/tests/Unit/Index/ResetterTest.php
@@ -30,16 +30,13 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
  */
 class ResetterTest extends TestCase
 {
-    /**
-     * @var Resetter
-     */
-    private $resetter;
+    private Resetter $resetter;
 
-    private $aliasProcessor;
-    private $configManager;
-    private $dispatcher;
-    private $indexManager;
-    private $mappingBuilder;
+    private MockObject $aliasProcessor;
+    private MockObject $configManager;
+    private MockObject $dispatcher;
+    private MockObject $indexManager;
+    private MockObject $mappingBuilder;
 
     protected function setUp(): void
     {
@@ -58,7 +55,7 @@ class ResetterTest extends TestCase
         );
     }
 
-    public function testResetAllIndexes()
+    public function testResetAllIndexes(): void
     {
         $indexName = 'index1';
         $indexConfig = new IndexConfig([
@@ -88,7 +85,7 @@ class ResetterTest extends TestCase
         $this->resetter->resetAllIndexes();
     }
 
-    public function testResetIndex()
+    public function testResetIndex(): void
     {
         $indexConfig = new IndexConfig([
             'name' => 'index1',
@@ -112,7 +109,7 @@ class ResetterTest extends TestCase
         $this->resetter->resetIndex('index1');
     }
 
-    public function testResetIndexWithDifferentNameAndAlias()
+    public function testResetIndexWithDifferentNameAndAlias(): void
     {
         $indexConfig = new IndexConfig([
             'name' => 'index1',
@@ -142,7 +139,7 @@ class ResetterTest extends TestCase
         $this->resetter->resetIndex('index1');
     }
 
-    public function testFailureWhenMissingIndexDoesntDispatch()
+    public function testFailureWhenMissingIndexDoesntDispatch(): void
     {
         $this->configManager->expects($this->once())
             ->method('getIndexConfiguration')
@@ -158,7 +155,7 @@ class ResetterTest extends TestCase
         $this->resetter->resetIndex('nonExistant');
     }
 
-    public function testPostPopulateWithoutAlias()
+    public function testPostPopulateWithoutAlias(): void
     {
         $this->mockIndex('index', new IndexConfig([
             'name' => 'index',
@@ -177,7 +174,7 @@ class ResetterTest extends TestCase
         $this->resetter->switchIndexAlias('index');
     }
 
-    public function testPostPopulate()
+    public function testPostPopulate(): void
     {
         $indexConfig = new IndexConfig([
             'name' => 'index1',
@@ -196,12 +193,12 @@ class ResetterTest extends TestCase
         $this->resetter->switchIndexAlias('index');
     }
 
-    public function testResetterImplementsResetterInterface()
+    public function testResetterImplementsResetterInterface(): void
     {
         $this->assertInstanceOf(ResetterInterface::class, $this->resetter);
     }
 
-    private function dispatcherExpects(array $events)
+    private function dispatcherExpects(array $events): void
     {
         $expectation = $this->dispatcher->expects($this->exactly(\count($events)))
             ->method('dispatch')

--- a/tests/Unit/Index/ResetterTest.php
+++ b/tests/Unit/Index/ResetterTest.php
@@ -204,7 +204,7 @@ class ResetterTest extends TestCase
             ->method('dispatch')
         ;
 
-        \call_user_func_array([$expectation, 'withConsecutive'], $events);
+        \call_user_func_array($expectation->withConsecutive(...), $events);
     }
 
     private function mockIndex(string $indexName, IndexConfig $config, array $mapping = []): Index&MockObject

--- a/tests/Unit/Index/TemplateResetterTest.php
+++ b/tests/Unit/Index/TemplateResetterTest.php
@@ -33,22 +33,19 @@ class TemplateResetterTest extends TestCase
     /**
      * @var ManagerInterface&MockObject
      */
-    private $configManager;
+    private MockObject $configManager;
 
     /**
      * @var MappingBuilder&MockObject
      */
-    private $mappingBuilder;
+    private MockObject $mappingBuilder;
 
     /**
      * @var IndexTemplateManager&MockObject
      */
-    private $templateManager;
+    private MockObject $templateManager;
 
-    /**
-     * @var TemplateResetter
-     */
-    private $resetter;
+    private TemplateResetter $resetter;
 
     protected function setUp(): void
     {
@@ -62,12 +59,12 @@ class TemplateResetterTest extends TestCase
         );
     }
 
-    public function testResetterImplementsResetterInterface()
+    public function testResetterImplementsResetterInterface(): void
     {
         $this->assertInstanceOf(ResetterInterface::class, $this->resetter);
     }
 
-    public function testResetAllIndexes()
+    public function testResetAllIndexes(): void
     {
         // assemble
         $names = ['first_template'];
@@ -108,7 +105,7 @@ class TemplateResetterTest extends TestCase
         $this->resetter->resetAllIndexes();
     }
 
-    public function testResetAllIndexesAndDelete()
+    public function testResetAllIndexesAndDelete(): void
     {
         // assemble
         $templateName = 'index_template';
@@ -176,7 +173,7 @@ class TemplateResetterTest extends TestCase
         $this->resetter->resetAllIndexes(true);
     }
 
-    public function testResetIndex()
+    public function testResetIndex(): void
     {
         // assemble
         $name = 'first_template';
@@ -213,7 +210,7 @@ class TemplateResetterTest extends TestCase
         $this->resetter->resetIndex($name);
     }
 
-    public function testResetIndexIndexeAndDelete()
+    public function testResetIndexIndexeAndDelete(): void
     {
         // assemble
         $templateName = 'index_template';
@@ -276,7 +273,7 @@ class TemplateResetterTest extends TestCase
         $this->resetter->resetIndex($templateName, true);
     }
 
-    public function testDeleteTemplateIndexes()
+    public function testDeleteTemplateIndexes(): void
     {
         // assemble
         $templateName = 'some_template';

--- a/tests/Unit/Logger/ElasticaLoggerTest.php
+++ b/tests/Unit/Logger/ElasticaLoggerTest.php
@@ -22,17 +22,17 @@ use Psr\Log\LoggerInterface;
  */
 class ElasticaLoggerTest extends TestCase
 {
-    public function testGetZeroIfNoQueriesAdded()
+    public function testGetZeroIfNoQueriesAdded(): void
     {
         $elasticaLogger = new ElasticaLogger();
         $this->assertSame(0, $elasticaLogger->getNbQueries());
     }
 
-    public function testCorrectAmountIfRandomNumberOfQueriesAdded()
+    public function testCorrectAmountIfRandomNumberOfQueriesAdded(): void
     {
         $elasticaLogger = new ElasticaLogger(null, true);
 
-        $total = \rand(1, 15);
+        $total = \random_int(1, 15);
         for ($i = 0; $i < $total; ++$i) {
             $elasticaLogger->logQuery('testPath', 'testMethod', ['data'], 12);
         }
@@ -40,7 +40,7 @@ class ElasticaLoggerTest extends TestCase
         $this->assertSame($total, $elasticaLogger->getNbQueries());
     }
 
-    public function testCorrectlyFormattedQueryReturned()
+    public function testCorrectlyFormattedQueryReturned(): void
     {
         $elasticaLogger = new ElasticaLogger(null, true);
 
@@ -70,11 +70,11 @@ class ElasticaLoggerTest extends TestCase
         $this->assertSame($expected, $returnedQueries[0]);
     }
 
-    public function testNoQueriesStoredIfDebugFalseAdded()
+    public function testNoQueriesStoredIfDebugFalseAdded(): void
     {
         $elasticaLogger = new ElasticaLogger(null, false);
 
-        $total = \rand(1, 15);
+        $total = \random_int(1, 15);
         for ($i = 0; $i < $total; ++$i) {
             $elasticaLogger->logQuery('testPath', 'testMethod', ['data'], 12);
         }
@@ -82,7 +82,7 @@ class ElasticaLoggerTest extends TestCase
         $this->assertSame(0, $elasticaLogger->getNbQueries());
     }
 
-    public function testQueryIsLogged()
+    public function testQueryIsLogged(): void
     {
         $loggerMock = $this->getMockLogger();
 
@@ -106,10 +106,7 @@ class ElasticaLoggerTest extends TestCase
         $elasticaLogger->logQuery($path, $method, $data, $time);
     }
 
-    /**
-     * @return array
-     */
-    public function logLevels()
+    public function logLevels(): array
     {
         return [
             ['emergency'],
@@ -126,7 +123,7 @@ class ElasticaLoggerTest extends TestCase
     /**
      * @dataProvider logLevels
      */
-    public function testMessagesCanBeLoggedAtSpecificLogLevels($level)
+    public function testMessagesCanBeLoggedAtSpecificLogLevels(string $level): void
     {
         $message = 'foo';
         $context = ['data'];
@@ -136,7 +133,7 @@ class ElasticaLoggerTest extends TestCase
         \call_user_func([$loggerMock, $level], $message, $context);
     }
 
-    public function testMessagesCanBeLoggedToArbitraryLevels()
+    public function testMessagesCanBeLoggedToArbitraryLevels(): void
     {
         $loggerMock = $this->getMockLogger();
 
@@ -158,7 +155,7 @@ class ElasticaLoggerTest extends TestCase
         $elasticaLogger->log($level, $message, $context);
     }
 
-    public function testQueryCanBeMultilineStrings()
+    public function testQueryCanBeMultilineStrings(): void
     {
         $elasticaLogger = new ElasticaLogger(null, true);
 
@@ -168,7 +165,7 @@ class ElasticaLoggerTest extends TestCase
         $this->assertEquals(['foo' => 'bar'], $elasticaLogger->getQueries()[0]['data'][0]);
     }
 
-    public function testQueryCanBeAnArray()
+    public function testQueryCanBeAnArray(): void
     {
         $elasticaLogger = new ElasticaLogger(null, true);
 
@@ -181,19 +178,12 @@ class ElasticaLoggerTest extends TestCase
     /**
      * @return \PHPUnit\Framework\MockObject\MockObject|LoggerInterface
      */
-    private function getMockLogger()
+    private function getMockLogger(): \PHPUnit\Framework\MockObject\MockObject
     {
         return $this->createMock(LoggerInterface::class);
     }
 
-    /**
-     * @param string $level
-     * @param string $message
-     * @param array  $context
-     *
-     * @return ElasticaLogger
-     */
-    private function getMockLoggerForLevelMessageAndContext($level, $message, $context)
+    private function getMockLoggerForLevelMessageAndContext(string $level, string $message, array $context): ElasticaLogger
     {
         $loggerMock = $this->createMock(LoggerInterface::class);
 

--- a/tests/Unit/Manager/RepositoryManagerTest.php
+++ b/tests/Unit/Manager/RepositoryManagerTest.php
@@ -32,7 +32,7 @@ class Entity
  */
 class RepositoryManagerTest extends TestCase
 {
-    public function testThatGetRepositoryReturnsDefaultRepository()
+    public function testThatGetRepositoryReturnsDefaultRepository(): void
     {
         $finderMock = $this->createMock(TransformedFinder::class);
 
@@ -44,7 +44,7 @@ class RepositoryManagerTest extends TestCase
         $this->assertInstanceOf(Repository::class, $repository);
     }
 
-    public function testThatGetRepositoryReturnsCustomRepositoryFromLocator()
+    public function testThatGetRepositoryReturnsCustomRepositoryFromLocator(): void
     {
         $finderMock = $this->createMock(TransformedFinder::class);
         $customRepository = new CustomRepository($finderMock);
@@ -81,7 +81,7 @@ class RepositoryManagerTest extends TestCase
         $this->assertSame($first, $second);
     }
 
-    public function testThatGetRepositoryThrowsExceptionIfEntityNotConfigured()
+    public function testThatGetRepositoryThrowsExceptionIfEntityNotConfigured(): void
     {
         $finderMock = $this->createMock(TransformedFinder::class);
 
@@ -94,7 +94,7 @@ class RepositoryManagerTest extends TestCase
         $manager->getRepository('Missing type');
     }
 
-    public function testThatLocatorIsPreferredOverDefaultRepository()
+    public function testThatLocatorIsPreferredOverDefaultRepository(): void
     {
         $finderMock = $this->createMock(TransformedFinder::class);
         $customRepository = new CustomRepository($finderMock);

--- a/tests/Unit/Mocks/DoctrineMongoDBCustomRepositoryMock.php
+++ b/tests/Unit/Mocks/DoctrineMongoDBCustomRepositoryMock.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the FOSElasticaBundle package.
  *

--- a/tests/Unit/Mocks/DoctrineMongoDBCustomRepositoryMock.php
+++ b/tests/Unit/Mocks/DoctrineMongoDBCustomRepositoryMock.php
@@ -13,11 +13,13 @@ declare(strict_types=1);
 
 namespace FOS\ElasticaBundle\Tests\Unit\Mocks;
 
+use Doctrine\ODM\MongoDB\Query\Builder;
 use Doctrine\ODM\MongoDB\Repository\DocumentRepository;
 
 class DoctrineMongoDBCustomRepositoryMock extends DocumentRepository
 {
-    public function createCustomQueryBuilder()
+    public function createCustomQueryBuilder(): ?Builder
     {
+        return null;
     }
 }

--- a/tests/Unit/Mocks/DoctrineORMCustomRepositoryMock.php
+++ b/tests/Unit/Mocks/DoctrineORMCustomRepositoryMock.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the FOSElasticaBundle package.
  *

--- a/tests/Unit/Mocks/DoctrineORMCustomRepositoryMock.php
+++ b/tests/Unit/Mocks/DoctrineORMCustomRepositoryMock.php
@@ -14,10 +14,12 @@ declare(strict_types=1);
 namespace FOS\ElasticaBundle\Tests\Unit\Mocks;
 
 use Doctrine\ORM\EntityRepository;
+use Doctrine\ORM\QueryBuilder;
 
 class DoctrineORMCustomRepositoryMock extends EntityRepository
 {
-    public function createCustomQueryBuilder()
+    public function createCustomQueryBuilder(): ?QueryBuilder
     {
+        return null;
     }
 }

--- a/tests/Unit/Mocks/DoctrinePHPCRCustomRepositoryMock.php
+++ b/tests/Unit/Mocks/DoctrinePHPCRCustomRepositoryMock.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the FOSElasticaBundle package.
  *

--- a/tests/Unit/Mocks/DoctrinePHPCRCustomRepositoryMock.php
+++ b/tests/Unit/Mocks/DoctrinePHPCRCustomRepositoryMock.php
@@ -14,10 +14,12 @@ declare(strict_types=1);
 namespace FOS\ElasticaBundle\Tests\Unit\Mocks;
 
 use Doctrine\ODM\PHPCR\DocumentRepository;
+use Doctrine\ODM\PHPCR\Query\Builder\QueryBuilder;
 
 class DoctrinePHPCRCustomRepositoryMock extends DocumentRepository
 {
-    public function createCustomQueryBuilder()
+    public function createCustomQueryBuilder(): ?QueryBuilder
     {
+        return null;
     }
 }

--- a/tests/Unit/Mocks/ObjectPersisterPOPO.php
+++ b/tests/Unit/Mocks/ObjectPersisterPOPO.php
@@ -17,7 +17,7 @@ class ObjectPersisterPOPO
 {
     public $id = 123;
 
-    public function getId()
+    public function getId(): int
     {
         return $this->id;
     }

--- a/tests/Unit/Mocks/ObjectPersisterPOPO.php
+++ b/tests/Unit/Mocks/ObjectPersisterPOPO.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the FOSElasticaBundle package.
  *
@@ -20,7 +22,7 @@ class ObjectPersisterPOPO
         return $this->id;
     }
 
-    public function getName()
+    public function getName(): string
     {
         return 'popoName';
     }

--- a/tests/Unit/Mocks/ObjectSerializerPersisterPOPO.php
+++ b/tests/Unit/Mocks/ObjectSerializerPersisterPOPO.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the FOSElasticaBundle package.
  *

--- a/tests/Unit/Mocks/ObjectSerializerPersisterPOPO.php
+++ b/tests/Unit/Mocks/ObjectSerializerPersisterPOPO.php
@@ -18,12 +18,12 @@ class ObjectSerializerPersisterPOPO
     public $id = 123;
     public $name = 'popoName';
 
-    public function getId()
+    public function getId(): int
     {
         return $this->id;
     }
 
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }

--- a/tests/Unit/Paginator/FantaPaginatorAdapterTest.php
+++ b/tests/Unit/Paginator/FantaPaginatorAdapterTest.php
@@ -21,7 +21,7 @@ use PHPUnit\Framework\TestCase;
  */
 class FantaPaginatorAdapterTest extends TestCase
 {
-    public function testGetNbResults()
+    public function testGetNbResults(): void
     {
         $mock = $this->mockPaginatorAdapter();
         $mock
@@ -33,7 +33,7 @@ class FantaPaginatorAdapterTest extends TestCase
         $this->assertEquals(123, $adapter->getNbResults());
     }
 
-    public function testGetAggregations()
+    public function testGetAggregations(): void
     {
         $mock = $this->mockPaginatorAdapter();
         $mock
@@ -45,7 +45,7 @@ class FantaPaginatorAdapterTest extends TestCase
         $this->assertEquals([], $adapter->getAggregations());
     }
 
-    public function testGetSuggests()
+    public function testGetSuggests(): void
     {
         $mock = $this->mockPaginatorAdapter();
         $mock
@@ -57,7 +57,7 @@ class FantaPaginatorAdapterTest extends TestCase
         $this->assertEquals([], $adapter->getSuggests());
     }
 
-    public function testGetGetSlice()
+    public function testGetGetSlice(): void
     {
         $results = [];
         $resultsMock = $this->mockPartialResults($results);
@@ -73,7 +73,7 @@ class FantaPaginatorAdapterTest extends TestCase
         $this->assertEquals($results, $adapter->getSlice(1, 10));
     }
 
-    public function testGetMaxScore()
+    public function testGetMaxScore(): void
     {
         $mock = $this->mockPaginatorAdapter();
         $mock
@@ -85,7 +85,7 @@ class FantaPaginatorAdapterTest extends TestCase
         $this->assertEquals(123, $adapter->getMaxScore());
     }
 
-    private function mockPartialResults($results)
+    private function mockPartialResults(array $results)
     {
         $mock = $this
             ->getMockBuilder(PartialResultsInterface::class)

--- a/tests/Unit/Paginator/FantaPaginatorAdapterTest.php
+++ b/tests/Unit/Paginator/FantaPaginatorAdapterTest.php
@@ -79,13 +79,13 @@ class FantaPaginatorAdapterTest extends TestCase
         $mock
             ->expects($this->exactly(1))
             ->method('getMaxScore')
-            ->willReturn(123)
+            ->willReturn(123.0)
         ;
         $adapter = new FantaPaginatorAdapter($mock);
-        $this->assertEquals(123, $adapter->getMaxScore());
+        $this->assertEquals(123.0, $adapter->getMaxScore());
     }
 
-    private function mockPartialResults(array $results)
+    private function mockPartialResults(array $results): \PHPUnit\Framework\MockObject\MockObject
     {
         $mock = $this
             ->getMockBuilder(PartialResultsInterface::class)
@@ -100,7 +100,7 @@ class FantaPaginatorAdapterTest extends TestCase
         return $mock;
     }
 
-    private function mockPaginatorAdapter()
+    private function mockPaginatorAdapter(): \PHPUnit\Framework\MockObject\MockObject
     {
         return $this
             ->getMockBuilder(PaginatorAdapterInterface::class)

--- a/tests/Unit/Paginator/HybridPaginatorAdapterTest.php
+++ b/tests/Unit/Paginator/HybridPaginatorAdapterTest.php
@@ -30,7 +30,7 @@ class HybridPaginatorAdapterTest extends UnitTestHelper
         $adapter->getResults(0, 0);
     }
 
-    protected function mockHybridPaginatorAdapter($args)
+    protected function mockHybridPaginatorAdapter(array $args): \PHPUnit\Framework\MockObject\MockObject
     {
         $mock = $this
             ->getMockBuilder(HybridPaginatorAdapter::class)

--- a/tests/Unit/Paginator/HybridPaginatorAdapterTest.php
+++ b/tests/Unit/Paginator/HybridPaginatorAdapterTest.php
@@ -20,7 +20,7 @@ use FOS\ElasticaBundle\Tests\Unit\UnitTestHelper;
  */
 class HybridPaginatorAdapterTest extends UnitTestHelper
 {
-    public function testGetResults()
+    public function testGetResults(): void
     {
         $searchable = $this->mockSearchable();
         $query = new Query();

--- a/tests/Unit/Paginator/HybridPartialResultsTest.php
+++ b/tests/Unit/Paginator/HybridPartialResultsTest.php
@@ -20,7 +20,7 @@ use FOS\ElasticaBundle\Tests\Unit\UnitTestHelper;
  */
 class HybridPartialResultsTest extends UnitTestHelper
 {
-    public function testToArray()
+    public function testToArray(): void
     {
         $transformer = $this->mockElasticaToModelTransformer();
         $transformer

--- a/tests/Unit/Paginator/HybridPartialResultsTest.php
+++ b/tests/Unit/Paginator/HybridPartialResultsTest.php
@@ -36,7 +36,7 @@ class HybridPartialResultsTest extends UnitTestHelper
         $results->toArray();
     }
 
-    protected function mockResultSet()
+    protected function mockResultSet(): \PHPUnit\Framework\MockObject\MockObject
     {
         $mock = $this
             ->getMockBuilder(ResultSet::class)

--- a/tests/Unit/Paginator/RawPaginatorAdapterTest.php
+++ b/tests/Unit/Paginator/RawPaginatorAdapterTest.php
@@ -72,7 +72,7 @@ class RawPaginatorAdapterTest extends UnitTestHelper
         $this->assertEquals($query, $adapter->getQuery());
     }
 
-    protected function mockResultSet()
+    protected function mockResultSet(): \PHPUnit\Framework\MockObject\MockObject
     {
         $methods = ['getTotalHits', 'getAggregations', 'getSuggests', 'getMaxScore'];
 

--- a/tests/Unit/Paginator/RawPaginatorAdapterTest.php
+++ b/tests/Unit/Paginator/RawPaginatorAdapterTest.php
@@ -21,7 +21,7 @@ use FOS\ElasticaBundle\Tests\Unit\UnitTestHelper;
  */
 class RawPaginatorAdapterTest extends UnitTestHelper
 {
-    public function testGetTotalHits()
+    public function testGetTotalHits(): void
     {
         $adapter = $this->createAdapterWithCount(123);
         $this->assertEquals(123, $adapter->getTotalHits());
@@ -30,7 +30,7 @@ class RawPaginatorAdapterTest extends UnitTestHelper
         $this->assertEquals(100, $adapter->getTotalHits());
     }
 
-    public function testGetTotalHitsGenuineTotal()
+    public function testGetTotalHitsGenuineTotal(): void
     {
         $adapter = $this->createAdapterWithCount(123);
         $this->assertEquals(123, $adapter->getTotalHits(true));
@@ -39,30 +39,30 @@ class RawPaginatorAdapterTest extends UnitTestHelper
         $this->assertEquals(123, $adapter->getTotalHits(true));
     }
 
-    public function testGetAggregations()
+    public function testGetAggregations(): void
     {
         $value = [];
         $adapter = $this->createAdapterWithSearch('getAggregations', $value);
         $this->assertEquals($value, $adapter->getAggregations());
     }
 
-    public function testGetSuggests()
+    public function testGetSuggests(): void
     {
         $value = [];
         $adapter = $this->createAdapterWithSearch('getSuggests', $value);
         $this->assertEquals($value, $adapter->getSuggests());
     }
 
-    public function testGetMaxScore()
+    public function testGetMaxScore(): void
     {
         $value = 1.0;
         $adapter = $this->createAdapterWithSearch('getMaxScore', $value);
         $this->assertEquals($value, $adapter->getMaxScore());
     }
 
-    public function testGetQuery()
+    public function testGetQuery(): void
     {
-        $resultSet = $this->mockResultSet();
+        $this->mockResultSet();
 
         $query = new Query();
         $options = [];
@@ -84,7 +84,7 @@ class RawPaginatorAdapterTest extends UnitTestHelper
         ;
     }
 
-    private function createAdapterWithSearch($methodName, $value)
+    private function createAdapterWithSearch(string $methodName, array|float $value): RawPaginatorAdapter
     {
         $resultSet = $this->mockResultSet();
         $resultSet
@@ -106,7 +106,7 @@ class RawPaginatorAdapterTest extends UnitTestHelper
         return new RawPaginatorAdapter($searchable, $query, $options);
     }
 
-    private function createAdapterWithCount($totalHits, $querySize = null)
+    private function createAdapterWithCount(int $totalHits, $querySize = null): RawPaginatorAdapter
     {
         $query = new Query();
         if ($querySize) {

--- a/tests/Unit/Persister/AsyncPagerPersisterTest.php
+++ b/tests/Unit/Persister/AsyncPagerPersisterTest.php
@@ -42,7 +42,7 @@ class AsyncPagerPersisterTest extends TestCase
 
         $messageBus->expects($this->once())->method('dispatch')->with(
             $this->callback(
-                fn ($message) => $message instanceof AsyncPersistPage
+                fn (object $message) => $message instanceof AsyncPersistPage
             )
         )->willReturn(new Envelope(new AsyncPersistPage(0, [])));
 

--- a/tests/Unit/Persister/AsyncPagerPersisterTest.php
+++ b/tests/Unit/Persister/AsyncPagerPersisterTest.php
@@ -42,7 +42,7 @@ class AsyncPagerPersisterTest extends TestCase
 
         $messageBus->expects($this->once())->method('dispatch')->with(
             $this->callback(
-                fn (object $message) => $message instanceof AsyncPersistPage
+                fn (object $message): bool => $message instanceof AsyncPersistPage
             )
         )->willReturn(new Envelope(new AsyncPersistPage(0, [])));
 

--- a/tests/Unit/Persister/AsyncPagerPersisterTest.php
+++ b/tests/Unit/Persister/AsyncPagerPersisterTest.php
@@ -27,13 +27,13 @@ use Symfony\Component\Messenger\MessageBusInterface;
  */
 class AsyncPagerPersisterTest extends TestCase
 {
-    public function testShouldImplementPagerPersisterInterface()
+    public function testShouldImplementPagerPersisterInterface(): void
     {
         $reflectionClass = new \ReflectionClass(AsyncPagerPersister::class);
         $this->assertTrue($reflectionClass->implementsInterface(PagerPersisterInterface::class));
     }
 
-    public function testInsertDispatchAsyncPersistPageObject()
+    public function testInsertDispatchAsyncPersistPageObject(): void
     {
         $pagerPersisterRegistry = new PagerPersisterRegistry($this->createMock(ServiceLocator::class));
         $pagerProviderRegistry = $this->createMock(PagerProviderRegistry::class);
@@ -42,9 +42,7 @@ class AsyncPagerPersisterTest extends TestCase
 
         $messageBus->expects($this->once())->method('dispatch')->with(
             $this->callback(
-                function ($message) {
-                    return $message instanceof AsyncPersistPage;
-                }
+                fn ($message) => $message instanceof AsyncPersistPage
             )
         )->willReturn(new Envelope(new AsyncPersistPage(0, [])));
 

--- a/tests/Unit/Persister/Event/OnExceptionEventTest.php
+++ b/tests/Unit/Persister/Event/OnExceptionEventTest.php
@@ -23,28 +23,28 @@ use Symfony\Contracts\EventDispatcher\Event;
  */
 final class OnExceptionEventTest extends TestCase
 {
-    public function testShouldBeSubClassOfEventClass()
+    public function testShouldBeSubClassOfEventClass(): void
     {
         $rc = new \ReflectionClass(OnExceptionEvent::class);
 
         $this->assertTrue($rc->isSubclassOf(Event::class));
     }
 
-    public function testShouldImplementPersistEventInterface()
+    public function testShouldImplementPersistEventInterface(): void
     {
         $rc = new \ReflectionClass(OnExceptionEvent::class);
 
         $this->assertTrue($rc->implementsInterface(PersistEvent::class));
     }
 
-    public function testShouldFinal()
+    public function testShouldFinal(): void
     {
         $rc = new \ReflectionClass(OnExceptionEvent::class);
 
         $this->assertTrue($rc->isFinal());
     }
 
-    public function testCouldBeConstructedWithExpectedArguments()
+    public function testCouldBeConstructedWithExpectedArguments(): void
     {
         new OnExceptionEvent(
             $this->createPagerMock(),
@@ -55,7 +55,7 @@ final class OnExceptionEventTest extends TestCase
         );
     }
 
-    public function testShouldAllowGetPagerSetInConstructor()
+    public function testShouldAllowGetPagerSetInConstructor(): void
     {
         $expectedPager = $this->createPagerMock();
 
@@ -64,7 +64,7 @@ final class OnExceptionEventTest extends TestCase
         $this->assertSame($expectedPager, $event->getPager());
     }
 
-    public function testShouldAllowGetObjectPersisterSetInConstructor()
+    public function testShouldAllowGetObjectPersisterSetInConstructor(): void
     {
         $expectedPersister = $this->createObjectPersisterMock();
 
@@ -73,7 +73,7 @@ final class OnExceptionEventTest extends TestCase
         $this->assertSame($expectedPersister, $event->getObjectPersister());
     }
 
-    public function testShouldAllowGetOptionsSetInConstructor()
+    public function testShouldAllowGetOptionsSetInConstructor(): void
     {
         $expectedOptions = ['foo' => 'fooVal', 'bar' => 'barVal'];
 
@@ -82,7 +82,7 @@ final class OnExceptionEventTest extends TestCase
         $this->assertSame($expectedOptions, $event->getOptions());
     }
 
-    public function testShouldAllowGetObjectsSetInConstructor()
+    public function testShouldAllowGetObjectsSetInConstructor(): void
     {
         $expectedObjects = [new \stdClass(), new \stdClass()];
 
@@ -91,7 +91,7 @@ final class OnExceptionEventTest extends TestCase
         $this->assertSame($expectedObjects, $event->getObjects());
     }
 
-    public function testShouldAllowGetExceptionSetInConstructor()
+    public function testShouldAllowGetExceptionSetInConstructor(): void
     {
         $expectedException = new \Exception();
 
@@ -100,7 +100,7 @@ final class OnExceptionEventTest extends TestCase
         $this->assertSame($expectedException, $event->getException());
     }
 
-    public function testShouldAllowGetPreviouslySetException()
+    public function testShouldAllowGetPreviouslySetException(): void
     {
         $event = new OnExceptionEvent($this->createPagerMock(), $this->createObjectPersisterMock(), new \Exception(), [], []);
 
@@ -110,14 +110,14 @@ final class OnExceptionEventTest extends TestCase
         $this->assertSame($expectedException, $event->getException());
     }
 
-    public function testShouldNotIgnoreExceptionByDefault()
+    public function testShouldNotIgnoreExceptionByDefault(): void
     {
         $event = new OnExceptionEvent($this->createPagerMock(), $this->createObjectPersisterMock(), new \Exception(), [], []);
 
         $this->assertFalse($event->isIgnored());
     }
 
-    public function testShouldAllowIgnoredException()
+    public function testShouldAllowIgnoredException(): void
     {
         $event = new OnExceptionEvent($this->createPagerMock(), $this->createObjectPersisterMock(), new \Exception(), [], []);
 
@@ -129,7 +129,7 @@ final class OnExceptionEventTest extends TestCase
     /**
      * @return ObjectPersisterInterface|\PHPUnit\Framework\MockObject\MockObject
      */
-    private function createObjectPersisterMock()
+    private function createObjectPersisterMock(): \PHPUnit\Framework\MockObject\MockObject
     {
         return $this->createMock(ObjectPersisterInterface::class);
     }
@@ -137,7 +137,7 @@ final class OnExceptionEventTest extends TestCase
     /**
      * @return PagerInterface|\PHPUnit\Framework\MockObject\MockObject
      */
-    private function createPagerMock()
+    private function createPagerMock(): \PHPUnit\Framework\MockObject\MockObject
     {
         return $this->createMock(PagerInterface::class);
     }

--- a/tests/Unit/Persister/Event/PostAsyncInsertObjectsEventTest.php
+++ b/tests/Unit/Persister/Event/PostAsyncInsertObjectsEventTest.php
@@ -25,28 +25,28 @@ use Symfony\Contracts\EventDispatcher\Event;
  */
 final class PostAsyncInsertObjectsEventTest extends TestCase
 {
-    public function testShouldBeSubClassOfEventClass()
+    public function testShouldBeSubClassOfEventClass(): void
     {
         $rc = new \ReflectionClass(PostAsyncInsertObjectsEvent::class);
 
         $this->assertTrue($rc->isSubclassOf(Event::class));
     }
 
-    public function testShouldImplementPersistEventInterface()
+    public function testShouldImplementPersistEventInterface(): void
     {
         $rc = new \ReflectionClass(PostAsyncInsertObjectsEvent::class);
 
         $this->assertTrue($rc->implementsInterface(PersistEvent::class));
     }
 
-    public function testShouldFinal()
+    public function testShouldFinal(): void
     {
         $rc = new \ReflectionClass(PostAsyncInsertObjectsEvent::class);
 
         $this->assertTrue($rc->isFinal());
     }
 
-    public function testCouldBeConstructedWithPagerAndObjectPersisterAndObjectsCountAndOptions()
+    public function testCouldBeConstructedWithPagerAndObjectPersisterAndObjectsCountAndOptions(): void
     {
         new PostAsyncInsertObjectsEvent(
             $this->createPagerMock(),
@@ -57,7 +57,7 @@ final class PostAsyncInsertObjectsEventTest extends TestCase
         );
     }
 
-    public function testShouldAllowGetPagerSetInConstructor()
+    public function testShouldAllowGetPagerSetInConstructor(): void
     {
         $expectedPager = $this->createPagerMock();
 
@@ -66,7 +66,7 @@ final class PostAsyncInsertObjectsEventTest extends TestCase
         $this->assertSame($expectedPager, $event->getPager());
     }
 
-    public function testShouldAllowGetObjectPersisterSetInConstructor()
+    public function testShouldAllowGetObjectPersisterSetInConstructor(): void
     {
         $expectedPersister = $this->createObjectPersisterMock();
 
@@ -75,7 +75,7 @@ final class PostAsyncInsertObjectsEventTest extends TestCase
         $this->assertSame($expectedPersister, $event->getObjectPersister());
     }
 
-    public function testShouldAllowGetOptionsSetInConstructor()
+    public function testShouldAllowGetOptionsSetInConstructor(): void
     {
         $expectedOptions = ['foo' => 'fooVal', 'bar' => 'barVal'];
 
@@ -84,7 +84,7 @@ final class PostAsyncInsertObjectsEventTest extends TestCase
         $this->assertSame($expectedOptions, $event->getOptions());
     }
 
-    public function testShouldAllowGetObjectsSetInConstructor()
+    public function testShouldAllowGetObjectsSetInConstructor(): void
     {
         $expectedObjectsCount = 321;
 
@@ -93,7 +93,7 @@ final class PostAsyncInsertObjectsEventTest extends TestCase
         $this->assertSame($expectedObjectsCount, $event->getObjectsCount());
     }
 
-    public function testShouldAllowGetErrorMessageSetInConstructor()
+    public function testShouldAllowGetErrorMessageSetInConstructor(): void
     {
         $expectedErrorMessage = 'theErrorMessage';
 
@@ -105,7 +105,7 @@ final class PostAsyncInsertObjectsEventTest extends TestCase
     /**
      * @return ObjectPersisterInterface|\PHPUnit\Framework\MockObject\MockObject
      */
-    private function createObjectPersisterMock()
+    private function createObjectPersisterMock(): \PHPUnit\Framework\MockObject\MockObject
     {
         return $this->createMock(ObjectPersisterInterface::class);
     }
@@ -113,7 +113,7 @@ final class PostAsyncInsertObjectsEventTest extends TestCase
     /**
      * @return PagerInterface|\PHPUnit\Framework\MockObject\MockObject
      */
-    private function createPagerMock()
+    private function createPagerMock(): \PHPUnit\Framework\MockObject\MockObject
     {
         return $this->createMock(PagerInterface::class);
     }

--- a/tests/Unit/Persister/Event/PostInsertObjectsEventTest.php
+++ b/tests/Unit/Persister/Event/PostInsertObjectsEventTest.php
@@ -23,28 +23,28 @@ use Symfony\Contracts\EventDispatcher\Event;
  */
 final class PostInsertObjectsEventTest extends TestCase
 {
-    public function testShouldBeSubClassOfEventClass()
+    public function testShouldBeSubClassOfEventClass(): void
     {
         $rc = new \ReflectionClass(PostInsertObjectsEvent::class);
 
         $this->assertTrue($rc->isSubclassOf(Event::class));
     }
 
-    public function testShouldImplementPersistEventInterface()
+    public function testShouldImplementPersistEventInterface(): void
     {
         $rc = new \ReflectionClass(PostInsertObjectsEvent::class);
 
         $this->assertTrue($rc->implementsInterface(PersistEvent::class));
     }
 
-    public function testShouldFinal()
+    public function testShouldFinal(): void
     {
         $rc = new \ReflectionClass(PostInsertObjectsEvent::class);
 
         $this->assertTrue($rc->isFinal());
     }
 
-    public function testCouldBeConstructedWithPagerAndObjectPersisterAndObjectsAndOptions()
+    public function testCouldBeConstructedWithPagerAndObjectPersisterAndObjectsAndOptions(): void
     {
         new PostInsertObjectsEvent(
             $this->createPagerMock(),
@@ -54,7 +54,7 @@ final class PostInsertObjectsEventTest extends TestCase
         );
     }
 
-    public function testShouldAllowGetPagerSetInConstructor()
+    public function testShouldAllowGetPagerSetInConstructor(): void
     {
         $expectedPager = $this->createPagerMock();
 
@@ -63,7 +63,7 @@ final class PostInsertObjectsEventTest extends TestCase
         $this->assertSame($expectedPager, $event->getPager());
     }
 
-    public function testShouldAllowGetObjectPersisterSetInConstructor()
+    public function testShouldAllowGetObjectPersisterSetInConstructor(): void
     {
         $expectedPersister = $this->createObjectPersisterMock();
 
@@ -72,7 +72,7 @@ final class PostInsertObjectsEventTest extends TestCase
         $this->assertSame($expectedPersister, $event->getObjectPersister());
     }
 
-    public function testShouldAllowGetOptionsSetInConstructor()
+    public function testShouldAllowGetOptionsSetInConstructor(): void
     {
         $expectedOptions = ['foo' => 'fooVal', 'bar' => 'barVal'];
 
@@ -81,7 +81,7 @@ final class PostInsertObjectsEventTest extends TestCase
         $this->assertSame($expectedOptions, $event->getOptions());
     }
 
-    public function testShouldAllowGetObjectsSetInConstructor()
+    public function testShouldAllowGetObjectsSetInConstructor(): void
     {
         $expectedObjects = [new \stdClass(), new \stdClass()];
 
@@ -93,7 +93,7 @@ final class PostInsertObjectsEventTest extends TestCase
     /**
      * @return ObjectPersisterInterface|\PHPUnit\Framework\MockObject\MockObject
      */
-    private function createObjectPersisterMock()
+    private function createObjectPersisterMock(): \PHPUnit\Framework\MockObject\MockObject
     {
         return $this->createMock(ObjectPersisterInterface::class);
     }
@@ -101,7 +101,7 @@ final class PostInsertObjectsEventTest extends TestCase
     /**
      * @return PagerInterface|\PHPUnit\Framework\MockObject\MockObject
      */
-    private function createPagerMock()
+    private function createPagerMock(): \PHPUnit\Framework\MockObject\MockObject
     {
         return $this->createMock(PagerInterface::class);
     }

--- a/tests/Unit/Persister/Event/PostPersistEventTest.php
+++ b/tests/Unit/Persister/Event/PostPersistEventTest.php
@@ -23,33 +23,33 @@ use Symfony\Contracts\EventDispatcher\Event;
  */
 final class PostPersistEventTest extends TestCase
 {
-    public function testShouldBeSubClassOfEventClass()
+    public function testShouldBeSubClassOfEventClass(): void
     {
         $rc = new \ReflectionClass(PostPersistEvent::class);
 
         $this->assertTrue($rc->isSubclassOf(Event::class));
     }
 
-    public function testShouldImplementPersistEventInterface()
+    public function testShouldImplementPersistEventInterface(): void
     {
         $rc = new \ReflectionClass(PostPersistEvent::class);
 
         $this->assertTrue($rc->implementsInterface(PersistEvent::class));
     }
 
-    public function testShouldFinal()
+    public function testShouldFinal(): void
     {
         $rc = new \ReflectionClass(PostPersistEvent::class);
 
         $this->assertTrue($rc->isFinal());
     }
 
-    public function testCouldBeConstructedWithPagerAndObjectPersisterAndOptions()
+    public function testCouldBeConstructedWithPagerAndObjectPersisterAndOptions(): void
     {
         new PostPersistEvent($this->createPagerMock(), $this->createObjectPersisterMock(), []);
     }
 
-    public function testShouldAllowGetPagerSetInConstructor()
+    public function testShouldAllowGetPagerSetInConstructor(): void
     {
         $expectedPager = $this->createPagerMock();
 
@@ -58,7 +58,7 @@ final class PostPersistEventTest extends TestCase
         $this->assertSame($expectedPager, $event->getPager());
     }
 
-    public function testShouldAllowGetObjectPersisterSetInConstructor()
+    public function testShouldAllowGetObjectPersisterSetInConstructor(): void
     {
         $expectedPersister = $this->createObjectPersisterMock();
 
@@ -67,7 +67,7 @@ final class PostPersistEventTest extends TestCase
         $this->assertSame($expectedPersister, $event->getObjectPersister());
     }
 
-    public function testShouldAllowGetOptionsSetInConstructor()
+    public function testShouldAllowGetOptionsSetInConstructor(): void
     {
         $expectedOptions = ['foo' => 'fooVal', 'bar' => 'barVal'];
 
@@ -79,7 +79,7 @@ final class PostPersistEventTest extends TestCase
     /**
      * @return ObjectPersisterInterface|\PHPUnit\Framework\MockObject\MockObject
      */
-    private function createObjectPersisterMock()
+    private function createObjectPersisterMock(): \PHPUnit\Framework\MockObject\MockObject
     {
         return $this->createMock(ObjectPersisterInterface::class);
     }
@@ -87,7 +87,7 @@ final class PostPersistEventTest extends TestCase
     /**
      * @return PagerInterface|\PHPUnit\Framework\MockObject\MockObject
      */
-    private function createPagerMock()
+    private function createPagerMock(): \PHPUnit\Framework\MockObject\MockObject
     {
         return $this->createMock(PagerInterface::class);
     }

--- a/tests/Unit/Persister/Event/PreFetchObjectsEventTest.php
+++ b/tests/Unit/Persister/Event/PreFetchObjectsEventTest.php
@@ -23,33 +23,33 @@ use Symfony\Contracts\EventDispatcher\Event;
  */
 final class PreFetchObjectsEventTest extends TestCase
 {
-    public function testShouldBeSubClassOfEventClass()
+    public function testShouldBeSubClassOfEventClass(): void
     {
         $rc = new \ReflectionClass(PreFetchObjectsEvent::class);
 
         $this->assertTrue($rc->isSubclassOf(Event::class));
     }
 
-    public function testShouldImplementPersistEventInterface()
+    public function testShouldImplementPersistEventInterface(): void
     {
         $rc = new \ReflectionClass(PreFetchObjectsEvent::class);
 
         $this->assertTrue($rc->implementsInterface(PersistEvent::class));
     }
 
-    public function testShouldFinal()
+    public function testShouldFinal(): void
     {
         $rc = new \ReflectionClass(PreFetchObjectsEvent::class);
 
         $this->assertTrue($rc->isFinal());
     }
 
-    public function testCouldBeConstructedWithPagerAndObjectPersisterAndOptions()
+    public function testCouldBeConstructedWithPagerAndObjectPersisterAndOptions(): void
     {
         new PreFetchObjectsEvent($this->createPagerMock(), $this->createObjectPersisterMock(), []);
     }
 
-    public function testShouldAllowGetPagerSetInConstructor()
+    public function testShouldAllowGetPagerSetInConstructor(): void
     {
         $expectedPager = $this->createPagerMock();
 
@@ -58,7 +58,7 @@ final class PreFetchObjectsEventTest extends TestCase
         $this->assertSame($expectedPager, $event->getPager());
     }
 
-    public function testShouldAllowGetPreviouslySetPager()
+    public function testShouldAllowGetPreviouslySetPager(): void
     {
         $event = new PreFetchObjectsEvent($this->createPagerMock(), $this->createObjectPersisterMock(), []);
 
@@ -68,7 +68,7 @@ final class PreFetchObjectsEventTest extends TestCase
         $this->assertSame($expectedPager, $event->getPager());
     }
 
-    public function testShouldAllowGetObjectPersisterSetInConstructor()
+    public function testShouldAllowGetObjectPersisterSetInConstructor(): void
     {
         $expectedPersister = $this->createObjectPersisterMock();
 
@@ -77,7 +77,7 @@ final class PreFetchObjectsEventTest extends TestCase
         $this->assertSame($expectedPersister, $event->getObjectPersister());
     }
 
-    public function testShouldAllowGetPreviouslySetObjectsPersister()
+    public function testShouldAllowGetPreviouslySetObjectsPersister(): void
     {
         $event = new PreFetchObjectsEvent($this->createPagerMock(), $this->createObjectPersisterMock(), []);
 
@@ -87,7 +87,7 @@ final class PreFetchObjectsEventTest extends TestCase
         $this->assertSame($expectedPersister, $event->getObjectPersister());
     }
 
-    public function testShouldAllowGetOptionsSetInConstructor()
+    public function testShouldAllowGetOptionsSetInConstructor(): void
     {
         $expectedOptions = ['foo' => 'fooVal', 'bar' => 'barVal'];
 
@@ -96,7 +96,7 @@ final class PreFetchObjectsEventTest extends TestCase
         $this->assertSame($expectedOptions, $event->getOptions());
     }
 
-    public function testShouldAllowGetPreviouslySetOptions()
+    public function testShouldAllowGetPreviouslySetOptions(): void
     {
         $event = new PreFetchObjectsEvent($this->createPagerMock(), $this->createObjectPersisterMock(), ['foo' => 'fooVal', 'bar' => 'barVal']);
 
@@ -109,7 +109,7 @@ final class PreFetchObjectsEventTest extends TestCase
     /**
      * @return ObjectPersisterInterface|\PHPUnit\Framework\MockObject\MockObject
      */
-    private function createObjectPersisterMock()
+    private function createObjectPersisterMock(): \PHPUnit\Framework\MockObject\MockObject
     {
         return $this->createMock(ObjectPersisterInterface::class);
     }
@@ -117,7 +117,7 @@ final class PreFetchObjectsEventTest extends TestCase
     /**
      * @return PagerInterface|\PHPUnit\Framework\MockObject\MockObject
      */
-    private function createPagerMock()
+    private function createPagerMock(): \PHPUnit\Framework\MockObject\MockObject
     {
         return $this->createMock(PagerInterface::class);
     }

--- a/tests/Unit/Persister/Event/PreInsertObjectsEventTest.php
+++ b/tests/Unit/Persister/Event/PreInsertObjectsEventTest.php
@@ -23,28 +23,28 @@ use Symfony\Contracts\EventDispatcher\Event;
  */
 final class PreInsertObjectsEventTest extends TestCase
 {
-    public function testShouldBeSubClassOfEventClass()
+    public function testShouldBeSubClassOfEventClass(): void
     {
         $rc = new \ReflectionClass(PreInsertObjectsEvent::class);
 
         $this->assertTrue($rc->isSubclassOf(Event::class));
     }
 
-    public function testShouldImplementPersistEventInterface()
+    public function testShouldImplementPersistEventInterface(): void
     {
         $rc = new \ReflectionClass(PreInsertObjectsEvent::class);
 
         $this->assertTrue($rc->implementsInterface(PersistEvent::class));
     }
 
-    public function testShouldFinal()
+    public function testShouldFinal(): void
     {
         $rc = new \ReflectionClass(PreInsertObjectsEvent::class);
 
         $this->assertTrue($rc->isFinal());
     }
 
-    public function testCouldBeConstructedWithPagerAndObjectPersisterAndObjectsAndOptions()
+    public function testCouldBeConstructedWithPagerAndObjectPersisterAndObjectsAndOptions(): void
     {
         new PreInsertObjectsEvent(
             $this->createPagerMock(),
@@ -54,7 +54,7 @@ final class PreInsertObjectsEventTest extends TestCase
         );
     }
 
-    public function testShouldAllowGetPagerSetInConstructor()
+    public function testShouldAllowGetPagerSetInConstructor(): void
     {
         $expectedPager = $this->createPagerMock();
 
@@ -63,7 +63,7 @@ final class PreInsertObjectsEventTest extends TestCase
         $this->assertSame($expectedPager, $event->getPager());
     }
 
-    public function testShouldAllowGetPreviouslySetPager()
+    public function testShouldAllowGetPreviouslySetPager(): void
     {
         $event = new PreInsertObjectsEvent($this->createPagerMock(), $this->createObjectPersisterMock(), [], []);
 
@@ -73,7 +73,7 @@ final class PreInsertObjectsEventTest extends TestCase
         $this->assertSame($expectedPager, $event->getPager());
     }
 
-    public function testShouldAllowGetObjectPersisterSetInConstructor()
+    public function testShouldAllowGetObjectPersisterSetInConstructor(): void
     {
         $expectedPersister = $this->createObjectPersisterMock();
 
@@ -82,7 +82,7 @@ final class PreInsertObjectsEventTest extends TestCase
         $this->assertSame($expectedPersister, $event->getObjectPersister());
     }
 
-    public function testShouldAllowGetPreviouslySetObjectsPersister()
+    public function testShouldAllowGetPreviouslySetObjectsPersister(): void
     {
         $event = new PreInsertObjectsEvent($this->createPagerMock(), $this->createObjectPersisterMock(), [], []);
 
@@ -92,7 +92,7 @@ final class PreInsertObjectsEventTest extends TestCase
         $this->assertSame($expectedPersister, $event->getObjectPersister());
     }
 
-    public function testShouldAllowGetOptionsSetInConstructor()
+    public function testShouldAllowGetOptionsSetInConstructor(): void
     {
         $expectedOptions = ['foo' => 'fooVal', 'bar' => 'barVal'];
 
@@ -101,7 +101,7 @@ final class PreInsertObjectsEventTest extends TestCase
         $this->assertSame($expectedOptions, $event->getOptions());
     }
 
-    public function testShouldAllowGetPreviouslySetOptions()
+    public function testShouldAllowGetPreviouslySetOptions(): void
     {
         $event = new PreInsertObjectsEvent($this->createPagerMock(), $this->createObjectPersisterMock(), [], ['foo' => 'fooVal', 'bar' => 'barVal']);
 
@@ -111,7 +111,7 @@ final class PreInsertObjectsEventTest extends TestCase
         $this->assertSame($expectedOptions, $event->getOptions());
     }
 
-    public function testShouldAllowGetObjectsSetInConstructor()
+    public function testShouldAllowGetObjectsSetInConstructor(): void
     {
         $expectedObjects = [new \stdClass(), new \stdClass()];
 
@@ -120,7 +120,7 @@ final class PreInsertObjectsEventTest extends TestCase
         $this->assertSame($expectedObjects, $event->getObjects());
     }
 
-    public function testShouldAllowGetPreviouslySetObjects()
+    public function testShouldAllowGetPreviouslySetObjects(): void
     {
         $event = new PreInsertObjectsEvent($this->createPagerMock(), $this->createObjectPersisterMock(), [new \stdClass(), new \stdClass()], []);
 
@@ -133,7 +133,7 @@ final class PreInsertObjectsEventTest extends TestCase
     /**
      * @return ObjectPersisterInterface|\PHPUnit\Framework\MockObject\MockObject
      */
-    private function createObjectPersisterMock()
+    private function createObjectPersisterMock(): \PHPUnit\Framework\MockObject\MockObject
     {
         return $this->createMock(ObjectPersisterInterface::class);
     }
@@ -141,7 +141,7 @@ final class PreInsertObjectsEventTest extends TestCase
     /**
      * @return PagerInterface|\PHPUnit\Framework\MockObject\MockObject
      */
-    private function createPagerMock()
+    private function createPagerMock(): \PHPUnit\Framework\MockObject\MockObject
     {
         return $this->createMock(PagerInterface::class);
     }

--- a/tests/Unit/Persister/Event/PrePersistEventTest.php
+++ b/tests/Unit/Persister/Event/PrePersistEventTest.php
@@ -23,33 +23,33 @@ use Symfony\Contracts\EventDispatcher\Event;
  */
 final class PrePersistEventTest extends TestCase
 {
-    public function testShouldBeSubClassOfEventClass()
+    public function testShouldBeSubClassOfEventClass(): void
     {
         $rc = new \ReflectionClass(PrePersistEvent::class);
 
         $this->assertTrue($rc->isSubclassOf(Event::class));
     }
 
-    public function testShouldImplementPersistEventInterface()
+    public function testShouldImplementPersistEventInterface(): void
     {
         $rc = new \ReflectionClass(PrePersistEvent::class);
 
         $this->assertTrue($rc->implementsInterface(PersistEvent::class));
     }
 
-    public function testShouldFinal()
+    public function testShouldFinal(): void
     {
         $rc = new \ReflectionClass(PrePersistEvent::class);
 
         $this->assertTrue($rc->isFinal());
     }
 
-    public function testCouldBeConstructedWithPagerAndObjectPersisterAndOptions()
+    public function testCouldBeConstructedWithPagerAndObjectPersisterAndOptions(): void
     {
         new PrePersistEvent($this->createPagerMock(), $this->createObjectPersisterMock(), []);
     }
 
-    public function testShouldAllowGetPagerSetInConstructor()
+    public function testShouldAllowGetPagerSetInConstructor(): void
     {
         $expectedPager = $this->createPagerMock();
 
@@ -58,7 +58,7 @@ final class PrePersistEventTest extends TestCase
         $this->assertSame($expectedPager, $event->getPager());
     }
 
-    public function testShouldAllowGetPreviouslySetPager()
+    public function testShouldAllowGetPreviouslySetPager(): void
     {
         $event = new PrePersistEvent($this->createPagerMock(), $this->createObjectPersisterMock(), []);
 
@@ -68,7 +68,7 @@ final class PrePersistEventTest extends TestCase
         $this->assertSame($expectedPager, $event->getPager());
     }
 
-    public function testShouldAllowGetObjectPersisterSetInConstructor()
+    public function testShouldAllowGetObjectPersisterSetInConstructor(): void
     {
         $expectedPersister = $this->createObjectPersisterMock();
 
@@ -77,7 +77,7 @@ final class PrePersistEventTest extends TestCase
         $this->assertSame($expectedPersister, $event->getObjectPersister());
     }
 
-    public function testShouldAllowGetPreviouslySetObjectsPersister()
+    public function testShouldAllowGetPreviouslySetObjectsPersister(): void
     {
         $event = new PrePersistEvent($this->createPagerMock(), $this->createObjectPersisterMock(), []);
 
@@ -87,7 +87,7 @@ final class PrePersistEventTest extends TestCase
         $this->assertSame($expectedPersister, $event->getObjectPersister());
     }
 
-    public function testShouldAllowGetOptionsSetInConstructor()
+    public function testShouldAllowGetOptionsSetInConstructor(): void
     {
         $expectedOptions = ['foo' => 'fooVal', 'bar' => 'barVal'];
 
@@ -96,7 +96,7 @@ final class PrePersistEventTest extends TestCase
         $this->assertSame($expectedOptions, $event->getOptions());
     }
 
-    public function testShouldAllowGetPreviouslySetOptions()
+    public function testShouldAllowGetPreviouslySetOptions(): void
     {
         $event = new PrePersistEvent($this->createPagerMock(), $this->createObjectPersisterMock(), ['foo' => 'fooVal', 'bar' => 'barVal']);
 
@@ -109,7 +109,7 @@ final class PrePersistEventTest extends TestCase
     /**
      * @return ObjectPersisterInterface|\PHPUnit\Framework\MockObject\MockObject
      */
-    private function createObjectPersisterMock()
+    private function createObjectPersisterMock(): \PHPUnit\Framework\MockObject\MockObject
     {
         return $this->createMock(ObjectPersisterInterface::class);
     }
@@ -117,7 +117,7 @@ final class PrePersistEventTest extends TestCase
     /**
      * @return PagerInterface|\PHPUnit\Framework\MockObject\MockObject
      */
-    private function createPagerMock()
+    private function createPagerMock(): \PHPUnit\Framework\MockObject\MockObject
     {
         return $this->createMock(PagerInterface::class);
     }

--- a/tests/Unit/Persister/InPlacePagerPersisterTest.php
+++ b/tests/Unit/Persister/InPlacePagerPersisterTest.php
@@ -403,7 +403,7 @@ class InPlacePagerPersisterTest extends TestCase
      *
      * @return PersisterRegistry|\PHPUnit\Framework\MockObject\MockObject
      */
-    private function createPersisterRegistryStub($objectPersister = null)
+    private function createPersisterRegistryStub($objectPersister = null): \PHPUnit\Framework\MockObject\MockObject
     {
         $registryMock = $this->createPersisterRegistryMock();
         $registryMock

--- a/tests/Unit/Persister/InPlacePagerPersisterTest.php
+++ b/tests/Unit/Persister/InPlacePagerPersisterTest.php
@@ -32,19 +32,19 @@ use Symfony\Component\EventDispatcher\EventDispatcher;
  */
 class InPlacePagerPersisterTest extends TestCase
 {
-    public function testShouldImplementPagerPersisterInterface()
+    public function testShouldImplementPagerPersisterInterface(): void
     {
         $rc = new \ReflectionClass(InPlacePagerPersister::class);
 
         $this->assertTrue($rc->implementsInterface(PagerPersisterInterface::class));
     }
 
-    public function testCouldBeConstructedWithPersisterRegistryAndDispatcherAsArguments()
+    public function testCouldBeConstructedWithPersisterRegistryAndDispatcherAsArguments(): void
     {
         new InPlacePagerPersister($this->createPersisterRegistryMock(), new EventDispatcher());
     }
 
-    public function testShouldDispatchPrePersistEventWithExpectedArguments()
+    public function testShouldDispatchPrePersistEventWithExpectedArguments(): void
     {
         $objectPersisterMock = $this->createObjectPersisterMock();
 
@@ -58,7 +58,7 @@ class InPlacePagerPersisterTest extends TestCase
         $pager = $this->createPager([new \stdClass(), new \stdClass()]);
 
         $called = false;
-        $dispatcher->addListener(PrePersistEvent::class, function ($event) use (&$called, $pager, $objectPersisterMock, $options) {
+        $dispatcher->addListener(PrePersistEvent::class, function ($event) use (&$called, $pager, $objectPersisterMock, $options): void {
             $called = true;
 
             $this->assertInstanceOf(PrePersistEvent::class, $event);
@@ -75,7 +75,7 @@ class InPlacePagerPersisterTest extends TestCase
         $this->assertTrue($called);
     }
 
-    public function testShouldDispatchPreFetchObjectsEventWithExpectedArguments()
+    public function testShouldDispatchPreFetchObjectsEventWithExpectedArguments(): void
     {
         $objectPersisterMock = $this->createObjectPersisterMock();
 
@@ -91,7 +91,7 @@ class InPlacePagerPersisterTest extends TestCase
         $pager = $this->createPager($objects);
 
         $called = false;
-        $dispatcher->addListener(PreFetchObjectsEvent::class, function ($event) use (&$called, $pager, $objectPersisterMock, $options) {
+        $dispatcher->addListener(PreFetchObjectsEvent::class, function ($event) use (&$called, $pager, $objectPersisterMock, $options): void {
             $called = true;
 
             $this->assertInstanceOf(PreFetchObjectsEvent::class, $event);
@@ -108,7 +108,7 @@ class InPlacePagerPersisterTest extends TestCase
         $this->assertTrue($called);
     }
 
-    public function testShouldDispatchPreInsertObjectsEventWithExpectedArguments()
+    public function testShouldDispatchPreInsertObjectsEventWithExpectedArguments(): void
     {
         $objectPersisterMock = $this->createObjectPersisterMock();
 
@@ -124,7 +124,7 @@ class InPlacePagerPersisterTest extends TestCase
         $pager = $this->createPager($objects);
 
         $called = false;
-        $dispatcher->addListener(PreInsertObjectsEvent::class, function ($event) use (&$called, $pager, $objectPersisterMock, $objects, $options) {
+        $dispatcher->addListener(PreInsertObjectsEvent::class, function ($event) use (&$called, $pager, $objectPersisterMock, $objects, $options): void {
             $called = true;
 
             $this->assertInstanceOf(PreInsertObjectsEvent::class, $event);
@@ -142,7 +142,7 @@ class InPlacePagerPersisterTest extends TestCase
         $this->assertTrue($called);
     }
 
-    public function testShouldDispatchPostInsertObjectsEventWithExpectedArguments()
+    public function testShouldDispatchPostInsertObjectsEventWithExpectedArguments(): void
     {
         $objectPersisterMock = $this->createObjectPersisterMock();
 
@@ -158,7 +158,7 @@ class InPlacePagerPersisterTest extends TestCase
         $pager = $this->createPager($objects);
 
         $called = false;
-        $dispatcher->addListener(PostInsertObjectsEvent::class, function ($event) use (&$called, $pager, $objectPersisterMock, $objects, $options) {
+        $dispatcher->addListener(PostInsertObjectsEvent::class, function ($event) use (&$called, $pager, $objectPersisterMock, $objects, $options): void {
             $called = true;
 
             $this->assertInstanceOf(PostInsertObjectsEvent::class, $event);
@@ -176,7 +176,7 @@ class InPlacePagerPersisterTest extends TestCase
         $this->assertTrue($called);
     }
 
-    public function testShouldDispatchPostPersistEventWithExpectedArguments()
+    public function testShouldDispatchPostPersistEventWithExpectedArguments(): void
     {
         $objectPersisterMock = $this->createObjectPersisterMock();
 
@@ -192,7 +192,7 @@ class InPlacePagerPersisterTest extends TestCase
         $pager = $this->createPager($objects);
 
         $called = false;
-        $dispatcher->addListener(PostPersistEvent::class, function ($event) use (&$called, $pager, $objectPersisterMock, $options) {
+        $dispatcher->addListener(PostPersistEvent::class, function ($event) use (&$called, $pager, $objectPersisterMock, $options): void {
             $called = true;
 
             $this->assertInstanceOf(PostPersistEvent::class, $event);
@@ -209,7 +209,7 @@ class InPlacePagerPersisterTest extends TestCase
         $this->assertTrue($called);
     }
 
-    public function testShouldCallObjectPersisterInsertManyMethodForEachPage()
+    public function testShouldCallObjectPersisterInsertManyMethodForEachPage(): void
     {
         $options = ['indexName' => 'theIndex', 'max_per_page' => 2];
 
@@ -235,7 +235,7 @@ class InPlacePagerPersisterTest extends TestCase
         $persister->insert($pager, $options);
     }
 
-    public function testShouldCallObjectPersisterInsertManyMethodOnlyForSecondPage()
+    public function testShouldCallObjectPersisterInsertManyMethodOnlyForSecondPage(): void
     {
         $options = [
             'indexName' => 'theIndex',
@@ -266,7 +266,7 @@ class InPlacePagerPersisterTest extends TestCase
         $persister->insert($pager, $options);
     }
 
-    public function testShouldIterateToRealLastPageEvenIfLastPageOptionIsBigger()
+    public function testShouldIterateToRealLastPageEvenIfLastPageOptionIsBigger(): void
     {
         $options = [
             'indexName' => 'theIndex',
@@ -295,7 +295,7 @@ class InPlacePagerPersisterTest extends TestCase
         $persister->insert($pager, $options);
     }
 
-    public function testShouldDispatchOnExceptionEventWithExpectedArgumentsAndReThrowIt()
+    public function testShouldDispatchOnExceptionEventWithExpectedArgumentsAndReThrowIt(): void
     {
         $exception = new \LogicException();
 
@@ -318,7 +318,7 @@ class InPlacePagerPersisterTest extends TestCase
         $pager = $this->createPager($objects);
 
         $called = false;
-        $dispatcher->addListener(OnExceptionEvent::class, function ($event) use (&$called, $pager, $objectPersisterMock, $exception, $options) {
+        $dispatcher->addListener(OnExceptionEvent::class, function ($event) use (&$called, $pager, $objectPersisterMock, $exception, $options): void {
             $called = true;
 
             $this->assertInstanceOf(OnExceptionEvent::class, $event);
@@ -343,7 +343,7 @@ class InPlacePagerPersisterTest extends TestCase
         $this->fail('The exception is expected to be thrown');
     }
 
-    public function testShouldDispatchOnExceptionEventButNotReThrowIt()
+    public function testShouldDispatchOnExceptionEventButNotReThrowIt(): void
     {
         $exception = new \LogicException();
 
@@ -366,7 +366,7 @@ class InPlacePagerPersisterTest extends TestCase
         $pager = $this->createPager($objects);
 
         $called = false;
-        $dispatcher->addListener(OnExceptionEvent::class, function (OnExceptionEvent $event) use (&$called) {
+        $dispatcher->addListener(OnExceptionEvent::class, function (OnExceptionEvent $event) use (&$called): void {
             $called = true;
 
             $event->setIgnored(true);
@@ -377,7 +377,7 @@ class InPlacePagerPersisterTest extends TestCase
         $this->assertTrue($called);
     }
 
-    private function createPager(array $objects)
+    private function createPager(array $objects): PagerfantaPager
     {
         return new PagerfantaPager(new Pagerfanta(new ArrayAdapter($objects)));
     }
@@ -385,7 +385,7 @@ class InPlacePagerPersisterTest extends TestCase
     /**
      * @return ObjectPersisterInterface|\PHPUnit\Framework\MockObject\MockObject
      */
-    private function createObjectPersisterMock()
+    private function createObjectPersisterMock(): \PHPUnit\Framework\MockObject\MockObject
     {
         return $this->createMock(ObjectPersisterInterface::class);
     }
@@ -393,7 +393,7 @@ class InPlacePagerPersisterTest extends TestCase
     /**
      * @return PersisterRegistry|\PHPUnit\Framework\MockObject\MockObject
      */
-    private function createPersisterRegistryMock()
+    private function createPersisterRegistryMock(): \PHPUnit\Framework\MockObject\MockObject
     {
         return $this->createMock(PersisterRegistry::class);
     }

--- a/tests/Unit/Persister/InPlacePagerPersisterTest.php
+++ b/tests/Unit/Persister/InPlacePagerPersisterTest.php
@@ -58,7 +58,7 @@ class InPlacePagerPersisterTest extends TestCase
         $pager = $this->createPager([new \stdClass(), new \stdClass()]);
 
         $called = false;
-        $dispatcher->addListener(PrePersistEvent::class, function ($event) use (&$called, $pager, $objectPersisterMock, $options): void {
+        $dispatcher->addListener(PrePersistEvent::class, function (PrePersistEvent $event) use (&$called, $pager, $objectPersisterMock, $options): void {
             $called = true;
 
             $this->assertInstanceOf(PrePersistEvent::class, $event);
@@ -91,7 +91,7 @@ class InPlacePagerPersisterTest extends TestCase
         $pager = $this->createPager($objects);
 
         $called = false;
-        $dispatcher->addListener(PreFetchObjectsEvent::class, function ($event) use (&$called, $pager, $objectPersisterMock, $options): void {
+        $dispatcher->addListener(PreFetchObjectsEvent::class, function (PreFetchObjectsEvent $event) use (&$called, $pager, $objectPersisterMock, $options): void {
             $called = true;
 
             $this->assertInstanceOf(PreFetchObjectsEvent::class, $event);
@@ -124,7 +124,7 @@ class InPlacePagerPersisterTest extends TestCase
         $pager = $this->createPager($objects);
 
         $called = false;
-        $dispatcher->addListener(PreInsertObjectsEvent::class, function ($event) use (&$called, $pager, $objectPersisterMock, $objects, $options): void {
+        $dispatcher->addListener(PreInsertObjectsEvent::class, function (PreInsertObjectsEvent $event) use (&$called, $pager, $objectPersisterMock, $objects, $options): void {
             $called = true;
 
             $this->assertInstanceOf(PreInsertObjectsEvent::class, $event);
@@ -158,7 +158,7 @@ class InPlacePagerPersisterTest extends TestCase
         $pager = $this->createPager($objects);
 
         $called = false;
-        $dispatcher->addListener(PostInsertObjectsEvent::class, function ($event) use (&$called, $pager, $objectPersisterMock, $objects, $options): void {
+        $dispatcher->addListener(PostInsertObjectsEvent::class, function (PostInsertObjectsEvent $event) use (&$called, $pager, $objectPersisterMock, $objects, $options): void {
             $called = true;
 
             $this->assertInstanceOf(PostInsertObjectsEvent::class, $event);
@@ -192,7 +192,7 @@ class InPlacePagerPersisterTest extends TestCase
         $pager = $this->createPager($objects);
 
         $called = false;
-        $dispatcher->addListener(PostPersistEvent::class, function ($event) use (&$called, $pager, $objectPersisterMock, $options): void {
+        $dispatcher->addListener(PostPersistEvent::class, function (PostPersistEvent $event) use (&$called, $pager, $objectPersisterMock, $options): void {
             $called = true;
 
             $this->assertInstanceOf(PostPersistEvent::class, $event);
@@ -318,7 +318,7 @@ class InPlacePagerPersisterTest extends TestCase
         $pager = $this->createPager($objects);
 
         $called = false;
-        $dispatcher->addListener(OnExceptionEvent::class, function ($event) use (&$called, $pager, $objectPersisterMock, $exception, $options): void {
+        $dispatcher->addListener(OnExceptionEvent::class, function (OnExceptionEvent $event) use (&$called, $pager, $objectPersisterMock, $exception, $options): void {
             $called = true;
 
             $this->assertInstanceOf(OnExceptionEvent::class, $event);

--- a/tests/Unit/Persister/Listener/FilterObjectsListenerTest.php
+++ b/tests/Unit/Persister/Listener/FilterObjectsListenerTest.php
@@ -24,24 +24,24 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
  */
 class FilterObjectsListenerTest extends TestCase
 {
-    public function testShouldImplementEventSubscriberInterface()
+    public function testShouldImplementEventSubscriberInterface(): void
     {
         $rc = new \ReflectionClass(FilterObjectsListener::class);
 
         $this->assertTrue($rc->implementsInterface(EventSubscriberInterface::class));
     }
 
-    public function testShouldSubscribeOnPreInsertObjectsEvent()
+    public function testShouldSubscribeOnPreInsertObjectsEvent(): void
     {
         $this->assertSame([PreInsertObjectsEvent::class => 'filterObjects'], FilterObjectsListener::getSubscribedEvents());
     }
 
-    public function testCouldBeConstructedWithIndexableAsFirstArgument()
+    public function testCouldBeConstructedWithIndexableAsFirstArgument(): void
     {
         new FilterObjectsListener($this->createIndexableMock());
     }
 
-    public function testShouldFilterOutEverything()
+    public function testShouldFilterOutEverything(): void
     {
         $objects = [new \stdClass(), new \stdClass(), new \stdClass()];
 
@@ -71,7 +71,7 @@ class FilterObjectsListenerTest extends TestCase
         $this->assertEmpty($event->getObjects());
     }
 
-    public function testShouldFilterSecondObject()
+    public function testShouldFilterSecondObject(): void
     {
         $objects = [new \stdClass(), new \stdClass(), new \stdClass()];
 
@@ -101,7 +101,7 @@ class FilterObjectsListenerTest extends TestCase
         $this->assertSame([$objects[0], $objects[2]], $event->getObjects());
     }
 
-    public function testShouldSkipIndexableCheckIfOptionTrue()
+    public function testShouldSkipIndexableCheckIfOptionTrue(): void
     {
         $objects = [new \stdClass(), new \stdClass(), new \stdClass()];
 
@@ -128,7 +128,7 @@ class FilterObjectsListenerTest extends TestCase
     /**
      * @return ObjectPersisterInterface|\PHPUnit\Framework\MockObject\MockObject
      */
-    private function createObjectPersisterMock()
+    private function createObjectPersisterMock(): \PHPUnit\Framework\MockObject\MockObject
     {
         return $this->createMock(ObjectPersisterInterface::class);
     }
@@ -136,7 +136,7 @@ class FilterObjectsListenerTest extends TestCase
     /**
      * @return PagerInterface|\PHPUnit\Framework\MockObject\MockObject
      */
-    private function createPagerMock()
+    private function createPagerMock(): \PHPUnit\Framework\MockObject\MockObject
     {
         return $this->createMock(PagerInterface::class);
     }
@@ -144,7 +144,7 @@ class FilterObjectsListenerTest extends TestCase
     /**
      * @return IndexableInterface|\PHPUnit\Framework\MockObject\MockObject
      */
-    private function createIndexableMock()
+    private function createIndexableMock(): \PHPUnit\Framework\MockObject\MockObject
     {
         return $this->createMock(IndexableInterface::class);
     }

--- a/tests/Unit/Persister/ObjectPersisterTest.php
+++ b/tests/Unit/Persister/ObjectPersisterTest.php
@@ -32,7 +32,7 @@ class InvalidObjectPersister extends ObjectPersister
  */
 class ObjectPersisterTest extends TestCase
 {
-    public function testThatCanReplaceObject()
+    public function testThatCanReplaceObject(): void
     {
         $transformer = $this->getTransformer();
 
@@ -47,7 +47,7 @@ class ObjectPersisterTest extends TestCase
         $objectPersister->replaceOne(new POPO());
     }
 
-    public function testThatErrorIsHandledWhenCannotReplaceObject()
+    public function testThatErrorIsHandledWhenCannotReplaceObject(): void
     {
         $transformer = $this->getTransformer();
 
@@ -67,7 +67,7 @@ class ObjectPersisterTest extends TestCase
         $objectPersister->replaceOne(new POPO());
     }
 
-    public function testThatCanInsertObject()
+    public function testThatCanInsertObject(): void
     {
         $transformer = $this->getTransformer();
 
@@ -85,7 +85,7 @@ class ObjectPersisterTest extends TestCase
         $objectPersister->insertOne(new POPO());
     }
 
-    public function testThatErrorIsHandledWhenCannotInsertObject()
+    public function testThatErrorIsHandledWhenCannotInsertObject(): void
     {
         $transformer = $this->getTransformer();
 
@@ -105,7 +105,7 @@ class ObjectPersisterTest extends TestCase
         $objectPersister->insertOne(new POPO());
     }
 
-    public function testThatCanDeleteObject()
+    public function testThatCanDeleteObject(): void
     {
         $transformer = $this->getTransformer();
 
@@ -123,7 +123,7 @@ class ObjectPersisterTest extends TestCase
         $objectPersister->deleteOne(new POPO());
     }
 
-    public function testThatErrorIsHandledWhenCannotDeleteObject()
+    public function testThatErrorIsHandledWhenCannotDeleteObject(): void
     {
         $transformer = $this->getTransformer();
 
@@ -143,7 +143,7 @@ class ObjectPersisterTest extends TestCase
         $objectPersister->deleteOne(new POPO());
     }
 
-    public function testThatCanInsertManyObjects()
+    public function testThatCanInsertManyObjects(): void
     {
         $transformer = $this->getTransformer();
 
@@ -164,7 +164,7 @@ class ObjectPersisterTest extends TestCase
         $objectPersister->insertMany([new POPO(), new POPO()]);
     }
 
-    public function testThatErrorIsHandledWhenCannotInsertManyObject()
+    public function testThatErrorIsHandledWhenCannotInsertManyObject(): void
     {
         $transformer = $this->getTransformer();
 
@@ -187,10 +187,7 @@ class ObjectPersisterTest extends TestCase
         $objectPersister->insertMany([new POPO(), new POPO()]);
     }
 
-    /**
-     * @return ModelToElasticaAutoTransformer
-     */
-    private function getTransformer()
+    private function getTransformer(): ModelToElasticaAutoTransformer
     {
         $transformer = new ModelToElasticaAutoTransformer();
         $transformer->setPropertyAccessor(PropertyAccess::createPropertyAccessor());

--- a/tests/Unit/Persister/ObjectSerializerPersisterTest.php
+++ b/tests/Unit/Persister/ObjectSerializerPersisterTest.php
@@ -24,7 +24,7 @@ use Symfony\Component\PropertyAccess\PropertyAccess;
  */
 class ObjectSerializerPersisterTest extends TestCase
 {
-    public function testThatCanReplaceObject()
+    public function testThatCanReplaceObject(): void
     {
         $transformer = $this->getTransformer();
 
@@ -40,7 +40,7 @@ class ObjectSerializerPersisterTest extends TestCase
         $objectPersister->replaceOne(new POPO());
     }
 
-    public function testThatCanInsertObject()
+    public function testThatCanInsertObject(): void
     {
         $transformer = $this->getTransformer();
 
@@ -59,7 +59,7 @@ class ObjectSerializerPersisterTest extends TestCase
         $objectPersister->insertOne(new POPO());
     }
 
-    public function testThatCanDeleteObject()
+    public function testThatCanDeleteObject(): void
     {
         $transformer = $this->getTransformer();
 
@@ -78,7 +78,7 @@ class ObjectSerializerPersisterTest extends TestCase
         $objectPersister->deleteOne(new POPO());
     }
 
-    public function testThatCanInsertManyObjects()
+    public function testThatCanInsertManyObjects(): void
     {
         $transformer = $this->getTransformer();
 
@@ -97,10 +97,7 @@ class ObjectSerializerPersisterTest extends TestCase
         $objectPersister->insertMany([new POPO(), new POPO()]);
     }
 
-    /**
-     * @return ModelToElasticaIdentifierTransformer
-     */
-    private function getTransformer()
+    private function getTransformer(): ModelToElasticaIdentifierTransformer
     {
         $transformer = new ModelToElasticaIdentifierTransformer();
         $transformer->setPropertyAccessor(PropertyAccess::createPropertyAccessor());

--- a/tests/Unit/Persister/PagerPersisterRegistryTest.php
+++ b/tests/Unit/Persister/PagerPersisterRegistryTest.php
@@ -21,14 +21,14 @@ use Symfony\Component\DependencyInjection\ServiceLocator;
  */
 class PagerPersisterRegistryTest extends TestCase
 {
-    public function testShouldBeFinal()
+    public function testShouldBeFinal(): void
     {
         $rc = new \ReflectionClass(PagerPersisterRegistry::class);
 
         $this->assertTrue($rc->isFinal());
     }
 
-    public function testThrowsIfThereIsNoSuchEntryInNameToServiceIdMap()
+    public function testThrowsIfThereIsNoSuchEntryInNameToServiceIdMap(): void
     {
         $serviceLocator = $this->createMock(ServiceLocator::class);
         $serviceLocator->expects($this->once())->method('has')->with('the_name')->willReturn(false);
@@ -39,7 +39,7 @@ class PagerPersisterRegistryTest extends TestCase
         (new PagerPersisterRegistry($serviceLocator))->getPagerPersister('the_name');
     }
 
-    public function testThrowsIfRelatedServiceDoesNotImplementPagerPersisterInterface()
+    public function testThrowsIfRelatedServiceDoesNotImplementPagerPersisterInterface(): void
     {
         $serviceLocator = $this->createMock(ServiceLocator::class);
         $serviceLocator->expects($this->once())->method('has')->with('the_name')->willReturn(true);
@@ -47,16 +47,12 @@ class PagerPersisterRegistryTest extends TestCase
 
         $this->expectException(\TypeError::class);
 
-        if (\PHP_VERSION_ID >= 80000) {
-            $this->expectExceptionMessage('FOS\ElasticaBundle\Persister\PagerPersisterRegistry::getPagerPersister(): Return value must be of type FOS\ElasticaBundle\Persister\PagerPersisterInterface, stdClass returned');
-        } else {
-            $this->expectExceptionMessage('Return value of FOS\ElasticaBundle\Persister\PagerPersisterRegistry::getPagerPersister() must implement interface FOS\ElasticaBundle\Persister\PagerPersisterInterface, instance of stdClass returned');
-        }
+        $this->expectExceptionMessage('FOS\ElasticaBundle\Persister\PagerPersisterRegistry::getPagerPersister(): Return value must be of type FOS\ElasticaBundle\Persister\PagerPersisterInterface, stdClass returned');
 
         (new PagerPersisterRegistry($serviceLocator))->getPagerPersister('the_name');
     }
 
-    public function testShouldReturnPagerPersisterByGivenName()
+    public function testShouldReturnPagerPersisterByGivenName(): void
     {
         $pagerPersisterMock = $this->createPagerPersisterMock();
 
@@ -74,7 +70,7 @@ class PagerPersisterRegistryTest extends TestCase
     /**
      * @return PagerPersisterInterface|\PHPUnit\Framework\MockObject\MockObject
      */
-    private function createPagerPersisterMock()
+    private function createPagerPersisterMock(): \PHPUnit\Framework\MockObject\MockObject
     {
         return $this->createMock(PagerPersisterInterface::class);
     }

--- a/tests/Unit/ProphecyTrait.php
+++ b/tests/Unit/ProphecyTrait.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * This file is part of the FOSElasticaBundle package.
  *

--- a/tests/Unit/Provider/IndexableTest.php
+++ b/tests/Unit/Provider/IndexableTest.php
@@ -69,7 +69,7 @@ class IndexableTest extends TestCase
             ['isIndexable', false],
             [[new IndexableDecider(), 'isIndexable'], true],
             [new IndexableDecider(), true],
-            [fn (Entity $entity) => $entity->maybeIndex(), true],
+            [fn (Entity $entity): bool => $entity->maybeIndex(), true],
             ['entity.maybeIndex()', true],
             ['!object.isIndexable() && entity.property == "abc"', true],
             ['entity.property != "abc"', false],
@@ -106,7 +106,7 @@ class IndexableDecider
         return !$entity->isIndexable();
     }
 
-    protected function internalMethod()
+    protected function internalMethod(): void
     {
     }
 }

--- a/tests/Unit/Provider/IndexableTest.php
+++ b/tests/Unit/Provider/IndexableTest.php
@@ -19,7 +19,7 @@ use PHPUnit\Framework\TestCase;
  */
 class IndexableTest extends TestCase
 {
-    public function testIndexableUnknown()
+    public function testIndexableUnknown(): void
     {
         $indexable = new Indexable([]);
         $index = $indexable->isObjectIndexable('index', new Entity());
@@ -30,7 +30,7 @@ class IndexableTest extends TestCase
     /**
      * @dataProvider provideIsIndexableCallbacks
      */
-    public function testValidIndexableCallbacks($callback, $return)
+    public function testValidIndexableCallbacks(string|IndexableDecider|\Closure|array $callback, bool $return): void
     {
         $indexable = new Indexable([
             'index' => $callback,
@@ -43,7 +43,7 @@ class IndexableTest extends TestCase
     /**
      * @dataProvider provideInvalidIsIndexableCallbacks
      */
-    public function testInvalidIsIndexableCallbacks($callback)
+    public function testInvalidIsIndexableCallbacks(string|int|array $callback): void
     {
         $indexable = new Indexable([
             'index' => $callback,
@@ -53,7 +53,7 @@ class IndexableTest extends TestCase
         $indexable->isObjectIndexable('index', new Entity());
     }
 
-    public function provideInvalidIsIndexableCallbacks()
+    public function provideInvalidIsIndexableCallbacks(): array
     {
         return [
             ['nonexistentEntityMethod'],
@@ -63,15 +63,13 @@ class IndexableTest extends TestCase
         ];
     }
 
-    public function provideIsIndexableCallbacks()
+    public function provideIsIndexableCallbacks(): array
     {
         return [
             ['isIndexable', false],
             [[new IndexableDecider(), 'isIndexable'], true],
             [new IndexableDecider(), true],
-            [function (Entity $entity) {
-                return $entity->maybeIndex();
-            }, true],
+            [fn (Entity $entity) => $entity->maybeIndex(), true],
             ['entity.maybeIndex()', true],
             ['!object.isIndexable() && entity.property == "abc"', true],
             ['entity.property != "abc"', false],
@@ -85,12 +83,12 @@ class Entity
 {
     public $property = 'abc';
 
-    public function isIndexable()
+    public function isIndexable(): bool
     {
         return false;
     }
 
-    public function maybeIndex()
+    public function maybeIndex(): bool
     {
         return true;
     }
@@ -98,12 +96,12 @@ class Entity
 
 class IndexableDecider
 {
-    public function __invoke($object)
+    public function __invoke($object): bool
     {
         return true;
     }
 
-    public function isIndexable(Entity $entity)
+    public function isIndexable(Entity $entity): bool
     {
         return !$entity->isIndexable();
     }

--- a/tests/Unit/Provider/PagerProviderRegistryTest.php
+++ b/tests/Unit/Provider/PagerProviderRegistryTest.php
@@ -21,35 +21,31 @@ use Symfony\Component\DependencyInjection\ServiceLocator;
  */
 class PagerProviderRegistryTest extends TestCase
 {
-    public function testGetProviders()
+    public function testGetProviders(): void
     {
         $service = $this->createMock(PagerProviderInterface::class);
 
         $providers = new ServiceLocator([
-            'index' => static function () use ($service) {
-                return $service;
-            },
+            'index' => static fn () => $service,
         ]);
 
         $registry = new PagerProviderRegistry($providers);
         $this->assertEquals(['index' => $service], $registry->getProviders());
     }
 
-    public function testGetProviderValid()
+    public function testGetProviderValid(): void
     {
         $service = $this->createMock(PagerProviderInterface::class);
 
         $providers = new ServiceLocator([
-            'index' => static function () use ($service) {
-                return $service;
-            },
+            'index' => static fn () => $service,
         ]);
 
         $registry = new PagerProviderRegistry($providers);
         $this->assertEquals($service, $registry->getProvider('index'));
     }
 
-    public function testGetProviderInvalid()
+    public function testGetProviderInvalid(): void
     {
         $registry = new PagerProviderRegistry(new ServiceLocator([]));
         $this->expectException(\InvalidArgumentException::class);

--- a/tests/Unit/Provider/PagerProviderRegistryTest.php
+++ b/tests/Unit/Provider/PagerProviderRegistryTest.php
@@ -26,7 +26,7 @@ class PagerProviderRegistryTest extends TestCase
         $service = $this->createMock(PagerProviderInterface::class);
 
         $providers = new ServiceLocator([
-            'index' => static fn () => $service,
+            'index' => static fn (): \PHPUnit\Framework\MockObject\MockObject => $service,
         ]);
 
         $registry = new PagerProviderRegistry($providers);
@@ -38,7 +38,7 @@ class PagerProviderRegistryTest extends TestCase
         $service = $this->createMock(PagerProviderInterface::class);
 
         $providers = new ServiceLocator([
-            'index' => static fn () => $service,
+            'index' => static fn (): \PHPUnit\Framework\MockObject\MockObject => $service,
         ]);
 
         $registry = new PagerProviderRegistry($providers);

--- a/tests/Unit/RepositoryTest.php
+++ b/tests/Unit/RepositoryTest.php
@@ -77,7 +77,7 @@ class RepositoryTest extends TestCase
         $repository->findHybrid($testQuery);
     }
 
-    private function mockTransformedFinder(string $name, array $arguments)
+    private function mockTransformedFinder(string $name, array $arguments): \PHPUnit\Framework\MockObject\MockObject
     {
         $finderMock = $this->createMock(TransformedFinder::class);
         $finderMock->expects($this->once())

--- a/tests/Unit/RepositoryTest.php
+++ b/tests/Unit/RepositoryTest.php
@@ -22,7 +22,7 @@ use PHPUnit\Framework\TestCase;
  */
 class RepositoryTest extends TestCase
 {
-    public function testFind()
+    public function testFind(): void
     {
         $testQuery = 'Test Query';
 
@@ -31,7 +31,7 @@ class RepositoryTest extends TestCase
         $repository->find($testQuery);
     }
 
-    public function testFindWithLimit()
+    public function testFindWithLimit(): void
     {
         $testQuery = 'Test Query';
         $testLimit = 20;
@@ -41,7 +41,7 @@ class RepositoryTest extends TestCase
         $repository->find($testQuery, $testLimit);
     }
 
-    public function testFindPaginated()
+    public function testFindPaginated(): void
     {
         $testQuery = 'Test Query';
 
@@ -50,7 +50,7 @@ class RepositoryTest extends TestCase
         $repository->findPaginated($testQuery);
     }
 
-    public function testCreatePagitatorAdapter()
+    public function testCreatePagitatorAdapter(): void
     {
         $testQuery = 'Test Query';
 
@@ -59,7 +59,7 @@ class RepositoryTest extends TestCase
         $repository->createPaginatorAdapter($testQuery);
     }
 
-    public function testCreateHybridPaginatorAdapter()
+    public function testCreateHybridPaginatorAdapter(): void
     {
         $testQuery = 'Test Query';
 
@@ -68,7 +68,7 @@ class RepositoryTest extends TestCase
         $repository->createHybridPaginatorAdapter($testQuery);
     }
 
-    public function testFindHybrid()
+    public function testFindHybrid(): void
     {
         $testQuery = 'Test Query';
 
@@ -77,7 +77,7 @@ class RepositoryTest extends TestCase
         $repository->findHybrid($testQuery);
     }
 
-    private function mockTransformedFinder($name, $arguments)
+    private function mockTransformedFinder(string $name, array $arguments)
     {
         $finderMock = $this->createMock(TransformedFinder::class);
         $finderMock->expects($this->once())

--- a/tests/Unit/Serializer/CallbackTest.php
+++ b/tests/Unit/Serializer/CallbackTest.php
@@ -54,7 +54,7 @@ class CallbackTest extends TestCase
 
 class FakeSerializer
 {
-    public function serialize()
+    public function serialize(): void
     {
     }
 }

--- a/tests/Unit/Serializer/CallbackTest.php
+++ b/tests/Unit/Serializer/CallbackTest.php
@@ -20,7 +20,7 @@ use Symfony\Component\Serializer\SerializerInterface;
  */
 class CallbackTest extends TestCase
 {
-    public function testSerializerMustHaveSerializeMethod()
+    public function testSerializerMustHaveSerializeMethod(): void
     {
         $callback = new Callback();
         $this->expectException(\RuntimeException::class);
@@ -28,7 +28,7 @@ class CallbackTest extends TestCase
         $callback->setSerializer(new \stdClass());
     }
 
-    public function testSetGroupsWorksWithValidSerializer()
+    public function testSetGroupsWorksWithValidSerializer(): void
     {
         $callback = new Callback();
         $serializer = $this->createMock(SerializerInterface::class);
@@ -37,7 +37,7 @@ class CallbackTest extends TestCase
         $callback->setGroups(['foo']);
     }
 
-    public function testSetGroupsFailsWithInvalidSerializer()
+    public function testSetGroupsFailsWithInvalidSerializer(): void
     {
         $callback = new Callback();
         $serializer = $this->createMock(FakeSerializer::class);

--- a/tests/Unit/Subscriber/PaginateElasticaQuerySubscriberTest.php
+++ b/tests/Unit/Subscriber/PaginateElasticaQuerySubscriberTest.php
@@ -12,8 +12,8 @@
 namespace FOS\ElasticaBundle\Tests\Unit\Subscriber;
 
 use Elastica\Query;
-use FOS\ElasticaBundle\Paginator\PartialResultsInterface;
 use FOS\ElasticaBundle\Paginator\RawPaginatorAdapter;
+use FOS\ElasticaBundle\Paginator\RawPartialResults;
 use FOS\ElasticaBundle\Subscriber\PaginateElasticaQuerySubscriber;
 use Knp\Component\Pager\ArgumentAccess\ArgumentAccessInterface;
 use Knp\Component\Pager\Event\ItemsEvent;
@@ -26,7 +26,7 @@ use Symfony\Component\HttpFoundation\RequestStack;
  */
 class PaginateElasticaQuerySubscriberTest extends TestCase
 {
-    public function testShouldDoNothingIfSortParamIsEmpty()
+    public function testShouldDoNothingIfSortParamIsEmpty(): void
     {
         $subscriber = new PaginateElasticaQuerySubscriber($this->getRequestStack(new Request()));
 
@@ -44,7 +44,7 @@ class PaginateElasticaQuerySubscriberTest extends TestCase
         $subscriber->items($event);
     }
 
-    public function sortCases()
+    public function sortCases(): array
     {
         $tests = [];
 
@@ -75,7 +75,7 @@ class PaginateElasticaQuerySubscriberTest extends TestCase
     /**
      * @dataProvider sortCases
      */
-    public function testShouldSort(array $expected, Request $request)
+    public function testShouldSort(array $expected, Request $request): void
     {
         $subscriber = new PaginateElasticaQuerySubscriber($this->getRequestStack($request));
 
@@ -102,7 +102,7 @@ class PaginateElasticaQuerySubscriberTest extends TestCase
         $this->assertSame($expected, $query->getParam('sort'));
     }
 
-    public function testShouldThrowIfFieldIsNotWhitelisted()
+    public function testShouldThrowIfFieldIsNotWhitelisted(): void
     {
         $subscriber = new PaginateElasticaQuerySubscriber($this->getRequestStack(new Request(['ord' => 'owner'])));
 
@@ -129,7 +129,7 @@ class PaginateElasticaQuerySubscriberTest extends TestCase
         $subscriber->items($event);
     }
 
-    public function testShouldAddNestedPath()
+    public function testShouldAddNestedPath(): void
     {
         $subscriber = new PaginateElasticaQuerySubscriber($this->getRequestStack(new Request(['ord' => 'owner.name'])));
 
@@ -161,7 +161,7 @@ class PaginateElasticaQuerySubscriberTest extends TestCase
         ], $query->getParam('sort'));
     }
 
-    public function testShouldInvokeCallableNestedPath()
+    public function testShouldInvokeCallableNestedPath(): void
     {
         $subscriber = new PaginateElasticaQuerySubscriber($this->getRequestStack(new Request(['ord' => 'owner.name'])));
 
@@ -181,7 +181,7 @@ class PaginateElasticaQuerySubscriberTest extends TestCase
             'defaultSortFieldName' => 'createdAt',
             'sortFieldParameterName' => 'ord',
             'sortDirectionParameterName' => 'az',
-            'sortNestedPath' => function ($sortField) {
+            'sortNestedPath' => function ($sortField): string {
                 $this->assertSame('owner.name', $sortField);
 
                 return 'owner';
@@ -197,7 +197,7 @@ class PaginateElasticaQuerySubscriberTest extends TestCase
         ], $query->getParam('sort'));
     }
 
-    public function testShouldAddNestedFilter()
+    public function testShouldAddNestedFilter(): void
     {
         $subscriber = new PaginateElasticaQuerySubscriber($this->getRequestStack(new Request(['ord' => 'owner.name'])));
 
@@ -240,7 +240,7 @@ class PaginateElasticaQuerySubscriberTest extends TestCase
         ], $query->toArray());
     }
 
-    public function testShouldInvokeNestedFilterCallable()
+    public function testShouldInvokeNestedFilterCallable(): void
     {
         $subscriber = new PaginateElasticaQuerySubscriber($this->getRequestStack(new Request(['ord' => 'owner.name'])));
 
@@ -261,7 +261,7 @@ class PaginateElasticaQuerySubscriberTest extends TestCase
             'sortFieldParameterName' => 'ord',
             'sortDirectionParameterName' => 'az',
             'sortNestedPath' => 'owner',
-            'sortNestedFilter' => function ($sortField) {
+            'sortNestedFilter' => function ($sortField): Query\Term {
                 $this->assertSame('owner.name', $sortField);
 
                 return new Query\Term(['enabled' => ['value' => true]]);
@@ -287,7 +287,7 @@ class PaginateElasticaQuerySubscriberTest extends TestCase
         ], $query->toArray());
     }
 
-    public function testShouldDoNothingIfNoRequest()
+    public function testShouldDoNothingIfNoRequest(): void
     {
         $subscriber = new PaginateElasticaQuerySubscriber($this->getRequestStack());
 
@@ -305,21 +305,21 @@ class PaginateElasticaQuerySubscriberTest extends TestCase
         $subscriber->items($event);
     }
 
-    protected function getAdapterMock()
+    protected function getAdapterMock(): \PHPUnit\Framework\MockObject\MockObject
     {
         return $this->createMock(RawPaginatorAdapter::class);
     }
 
-    protected function getResultSetMock()
+    protected function getResultSetMock(): \PHPUnit\Framework\MockObject\MockObject
     {
-        return $this->createMock(PartialResultsInterface::class);
+        return $this->createMock(RawPartialResults::class);
     }
 
-    private function getRequestStack(?Request $request = null)
+    private function getRequestStack(?Request $request = null): RequestStack
     {
         $stack = new RequestStack();
 
-        if ($request) {
+        if ($request instanceof Request) {
             $stack->push($request);
         }
 

--- a/tests/Unit/Subscriber/PaginateElasticaQuerySubscriberTest.php
+++ b/tests/Unit/Subscriber/PaginateElasticaQuerySubscriberTest.php
@@ -181,7 +181,7 @@ class PaginateElasticaQuerySubscriberTest extends TestCase
             'defaultSortFieldName' => 'createdAt',
             'sortFieldParameterName' => 'ord',
             'sortDirectionParameterName' => 'az',
-            'sortNestedPath' => function ($sortField): string {
+            'sortNestedPath' => function (string $sortField): string {
                 $this->assertSame('owner.name', $sortField);
 
                 return 'owner';
@@ -261,7 +261,7 @@ class PaginateElasticaQuerySubscriberTest extends TestCase
             'sortFieldParameterName' => 'ord',
             'sortDirectionParameterName' => 'az',
             'sortNestedPath' => 'owner',
-            'sortNestedFilter' => function ($sortField): Query\Term {
+            'sortNestedFilter' => function (string $sortField): Query\Term {
                 $this->assertSame('owner.name', $sortField);
 
                 return new Query\Term(['enabled' => ['value' => true]]);

--- a/tests/Unit/Transformer/AbstractElasticaToModelTransformerTest.php
+++ b/tests/Unit/Transformer/AbstractElasticaToModelTransformerTest.php
@@ -28,7 +28,7 @@ class AbstractElasticaToModelTransformerTest extends UnitTestHelper
         $this->assertEquals($propertyAccessor, $this->getProtectedProperty($transformer, 'propertyAccessor'));
     }
 
-    protected function mockAbstractElasticaToModelTransformer()
+    protected function mockAbstractElasticaToModelTransformer(): \PHPUnit\Framework\MockObject\MockObject
     {
         return $this
             ->getMockBuilder(AbstractElasticaToModelTransformer::class)

--- a/tests/Unit/Transformer/AbstractElasticaToModelTransformerTest.php
+++ b/tests/Unit/Transformer/AbstractElasticaToModelTransformerTest.php
@@ -20,7 +20,7 @@ use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
  */
 class AbstractElasticaToModelTransformerTest extends UnitTestHelper
 {
-    public function testSetPropertyAccessor()
+    public function testSetPropertyAccessor(): void
     {
         $propertyAccessor = $this->mockPropertyAccesor();
         $transformer = $this->mockAbstractElasticaToModelTransformer();
@@ -36,7 +36,7 @@ class AbstractElasticaToModelTransformerTest extends UnitTestHelper
         ;
     }
 
-    protected function mockPropertyAccesor()
+    protected function mockPropertyAccesor(): \PHPUnit\Framework\MockObject\MockObject
     {
         return $this->createMock(PropertyAccessorInterface::class);
     }

--- a/tests/Unit/Transformer/ModelToElasticaAutoTransformerTest.php
+++ b/tests/Unit/Transformer/ModelToElasticaAutoTransformerTest.php
@@ -28,16 +28,20 @@ class POPO3
     public $float = 7.2;
     public $bool = true;
     public $falseBool = false;
+    /**
+     * @var \DateTime
+     */
     public $date;
+    /**
+     * @var \DateInterval
+     */
     public $duration;
     public $nullValue;
+    /**
+     * @var \SplFileInfo
+     */
     public $file;
     public $fileContents;
-
-    /**
-     * test non-accessible private property.
-     */
-    private $desc = 'desc';
 
     public function __construct()
     {
@@ -57,7 +61,7 @@ class POPO3
         return $this->name;
     }
 
-    public function getIterator()
+    public function getIterator(): \ArrayIterator
     {
         $iterator = new \ArrayIterator();
         $iterator->append('value1');
@@ -65,7 +69,7 @@ class POPO3
         return $iterator;
     }
 
-    public function getArray()
+    public function getArray(): array
     {
         return [
             'key1' => 'value1',
@@ -73,7 +77,7 @@ class POPO3
         ];
     }
 
-    public function getMultiArray()
+    public function getMultiArray(): array
     {
         return [
             'key1' => 'value1',
@@ -121,7 +125,7 @@ class POPO3
         return $this->fileContents;
     }
 
-    public function getSub()
+    public function getSub(): array
     {
         return [
             (object) ['foo' => 'foo', 'bar' => 'foo', 'id' => 1],
@@ -129,12 +133,12 @@ class POPO3
         ];
     }
 
-    public function getObj()
+    public function getObj(): array
     {
         return ['foo' => 'foo', 'bar' => 'foo', 'id' => 1];
     }
 
-    public function getNestedObject()
+    public function getNestedObject(): array
     {
         return ['key1' => (object) ['id' => 1, 'key1sub1' => 'value1sub1', 'key1sub2' => 'value1sub2']];
     }
@@ -154,7 +158,7 @@ class POPO3
         return (object) ['foo' => 'foo', 'bar' => 'foo'];
     }
 
-    public function getSubWithoutIdentifier()
+    public function getSubWithoutIdentifier(): array
     {
         return [
             (object) ['foo' => 'foo', 'bar' => 'foo'],
@@ -163,13 +167,13 @@ class POPO3
     }
 }
 
-class CastableObject
+class CastableObject implements \Stringable
 {
     public $foo;
 
-    public function __toString()
+    public function __toString(): string
     {
-        return $this->foo;
+        return (string) $this->foo;
     }
 }
 
@@ -178,7 +182,7 @@ class CastableObject
  */
 class ModelToElasticaAutoTransformerTest extends TestCase
 {
-    public function testTransformerDispatches()
+    public function testTransformerDispatches(): void
     {
         $dispatcher = $this->createMock(EventDispatcherInterface::class);
 
@@ -198,7 +202,7 @@ class ModelToElasticaAutoTransformerTest extends TestCase
         $transformer->transform(new POPO3(), []);
     }
 
-    public function testPropertyPath()
+    public function testPropertyPath(): void
     {
         $transformer = $this->getTransformer();
 
@@ -212,7 +216,7 @@ class ModelToElasticaAutoTransformerTest extends TestCase
         $this->assertSame('someName', $document->get('realName'));
     }
 
-    public function testThatCanTransformObject()
+    public function testThatCanTransformObject(): void
     {
         $transformer = $this->getTransformer();
         $document = $transformer->transform(new POPO3(), ['name' => []]);
@@ -223,7 +227,7 @@ class ModelToElasticaAutoTransformerTest extends TestCase
         $this->assertSame('someName', $data['name']);
     }
 
-    public function testThatCanTransformObjectWithCorrectTypes()
+    public function testThatCanTransformObjectWithCorrectTypes(): void
     {
         $transformer = $this->getTransformer();
         $document = $transformer->transform(
@@ -250,7 +254,7 @@ class ModelToElasticaAutoTransformerTest extends TestCase
         $this->assertSame('P1Y1M1DT1H1M1S', $data['duration']);
     }
 
-    public function testThatCanTransformObjectWithIteratorValue()
+    public function testThatCanTransformObjectWithIteratorValue(): void
     {
         $transformer = $this->getTransformer();
         $document = $transformer->transform(new POPO3(), ['iterator' => []]);
@@ -259,7 +263,7 @@ class ModelToElasticaAutoTransformerTest extends TestCase
         $this->assertSame(['value1'], $data['iterator']);
     }
 
-    public function testThatCanTransformObjectWithArrayValue()
+    public function testThatCanTransformObjectWithArrayValue(): void
     {
         $transformer = $this->getTransformer();
         $document = $transformer->transform(new POPO3(), ['array' => []]);
@@ -274,7 +278,7 @@ class ModelToElasticaAutoTransformerTest extends TestCase
         );
     }
 
-    public function testThatCanTransformObjectWithMultiDimensionalArrayValue()
+    public function testThatCanTransformObjectWithMultiDimensionalArrayValue(): void
     {
         $transformer = $this->getTransformer();
         $document = $transformer->transform(new POPO3(), ['multiArray' => []]);
@@ -291,7 +295,7 @@ class ModelToElasticaAutoTransformerTest extends TestCase
         );
     }
 
-    public function testThatNullValuesAreNotFilteredOut()
+    public function testThatNullValuesAreNotFilteredOut(): void
     {
         $transformer = $this->getTransformer();
         $document = $transformer->transform(new POPO3(), ['nullValue' => []]);
@@ -300,7 +304,7 @@ class ModelToElasticaAutoTransformerTest extends TestCase
         $this->assertArrayHasKey('nullValue', $data);
     }
 
-    public function testThatCannotTransformObjectWhenGetterDoesNotExistForPrivateMethod()
+    public function testThatCannotTransformObjectWhenGetterDoesNotExistForPrivateMethod(): void
     {
         $transformer = $this->getTransformer();
 
@@ -308,7 +312,7 @@ class ModelToElasticaAutoTransformerTest extends TestCase
         $transformer->transform(new POPO3(), ['desc' => []]);
     }
 
-    public function testFileAddedForAttachmentMapping()
+    public function testFileAddedForAttachmentMapping(): void
     {
         $transformer = $this->getTransformer();
         $document = $transformer->transform(new POPO3(), ['file' => ['type' => 'attachment']]);
@@ -317,7 +321,7 @@ class ModelToElasticaAutoTransformerTest extends TestCase
         $this->assertSame(\base64_encode(\file_get_contents(__DIR__.'/fixtures/attachment.odt')), $data['file']);
     }
 
-    public function testFileContentsAddedForAttachmentMapping()
+    public function testFileContentsAddedForAttachmentMapping(): void
     {
         $transformer = $this->getTransformer();
         $document = $transformer->transform(new POPO3(), ['fileContents' => ['type' => 'attachment']]);
@@ -329,7 +333,7 @@ class ModelToElasticaAutoTransformerTest extends TestCase
         );
     }
 
-    public function testNestedMapping()
+    public function testNestedMapping(): void
     {
         $transformer = $this->getTransformer();
         $document = $transformer->transform(new POPO3(), [
@@ -348,7 +352,7 @@ class ModelToElasticaAutoTransformerTest extends TestCase
         ], $data['sub']);
     }
 
-    public function tesObjectMapping()
+    public function tesObjectMapping(): void
     {
         $transformer = $this->getTransformer();
         $document = $transformer->transform(new POPO3(), [
@@ -367,7 +371,7 @@ class ModelToElasticaAutoTransformerTest extends TestCase
         ], $data['sub']);
     }
 
-    public function testObjectDoesNotRequireProperties()
+    public function testObjectDoesNotRequireProperties(): void
     {
         $transformer = $this->getTransformer();
         $document = $transformer->transform(new POPO3(), [
@@ -386,7 +390,7 @@ class ModelToElasticaAutoTransformerTest extends TestCase
         ], $data['obj']);
     }
 
-    public function testObjectsMappingOfAtLeastOneAutoMappedObjectAndAtLeastOneManuallyMappedObject()
+    public function testObjectsMappingOfAtLeastOneAutoMappedObjectAndAtLeastOneManuallyMappedObject(): void
     {
         $transformer = $this->getTransformer();
         $document = $transformer->transform(
@@ -431,7 +435,7 @@ class ModelToElasticaAutoTransformerTest extends TestCase
         );
     }
 
-    public function testThatMappedObjectsDontNeedAnIdentifierField()
+    public function testThatMappedObjectsDontNeedAnIdentifierField(): void
     {
         $transformer = $this->getTransformer();
         $document = $transformer->transform(new POPO3(), [
@@ -453,7 +457,7 @@ class ModelToElasticaAutoTransformerTest extends TestCase
         ], $data['objWithoutIdentifier']);
     }
 
-    public function testThatNestedObjectsDontNeedAnIdentifierField()
+    public function testThatNestedObjectsDontNeedAnIdentifierField(): void
     {
         $transformer = $this->getTransformer();
         $document = $transformer->transform(new POPO3(), [
@@ -475,7 +479,7 @@ class ModelToElasticaAutoTransformerTest extends TestCase
         ], $data['subWithoutIdentifier']);
     }
 
-    public function testNestedTransformHandlesSingleObjects()
+    public function testNestedTransformHandlesSingleObjects(): void
     {
         $transformer = $this->getTransformer();
         $document = $transformer->transform(new POPO3(), [
@@ -489,7 +493,7 @@ class ModelToElasticaAutoTransformerTest extends TestCase
         $this->assertSame('a random name', $data['upper']['name']);
     }
 
-    public function testNestedTransformReturnsAnEmptyArrayForNullValues()
+    public function testNestedTransformReturnsAnEmptyArrayForNullValues(): void
     {
         $transformer = $this->getTransformer();
         $document = $transformer->transform(new POPO3(), [
@@ -507,7 +511,7 @@ class ModelToElasticaAutoTransformerTest extends TestCase
         $this->assertEmpty($data['nullValue']);
     }
 
-    public function testUnmappedFieldValuesAreNormalisedToStrings()
+    public function testUnmappedFieldValuesAreNormalisedToStrings(): void
     {
         $object = new \stdClass();
         $value = new CastableObject();
@@ -523,7 +527,7 @@ class ModelToElasticaAutoTransformerTest extends TestCase
         $this->assertSame('bar', $data['unmappedValue']);
     }
 
-    public function testIdentifierIsCastedToString()
+    public function testIdentifierIsCastedToString(): void
     {
         $idObject = new CastableObject();
         $idObject->foo = '00000000-0000-0000-0000-000000000000';
@@ -556,10 +560,8 @@ class ModelToElasticaAutoTransformerTest extends TestCase
 
     /**
      * @param EventDispatcherInterface|null $dispatcher
-     *
-     * @return ModelToElasticaAutoTransformer
      */
-    private function getTransformer($dispatcher = null)
+    private function getTransformer($dispatcher = null): ModelToElasticaAutoTransformer
     {
         $transformer = new ModelToElasticaAutoTransformer([], $dispatcher);
         $transformer->setPropertyAccessor(PropertyAccess::createPropertyAccessor());

--- a/tests/Unit/Transformer/ModelToElasticaAutoTransformerTest.php
+++ b/tests/Unit/Transformer/ModelToElasticaAutoTransformerTest.php
@@ -51,12 +51,12 @@ class POPO3
         $this->fileContents = \file_get_contents(__DIR__.'/fixtures/attachment.odt');
     }
 
-    public function getId()
+    public function getId(): int
     {
         return $this->id;
     }
 
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
@@ -85,42 +85,42 @@ class POPO3
         ];
     }
 
-    public function getBool()
+    public function getBool(): bool
     {
         return $this->bool;
     }
 
-    public function getFalseBool()
+    public function getFalseBool(): bool
     {
         return $this->falseBool;
     }
 
-    public function getFloat()
+    public function getFloat(): float
     {
         return $this->float;
     }
 
-    public function getDate()
+    public function getDate(): \DateTime
     {
         return $this->date;
     }
 
-    public function getDuration()
+    public function getDuration(): \DateInterval
     {
         return $this->duration;
     }
 
-    public function getNullValue()
+    public function getNullValue(): mixed
     {
         return $this->nullValue;
     }
 
-    public function getFile()
+    public function getFile(): \SplFileInfo
     {
         return $this->file;
     }
 
-    public function getFileContents()
+    public function getFileContents(): string|false
     {
         return $this->fileContents;
     }
@@ -143,17 +143,17 @@ class POPO3
         return ['key1' => (object) ['id' => 1, 'key1sub1' => 'value1sub1', 'key1sub2' => 'value1sub2']];
     }
 
-    public function getUpper()
+    public function getUpper(): object
     {
         return (object) ['id' => 'parent', 'name' => 'a random name'];
     }
 
-    public function getUpperAlias()
+    public function getUpperAlias(): object
     {
         return $this->getUpper();
     }
 
-    public function getObjWithoutIdentifier()
+    public function getObjWithoutIdentifier(): object
     {
         return (object) ['foo' => 'foo', 'bar' => 'foo'];
     }

--- a/tests/Unit/Transformer/ModelToElasticaIdentifierTransformerTest.php
+++ b/tests/Unit/Transformer/ModelToElasticaIdentifierTransformerTest.php
@@ -21,12 +21,12 @@ class POPO4
     protected $id = 123;
     protected $name = 'Name';
 
-    public function getId()
+    public function getId(): int
     {
         return $this->id;
     }
 
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }

--- a/tests/Unit/Transformer/ModelToElasticaIdentifierTransformerTest.php
+++ b/tests/Unit/Transformer/ModelToElasticaIdentifierTransformerTest.php
@@ -37,7 +37,7 @@ class POPO4
  */
 class ModelToElasticaIdentifierTransformerTest extends TestCase
 {
-    public function testGetDocumentWithIdentifierOnly()
+    public function testGetDocumentWithIdentifierOnly(): void
     {
         $transformer = $this->getTransformer();
         $document = $transformer->transform(new POPO4(), []);
@@ -48,7 +48,7 @@ class ModelToElasticaIdentifierTransformerTest extends TestCase
         $this->assertCount(0, $data);
     }
 
-    public function testGetDocumentWithIdentifierOnlyWithFields()
+    public function testGetDocumentWithIdentifierOnlyWithFields(): void
     {
         $transformer = $this->getTransformer();
         $document = $transformer->transform(new POPO4(), ['name' => []]);
@@ -59,10 +59,7 @@ class ModelToElasticaIdentifierTransformerTest extends TestCase
         $this->assertCount(0, $data);
     }
 
-    /**
-     * @return ModelToElasticaIdentifierTransformer
-     */
-    private function getTransformer()
+    private function getTransformer(): ModelToElasticaIdentifierTransformer
     {
         $transformer = new ModelToElasticaIdentifierTransformer();
         $transformer->setPropertyAccessor(PropertyAccess::createPropertyAccessor());

--- a/tests/Unit/UnitTestHelper.php
+++ b/tests/Unit/UnitTestHelper.php
@@ -35,7 +35,7 @@ class UnitTestHelper extends TestCase
         return $reflectionProperty->getValue($object);
     }
 
-    protected function mockElasticaToModelTransformer()
+    protected function mockElasticaToModelTransformer(): \PHPUnit\Framework\MockObject\MockObject
     {
         return $this
             ->getMockBuilder(ElasticaToModelTransformerInterface::class)
@@ -43,7 +43,7 @@ class UnitTestHelper extends TestCase
         ;
     }
 
-    protected function mockSearchable()
+    protected function mockSearchable(): \PHPUnit\Framework\MockObject\MockObject
     {
         return $this
             ->getMockBuilder(SearchableInterface::class)
@@ -51,7 +51,7 @@ class UnitTestHelper extends TestCase
         ;
     }
 
-    protected function mockResultSet()
+    protected function mockResultSet(): \PHPUnit\Framework\MockObject\MockObject
     {
         return $this
             ->getMockBuilder(ResultSet::class)

--- a/tests/Unit/UnitTestHelper.php
+++ b/tests/Unit/UnitTestHelper.php
@@ -27,11 +27,10 @@ class UnitTestHelper extends TestCase
      * @param object $object   instance in which protected value is being modified
      * @param string $property property on instance being modified
      */
-    protected function getProtectedProperty($object, string $property)
+    protected function getProtectedProperty($object, string $property): mixed
     {
         $reflection = new \ReflectionClass($object);
         $reflectionProperty = $reflection->getProperty($property);
-        $reflectionProperty->setAccessible(true);
 
         return $reflectionProperty->getValue($object);
     }


### PR DESCRIPTION
Apply Rector with PHP 8.1 sets plus dead code, code quality, type declarations, privatization, and early return prepared sets.

Main changes:
- Constructor property promotion and readonly properties
- Add missing void/typed return types
- Remove redundant @return/@var phpdocs
- Replace isset() with null comparison on typed properties
- Drop ReflectionProperty::setAccessible() calls (no-op since PHP 8.1)
- Fix incorrect TCallbackInternal type (ExpressionLanguage -> Expression)