### PR TITLE
fix compatibility with latest packages version

### DIFF
--- a/CHANGELOG-7.0.md
+++ b/CHANGELOG-7.0.md
@@ -7,6 +7,8 @@ in 7.x versions.
 ### 7.1.1 (2026-xx-xx)
 * Fix deprecated Symfony method call.
 * Use DI service locator for custom repository instantiation.
+* Add compatibility with `doctrine/doctrine-bundle` 3.x, `doctrine/phpcr-odm` 3.x and Symfony 8.0 in highest-deps CI.
+* Raise minimum versions of `doctrine/doctrine-bundle` (^2.5), `doctrine/orm` (^2.17) and `jms/serializer-bundle` (^5.4) to fix lowest-deps CI.
 
 ### 7.1.0 (2026-04-24)
 * Added Symfony 8.0 support.

--- a/composer.json
+++ b/composer.json
@@ -42,14 +42,14 @@
         "symfony/stopwatch": "^6.4 || ^7.4 || ^8.0"
     },
     "require-dev": {
-        "doctrine/doctrine-bundle": "^2.1.1",
+        "doctrine/doctrine-bundle": "^2.5 || ^3.0",
         "doctrine/mongodb-odm": "^2.2",
-        "doctrine/orm": "^2.8 || ^3.2",
-        "doctrine/phpcr-odm": "^1.5.3 || ^2.0",
+        "doctrine/orm": "^2.17 || ^3.2",
+        "doctrine/phpcr-odm": "^1.5.3 || ^2.0 || ^3.0",
         "ergebnis/composer-normalize": "^2.28",
         "jackalope/jackalope-doctrine-dbal": "^2.0",
         "jms/serializer": "^3.32",
-        "jms/serializer-bundle": "^5.0",
+        "jms/serializer-bundle": "^5.4",
         "knplabs/knp-components": "^4.0 || ^5.0",
         "php-cs-fixer/shim": "3.60.0",
         "phpstan/extension-installer": "^1.1",

--- a/src/Doctrine/PHPCR/ElasticaToModelTransformer.php
+++ b/src/Doctrine/PHPCR/ElasticaToModelTransformer.php
@@ -31,11 +31,13 @@ class ElasticaToModelTransformer extends AbstractElasticaToModelTransformer
     protected function findByIdentifiers(array $identifierValues, $hydrate)
     {
         // @phpstan-ignore-next-line The call is \Doctrine\ODM\PHPCR\DocumentRepository::findMany()
-        return $this->registry
+        $documents = $this->registry
             ->getManager()
             ->getRepository($this->objectClass)
             ->findMany($identifierValues)
-            ->toArray()
         ;
+
+        // phpcr-odm < 3.0 returns a Collection, 3.0+ returns an array.
+        return \is_array($documents) ? $documents : $documents->toArray();
     }
 }

--- a/tests/Functional/app/ORM/config.yml
+++ b/tests/Functional/app/ORM/config.yml
@@ -6,7 +6,6 @@ doctrine:
         path: "%kernel.cache_dir%/db.sqlite"
         charset:  UTF8
     orm:
-        auto_generate_proxy_classes: false
         auto_mapping: false
 
 services:

--- a/tests/Functional/app/Serializer/config.yml
+++ b/tests/Functional/app/Serializer/config.yml
@@ -6,7 +6,6 @@ doctrine:
         path: "%kernel.cache_dir%/db.sqlite"
         charset:  UTF8
     orm:
-        auto_generate_proxy_classes: false
         auto_mapping: false
 
 services:

--- a/tests/Unit/Doctrine/PHPCR/ElasticaToModelTransformerTest.php
+++ b/tests/Unit/Doctrine/PHPCR/ElasticaToModelTransformerTest.php
@@ -69,9 +69,15 @@ class ElasticaToModelTransformerTest extends TestCase
             ])->getMock()
         ;
 
+        $documents = [new \stdClass(), new \stdClass()];
+        $findManyReturn = (new \ReflectionMethod(DocumentRepository::class, 'findMany'))->getReturnType();
+        $returnValue = $findManyReturn instanceof \ReflectionNamedType && 'array' === $findManyReturn->getName()
+            ? $documents
+            : new ArrayCollection($documents);
+
         $this->repository->expects($this->any())
             ->method('findMany')
-            ->will($this->returnValue(new ArrayCollection([new \stdClass(), new \stdClass()])))
+            ->will($this->returnValue($returnValue))
         ;
 
         $this->manager->expects($this->any())


### PR DESCRIPTION
Sf 8.0 + highest deps (composer install) — bumped doctrine/doctrine-bundle to ^2.5 || ^3.0 (3.x is needed because only 3.2+ supports symfony/cache ^8.0); added ^3.0 to doctrine/phpcr-odm (forced by doctrine-bundle 3.x requiring doctrine/persistence ^4, which conflicts with phpcr-odm 2.x).

Sf 6.4 + PHP 8.1 + lowest deps (PHPUnit) — two failures:

annotation_reader missing → bumped jms/serializer-bundle to ^5.4 (5.4 switched to nullOnInvalid() for the optional service)
Doctrine\ORM\Query declared final → bumped doctrine/orm to ^2.17 (the final keyword was downgraded to @final PHPDoc in 2.17)
Cascade fixes for the new Sf 8 highest deps combination:

Removed auto_generate_proxy_classes: false from two test configs (option removed in doctrine/doctrine-bundle 3.x)
Updated src/Doctrine/PHPCR/ElasticaToModelTransformer.php:31 to handle both array (phpcr-odm 3.x) and Collection (phpcr-odm 1.x/2.x) returns from findMany()
Updated tests/Unit/Doctrine/PHPCR/ElasticaToModelTransformerTest.php:72 to use reflection to choose the right mock return type per installed phpcr-odm version