### PR TITLE
Fix ProfilerTest with Twig >= 3.10 EscaperRuntime

### DIFF
--- a/tests/Functional/ProfilerTest.php
+++ b/tests/Functional/ProfilerTest.php
@@ -64,7 +64,13 @@ class ProfilerTest extends WebTestCase
 
         $urlGeneratorMock->method('generate')->willReturn('');
         $fragmentHandlerMock->method('render')->willReturn('');
-        $loaderMock->method('load')->willReturn(new HttpKernelRuntime($fragmentHandlerMock));
+        $loaderMock->method('load')->willReturnCallback(static function (string $class) use ($fragmentHandlerMock) {
+            if (HttpKernelRuntime::class === $class) {
+                return new HttpKernelRuntime($fragmentHandlerMock);
+            }
+
+            return null;
+        });
 
         $this->twig->addRuntimeLoader($loaderMock);
     }


### PR DESCRIPTION
The RuntimeLoaderInterface mock returned an HttpKernelRuntime instance for every load() call, including when Twig asked for the EscaperRuntime that provides the escape() filter starting with Twig 3.10. The web profiler template uses |escape, which now fails with "Call to undefined method HttpKernelRuntime::escape()".

Return HttpKernelRuntime only when explicitly requested and null otherwise, so Twig falls back to its default runtime loader for the EscaperRuntime.