### PR TITLE
Add Symfony 8.0 and lowest deps to PHPUnit CI matrix

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -45,13 +45,25 @@ jobs:
         symfony:
           - '6.4.*'
           - '7.4.*'
+          - '8.0.*'
         elasticsearch:
           - '8.12.0'
         dependencies:
           - 'highest'
+        include:
+          - php: '8.1'
+            dependencies: 'lowest'
+            symfony: '6.4.*'
+            elasticsearch: '8.12.0'
         exclude:
           - php: '8.1'
             symfony: '7.4.*'
+          - php: '8.1'
+            symfony: '8.0.*'
+          - php: '8.2'
+            symfony: '8.0.*'
+          - php: '8.3'
+            symfony: '8.0.*'
       fail-fast: false
     steps:
       - name: 'Checkout'
@@ -104,6 +116,7 @@ jobs:
         symfony:
           - '6.4.*'
           - '7.4.*'
+          - '8.0.*'
         dependencies:
           - 'highest'
         include:
@@ -113,6 +126,12 @@ jobs:
         exclude:
           - php: '8.1'
             symfony: '7.4.*'
+          - php: '8.1'
+            symfony: '8.0.*'
+          - php: '8.2'
+            symfony: '8.0.*'
+          - php: '8.3'
+            symfony: '8.0.*'
 
       fail-fast: false
     steps:


### PR DESCRIPTION
Re-introduce Symfony 8.0 in both the PHPUnit and PHPStan matrices (PHP 8.4+ only, since Symfony 8 requires PHP >= 8.4) and add a lowest-deps PHPUnit job (PHP 8.1 + Symfony 6.4) to mirror the existing PHPStan lowest-deps coverage.